### PR TITLE
fix(provider-generator): handle inline comments with brackets in variable type parsing

### DIFF
--- a/packages/@cdktn/hcl-tools/prebuild.sh
+++ b/packages/@cdktn/hcl-tools/prebuild.sh
@@ -11,12 +11,16 @@ if [[ -z "${GOROOT-}" ]]; then
   exit 1
 fi
 
-if [ ! -f "$GOROOT/misc/wasm/wasm_exec.js" ]
-then
-    echo "File $GOROOT/misc/wasm/wasm_exec.js does not exist!"
+WASM_EXEC_PATH=""
+if [ -f "$GOROOT/misc/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/misc/wasm/wasm_exec.js"
+elif [ -f "$GOROOT/lib/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/lib/wasm/wasm_exec.js"
+else
+    echo "File wasm_exec.js does not exist under either \$GOROOT/misc/wasm/ or \$GOROOT/lib/wasm/!"
     exit 1
 fi
 
-cp "$GOROOT/misc/wasm/wasm_exec.js" ./wasm/wasm_exec.js
+cp "$WASM_EXEC_PATH" ./wasm/wasm_exec.js
 
 echo "Copied build system wasm_exec.js file to wasm/ directory."

--- a/packages/@cdktn/hcl2json/prebuild.sh
+++ b/packages/@cdktn/hcl2json/prebuild.sh
@@ -11,12 +11,16 @@ if [[ -z "${GOROOT-}" ]]; then
   exit 1
 fi
 
-if [ ! -f "$GOROOT/misc/wasm/wasm_exec.js" ]
-then
-    echo "File $GOROOT/misc/wasm/wasm_exec.js does not exist!"
+WASM_EXEC_PATH=""
+if [ -f "$GOROOT/misc/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/misc/wasm/wasm_exec.js"
+elif [ -f "$GOROOT/lib/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/lib/wasm/wasm_exec.js"
+else
+    echo "File wasm_exec.js does not exist under either \$GOROOT/misc/wasm/ or \$GOROOT/lib/wasm/!"
     exit 1
 fi
 
-cp "$GOROOT/misc/wasm/wasm_exec.js" ./wasm/wasm_exec.js
+cp "$WASM_EXEC_PATH" ./wasm/wasm_exec.js
 
 echo "Copied build system wasm_exec.js file to wasm/ directory."

--- a/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-module-inline-comments/module.tf
+++ b/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-module-inline-comments/module.tf
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "iam_policy_statements" {
+  description = "A list of IAM policy statements"
+  type = list(object({  # TODO - change to map(object({...})) in next major version
+    sid       = optional(string)
+    actions   = optional(list(string))
+    effect    = optional(string)
+    resources = optional(list(string))
+  }))
+  default = null
+}
+
+variable "name" {
+  description = "The name"
+  type        = string
+}
+
+output "result" {
+  value = "result"
+}

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
@@ -64,6 +64,21 @@ describe("readSchema", () => {
     expect(sanitizeJson(result)).toMatchSnapshot();
   }, 120000);
 
+  it("generates a local module with inline comments in type constraints", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(
+        __dirname,
+        "fixtures",
+        "local-module-inline-comments",
+      ),
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(sanitizeJson(result)).toMatchSnapshot();
+  }, 120000);
+
   it("generates a local json module", async () => {
     const module = new TerraformModuleConstraint({
       name: "local_module",

--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -73,8 +73,17 @@ const transformVariables = (variables: any) => {
           variableType = "any";
       }
     } else {
-      const matched = (variable["type"] as string)?.match(/\$\{(.*)\}/);
-      variableType = matched ? matched[1] : "any";
+      const rawVariableType = variable["type"];
+      if (
+        typeof rawVariableType === "string" &&
+        rawVariableType.startsWith("${") &&
+        rawVariableType.endsWith("}") &&
+        !rawVariableType.includes("\n")
+      ) {
+        variableType = rawVariableType.slice(2, -1);
+      } else {
+        variableType = "any";
+      }
     }
 
     const item: Input = {


### PR DESCRIPTION
### Related issue

Fixes https://github.com/open-constructs/cdk-terrain/issues/39

### Description

This PR fixed `cdktn get` command failing to generate code from downstream Terraform that contains a variable with type including a closing bracket in the comments.

Example offending Terraform:
```
variable "iam_policy_statements" {
  description = "A list of IAM policy statements"
  type = list(object({  # TODO - change to map(object({...})) in next major version
    sid       = optional(string)
    actions   = optional(list(string))
    effect    = optional(string)
    resources = optional(list(string))
  }))
  default = null
}
```
(currently present in the [Karpenter Terraform module](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/v21.15.1/modules/karpenter/variables.tf#L121))

The code generation fails due to the `transformVariables` CDKTN function that's parsing the variable type definition. Since the regex does not match newlines, it ends up matching to the commented-out `}` character, causing the resulting type to be parsed as `list(object({ # TODO - change to map(object({...`, which then later can't be parsed to an expression.

Previous approach: match everything on the first line which is wrapped in `${...}`, everything else is an `any`.
Proposed fix: If it's a single-line type then grab everything between the starting `${` and ending `}`, else it's an `any`.

This PR also fixes the `hcl2json`/`hcl-tools` prebuild.sh script as in later versions of Go the wasm directory has changed from `misc` to `lib`.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
