### PR TITLE
chore(gha): Adding base14 Scout CI/CD observability workflow to instrument all the github actions.

### DIFF
--- a/.github/workflows/otel-export.yml
+++ b/.github/workflows/otel-export.yml
@@ -1,0 +1,25 @@
+---
+name: Export CI/CD Traces to Scout
+"on":
+  workflow_run:
+    workflows: ["*"]
+    types:
+      - completed
+jobs:
+  otel-export:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export workflow trace
+        uses: base-14/otel-cicd-action@v1.0.0
+        with:
+          otlpEndpoint: ${{ secrets.SCOUT_OTLP_ENDPOINT }}
+          otelServiceName: cdk-terrain-ci
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}
+          tokenUrl: >-
+            https://id.b14.dev/realms/${{
+            secrets.SCOUT_TENANT
+            }}/protocol/openid-connect/token
+          appName: ${{ secrets.SCOUT_CLIENT_ID }}
+          apiKey: ${{ secrets.SCOUT_CLIENT_SECRET }}
+          audience: b14collector

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -41,6 +41,7 @@ jobs:
             docs
             release
             deps
+            gha
           # Configure that a scope must always be provided.
           requireScope: false
           # When using "Squash and merge" on a PR with only one commit, GitHub
@@ -52,6 +53,6 @@ jobs:
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}" does not match the required format.
             The format is "type(scope): message", supported types are feat, fix, chore, refactor, revert.
-            The supported scopes are lib, cli, hcl2json, tests, examples, readme, docs, release, deps.
+            The supported scopes are lib, cli, hcl2json, tests, examples, readme, docs, release, deps, gha.
             Please stick to the format so that our automatic release process picks your commit up and
             your code makes it into the next release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,18 @@ Ensuring your PR titles follow this format helps us quickly identify the purpose
 
 #### Affected Component:
 
-- cli
-- lib
-- hcl2cdk
-- provider-generator
-- examples
+- **cli** — CLI tool (`cdktn-cli`)
+- **lib** — Core library (`cdktn`)
+- **hcl2cdk** — HCL to CDK converter
+- **hcl2json** — WASM-based HCL parser
+- **provider-generator** — Provider binding generator
+- **examples** — Example projects
+- **tests** — Test infrastructure
+- **docs** — Documentation
+- **readme** — README updates
+- **release** — Release process and configuration
+- **deps** — Dependency updates
+- **gha** — GitHub Actions workflows
 
 ## Prerequisites
 


### PR DESCRIPTION
### Description

Export GitHub Actions workflow traces to Scout via OpenTelemetry using a workflow_run trigger, requiring no changes to existing workflows.

Required secrets to configure in repo Settings > Secrets and variables > Actions:

Secret | Source
-- | --
SCOUT_OTLP_ENDPOINT | Provided during Scout onboarding
SCOUT_TENANT | Your Scout tenant identifier
SCOUT_CLIENT_ID | OAuth2 client ID from Scout
SCOUT_CLIENT_SECRET | OAuth2 client secret from Scout


  GITHUB_TOKEN is auto-provided by GitHub Actions.


### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes