### PR TITLE
chore: restore NuGet.org publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,11 +260,8 @@ jobs:
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
-    name: Release to GitHub Packages (NuGet)
+    name: Release to NuGet
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
       - prepare-release
       - integration_test
@@ -284,8 +281,7 @@ jobs:
       - name: Release
         run: npx -p publib publib-nuget
         env:
-          NUGET_SERVER: "https://nuget.pkg.github.com/open-constructs/index.json"
-          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   release_golang:
     name: Release Go to Github Repo

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -232,16 +232,13 @@ jobs:
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
-    name: Release to GitHub Packages (NuGet)
+    name: Release to NuGet
     needs:
       - prepare-release
       - integration_test
       - provider_integration_test
       - unit_test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     container:
       image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
     steps:
@@ -253,8 +250,7 @@ jobs:
       - name: Release
         run: npx -p publib publib-nuget
         env:
-          NUGET_SERVER: "https://nuget.pkg.github.com/open-constructs/index.json"
-          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
   release_golang:
     name: Release Go to Github Repo


### PR DESCRIPTION
### Description

Restore publishing of NuGet packages back to the default location (NuGet.org) using a new api key secret.
https://github.com/open-constructs/cdk-terrain-iac/pull/4 needs to be merged first.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
