### PR TITLE
chore: add cdktn keyword to all packages

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -35,6 +35,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform"
   ],
   "license": "MPL-2.0",

--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -35,6 +35,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform"
   ],
   "license": "MPL-2.0",

--- a/packages/@cdktn/hcl-tools/package.json
+++ b/packages/@cdktn/hcl-tools/package.json
@@ -5,6 +5,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform",
     "hcl"
   ],

--- a/packages/@cdktn/hcl2cdk/package.json
+++ b/packages/@cdktn/hcl2cdk/package.json
@@ -31,6 +31,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform",
     "hcl"
   ],

--- a/packages/@cdktn/hcl2json/package.json
+++ b/packages/@cdktn/hcl2json/package.json
@@ -32,6 +32,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform",
     "hcl"
   ],

--- a/packages/@cdktn/provider-generator/package.json
+++ b/packages/@cdktn/provider-generator/package.json
@@ -32,6 +32,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform"
   ],
   "license": "MPL-2.0",

--- a/packages/@cdktn/provider-schema/package.json
+++ b/packages/@cdktn/provider-schema/package.json
@@ -35,6 +35,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform"
   ],
   "license": "MPL-2.0",

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -36,6 +36,7 @@
   "keywords": [
     "cdk",
     "cdktf",
+    "cdktn",
     "terraform"
   ],
   "license": "MPL-2.0",

--- a/packages/cdktn/package.json
+++ b/packages/cdktn/package.json
@@ -24,6 +24,7 @@
     "keywords": [
         "cdk",
         "cdktf",
+        "cdktn",
         "terraform"
     ],
     "jsii": {


### PR DESCRIPTION
### Related issue

Fixes #29 

### Description

Adds the `cdktn` keyword to all package.json files for npm discoverability.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes