### PR TITLE
fix(provider-generator): handle inline comments with brackets in variable type parsing

### DIFF
--- a/packages/@cdktn/hcl-tools/prebuild.sh
+++ b/packages/@cdktn/hcl-tools/prebuild.sh
@@ -11,12 +11,16 @@ if [[ -z "${GOROOT-}" ]]; then
   exit 1
 fi
 
-if [ ! -f "$GOROOT/misc/wasm/wasm_exec.js" ]
-then
-    echo "File $GOROOT/misc/wasm/wasm_exec.js does not exist!"
+WASM_EXEC_PATH=""
+if [ -f "$GOROOT/misc/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/misc/wasm/wasm_exec.js"
+elif [ -f "$GOROOT/lib/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/lib/wasm/wasm_exec.js"
+else
+    echo "File wasm_exec.js does not exist under either \$GOROOT/misc/wasm/ or \$GOROOT/lib/wasm/!"
     exit 1
 fi
 
-cp "$GOROOT/misc/wasm/wasm_exec.js" ./wasm/wasm_exec.js
+cp "$WASM_EXEC_PATH" ./wasm/wasm_exec.js
 
 echo "Copied build system wasm_exec.js file to wasm/ directory."

--- a/packages/@cdktn/hcl2json/prebuild.sh
+++ b/packages/@cdktn/hcl2json/prebuild.sh
@@ -11,12 +11,16 @@ if [[ -z "${GOROOT-}" ]]; then
   exit 1
 fi
 
-if [ ! -f "$GOROOT/misc/wasm/wasm_exec.js" ]
-then
-    echo "File $GOROOT/misc/wasm/wasm_exec.js does not exist!"
+WASM_EXEC_PATH=""
+if [ -f "$GOROOT/misc/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/misc/wasm/wasm_exec.js"
+elif [ -f "$GOROOT/lib/wasm/wasm_exec.js" ]; then
+    WASM_EXEC_PATH="$GOROOT/lib/wasm/wasm_exec.js"
+else
+    echo "File wasm_exec.js does not exist under either \$GOROOT/misc/wasm/ or \$GOROOT/lib/wasm/!"
     exit 1
 fi
 
-cp "$GOROOT/misc/wasm/wasm_exec.js" ./wasm/wasm_exec.js
+cp "$WASM_EXEC_PATH" ./wasm/wasm_exec.js
 
 echo "Copied build system wasm_exec.js file to wasm/ directory."

--- a/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
+++ b/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
@@ -69,6 +69,35 @@ exports[`readSchema generates a local module 1`] = `
 }"
 `;
 
+exports[`readSchema generates a local module with inline comments in type constraints 1`] = `
+"{
+  "format_version": "STUBBED VERSION",
+  "local_module": {
+    "inputs": [
+      {
+        "default": null,
+        "description": "A list of IAM policy statements",
+        "name": "iam_policy_statements",
+        "required": false,
+        "type": "any"
+      },
+      {
+        "description": "The name",
+        "name": "name",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "name": "local_module",
+    "outputs": [
+      {
+        "name": "result"
+      }
+    ]
+  }
+}"
+`;
+
 exports[`readSchema generates a more complex schema 1`] = `
 "{
   "format_version": "STUBBED VERSION",

--- a/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-module-inline-comments/module.tf
+++ b/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-module-inline-comments/module.tf
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "iam_policy_statements" {
+  description = "A list of IAM policy statements"
+  type = list(object({  # TODO - change to map(object({...})) in next major version
+    sid       = optional(string)
+    actions   = optional(list(string))
+    effect    = optional(string)
+    resources = optional(list(string))
+  }))
+  default = null
+}
+
+variable "name" {
+  description = "The name"
+  type        = string
+}
+
+output "result" {
+  value = "result"
+}

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
@@ -64,6 +64,21 @@ describe("readSchema", () => {
     expect(sanitizeJson(result)).toMatchSnapshot();
   }, 120000);
 
+  it("generates a local module with inline comments in type constraints", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(
+        __dirname,
+        "fixtures",
+        "local-module-inline-comments",
+      ),
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(sanitizeJson(result)).toMatchSnapshot();
+  }, 120000);
+
   it("generates a local json module", async () => {
     const module = new TerraformModuleConstraint({
       name: "local_module",

--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -73,8 +73,17 @@ const transformVariables = (variables: any) => {
           variableType = "any";
       }
     } else {
-      const matched = (variable["type"] as string)?.match(/\$\{(.*)\}/);
-      variableType = matched ? matched[1] : "any";
+      const rawVariableType = variable["type"];
+      if (
+        typeof rawVariableType === "string" &&
+        rawVariableType.startsWith("${") &&
+        rawVariableType.endsWith("}") &&
+        !rawVariableType.includes("\n")
+      ) {
+        variableType = rawVariableType.slice(2, -1);
+      } else {
+        variableType = "any";
+      }
     }
 
     const item: Input = {


### PR DESCRIPTION
## Summary
- Includes the fix from #60 by @josh-hook  to handle inline comments with brackets in Terraform variable type constraints during schema parsing
- Adds the missing test snapshot that was not committed in the original PR

Closes #60

## Test plan
- [x] Snapshot generated locally with `yarn test:update` in `packages/@cdktn/provider-schema`
- [x] CI unit tests pass with the new snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)