### PR TITLE
feat(gha): Configure publishing to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,8 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven:
-    name: Release to GitHub Packages (Maven)
+  release_maven_github_packages:
+    name: Release Maven (GitHub Packages)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -257,6 +257,39 @@ jobs:
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
+          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
+
+  release_maven_central:
+    name: Release Maven (Central)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - prepare-release
+      - integration_test
+      - provider_integration_test
+      - unit_test
+    if: needs.prepare-release.outputs.release_status == 'unreleased'
+    container:
+      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: dist
+          path: dist
+      - name: ensure correct user
+        run: chown -R root /__w/cdk-terrain
+      - name: Release
+        run: npx -p publib publib-maven
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_ENDPOINT: https://central.sonatype.com
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
@@ -353,7 +386,8 @@ jobs:
       - prepare-release
       - release_github
       - release_golang
-      - release_maven
+      - release_maven_github_packages
+      - release_maven_central
       - release_npm
       - release_nuget
       - release_pypi

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -201,8 +201,8 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven:
-    name: Release to GitHub Packages (Maven)
+  release_maven_github_packages:
+    name: Release Maven (GitHub Packages)
     needs:
       - prepare-release
       - integration_test
@@ -229,6 +229,38 @@ jobs:
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
+          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
+
+  release_maven_central:
+    name: Release Maven (Central)
+    needs:
+      - prepare-release
+      - integration_test
+      - provider_integration_test
+      - unit_test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    container:
+      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: dist
+          path: dist
+      - name: ensure correct user
+        run: chown -R root /__w/cdk-terrain
+      - name: Release
+        run: npx -p publib publib-maven
+        env:
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_ENDPOINT: https://hashicorp.oss.sonatype.org
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
@@ -319,7 +351,8 @@ jobs:
       - linting
       - prepare-release
       - release_golang
-      - release_maven
+      - release_maven_github_packages
+      - release_maven_central
       - release_npm
       - release_nuget
       - release_pypi


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Part of #13.

### Description

This PR adds a new job for releasing Maven artifacts to Maven Central.

Why the current job that publishes to GitHub Packages isn't modified instead:
* because some folks may still depend on the packages landing in GitHub Packages, and removing it should be done in a separate change. It's technically a breaking change
* because merging this change right now likely won't make Maven Central publishing work - we need to set required secrets, and it may take some time. Merging this PR is vital to iteratively checking what's missing/misconfigured

These new parts are a blend of a copied job for GitHub Packages, and the `Release` step from before the renaming PR (https://raw.githubusercontent.com/open-constructs/cdk-terrain/a61d9aeef7d821756f8a2fa92f83127b45d01aa6/.github/workflows/release.yml and https://raw.githubusercontent.com/open-constructs/cdk-terrain/a61d9aeef7d821756f8a2fa92f83127b45d01aa6/.github/workflows/release_next.yml).

BTW, I'm struggling to understand why there are 2 workflows: release and release_next. I updated both.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
  - waiting for CI run 
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
  - to be mentioned in the release notes
- [ ] My changes generate no new warnings
  - waiting for CI run 
- [X] I have added tests that prove my fix is effective or that my feature works if applicable
- [X] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
