### PR TITLE
feat(gha): publish Maven artifacts to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,8 +228,8 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven:
-    name: Release to GitHub Packages (Maven)
+  release_maven_github_packages:
+    name: Release Maven (GitHub Packages)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -257,6 +257,39 @@ jobs:
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
+          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
+
+  release_maven_central:
+    name: Release Maven (Central)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - prepare-release
+      - integration_test
+      - provider_integration_test
+      - unit_test
+    if: needs.prepare-release.outputs.release_status == 'unreleased'
+    container:
+      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: dist
+          path: dist
+      - name: ensure correct user
+        run: chown -R root /__w/cdk-terrain
+      - name: Release
+        run: npx -p publib publib-maven
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_ENDPOINT: https://central.sonatype.com
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
@@ -353,7 +386,8 @@ jobs:
       - prepare-release
       - release_github
       - release_golang
-      - release_maven
+      - release_maven_github_packages
+      - release_maven_central
       - release_npm
       - release_nuget
       - release_pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,12 +228,9 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven_github_packages:
-    name: Release Maven (GitHub Packages)
+  release_maven:
+    name: Release to Maven Central
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     needs:
       - prepare-release
       - integration_test
@@ -253,43 +250,11 @@ jobs:
       - name: Release
         run: npx -p publib publib-maven
         env:
-          MAVEN_SERVER_ID: github
-          MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
-          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
-
-  release_maven_central:
-    name: Release Maven (Central)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs:
-      - prepare-release
-      - integration_test
-      - provider_integration_test
-      - unit_test
-    if: needs.prepare-release.outputs.release_status == 'unreleased'
-    container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: dist
-          path: dist
-      - name: ensure correct user
-        run: chown -R root /__w/cdk-terrain
-      - name: Release
-        run: npx -p publib publib-maven
-        env:
+          MAVEN_SERVER_ID: central-ossrh
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_ENDPOINT: https://central.sonatype.com
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
-          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
@@ -386,8 +351,7 @@ jobs:
       - prepare-release
       - release_github
       - release_golang
-      - release_maven_github_packages
-      - release_maven_central
+      - release_maven
       - release_npm
       - release_nuget
       - release_pypi

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -201,8 +201,8 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven:
-    name: Release to GitHub Packages (Maven)
+  release_maven_github_packages:
+    name: Release Maven (GitHub Packages)
     needs:
       - prepare-release
       - integration_test
@@ -229,6 +229,38 @@ jobs:
           MAVEN_USERNAME: ${{ github.actor }}
           MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
+          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
+
+  release_maven_central:
+    name: Release Maven (Central)
+    needs:
+      - prepare-release
+      - integration_test
+      - provider_integration_test
+      - unit_test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    container:
+      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+    steps:
+      - name: Download dist
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          name: dist
+          path: dist
+      - name: ensure correct user
+        run: chown -R root /__w/cdk-terrain
+      - name: Release
+        run: npx -p publib publib-maven
+        env:
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_ENDPOINT: https://hashicorp.oss.sonatype.org
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
@@ -319,7 +351,8 @@ jobs:
       - linting
       - prepare-release
       - release_golang
-      - release_maven
+      - release_maven_github_packages
+      - release_maven_central
       - release_npm
       - release_nuget
       - release_pypi

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -201,17 +201,14 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
-  release_maven_github_packages:
-    name: Release Maven (GitHub Packages)
+  release_maven:
+    name: Release to Maven Central
     needs:
       - prepare-release
       - integration_test
       - provider_integration_test
       - unit_test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     container:
       image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
     steps:
@@ -225,42 +222,11 @@ jobs:
       - name: Release
         run: npx -p publib publib-maven
         env:
-          MAVEN_SERVER_ID: github
-          MAVEN_USERNAME: ${{ github.actor }}
-          MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          MAVEN_REPOSITORY_URL: "https://maven.pkg.github.com/${{ github.repository }}"
-          MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
-
-  release_maven_central:
-    name: Release Maven (Central)
-    needs:
-      - prepare-release
-      - integration_test
-      - provider_integration_test
-      - unit_test
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
-    steps:
-      - name: Download dist
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: dist
-          path: dist
-      - name: ensure correct user
-        run: chown -R root /__w/cdk-terrain
-      - name: Release
-        run: npx -p publib publib-maven
-        env:
-          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_SERVER_ID: central-ossrh
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-          MAVEN_ENDPOINT: https://hashicorp.oss.sonatype.org
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
-          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" # See https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco
 
   release_nuget:
@@ -351,8 +317,7 @@ jobs:
       - linting
       - prepare-release
       - release_golang
-      - release_maven_github_packages
-      - release_maven_central
+      - release_maven
       - release_npm
       - release_nuget
       - release_pypi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,16 +78,16 @@ This is a **JSII monorepo** (Lerna + Yarn workspaces) that compiles TypeScript t
 
 ### Core Packages
 
-| Package | Purpose |
-| --- | --- |
-| `packages/cdktn` | Core library — constructs (TerraformStack, TerraformResource, etc.). Uses JSII. |
-| `packages/cdktn-cli` | CLI entry point — thin wrapper around cli-core, uses esbuild (transpile only, no type checking; tsc runs as pre-commit hook) |
-| `packages/@cdktn/cli-core` | CLI implementation — commands, project management, Terraform execution |
-| `packages/@cdktn/provider-generator` | Generates TypeScript bindings from Terraform provider schemas |
-| `packages/@cdktn/provider-schema` | Fetches and parses Terraform provider schemas |
-| `packages/@cdktn/hcl2cdk` | Converts HCL to CDK code (`cdktn convert`) |
-| `packages/@cdktn/hcl2json` | WASM-based HCL parser (Go compiled to WASM) |
-| `packages/@cdktn/commons` | Shared utilities across packages |
+| Package                              | Purpose                                                                                                                      |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `packages/cdktn`                     | Core library — constructs (TerraformStack, TerraformResource, etc.). Uses JSII.                                              |
+| `packages/cdktn-cli`                 | CLI entry point — thin wrapper around cli-core, uses esbuild (transpile only, no type checking; tsc runs as pre-commit hook) |
+| `packages/@cdktn/cli-core`           | CLI implementation — commands, project management, Terraform execution                                                       |
+| `packages/@cdktn/provider-generator` | Generates TypeScript bindings from Terraform provider schemas                                                                |
+| `packages/@cdktn/provider-schema`    | Fetches and parses Terraform provider schemas                                                                                |
+| `packages/@cdktn/hcl2cdk`            | Converts HCL to CDK code (`cdktn convert`)                                                                                   |
+| `packages/@cdktn/hcl2json`           | WASM-based HCL parser (Go compiled to WASM)                                                                                  |
+| `packages/@cdktn/commons`            | Shared utilities across packages                                                                                             |
 
 ### Key Flows
 


### PR DESCRIPTION
## Summary

Builds on #63 by @krzema12 — replaces the GitHub Packages Maven job with Maven Central publishing instead of adding a second job alongside it (consistent with the NuGet.org restoration in #50).

- **Replace** (not add alongside) the GitHub Packages Maven job
- Use `MAVEN_SERVER_ID=central-ossrh` ([publib #1667](https://github.com/cdklabs/publib/pull/1667)) instead of `MAVEN_ENDPOINT`
- Remove unnecessary `permissions: packages: write`
- Remove `MAVEN_STAGING_PROFILE_ID` (not needed for `central-ossrh`)
- Fix inconsistent `MAVEN_ENDPOINT` between release.yml (`central.sonatype.com`) and release_next.yml (`hashicorp.oss.sonatype.org`)

### Required secrets

All 4 secrets have been deployed via IaC:

| Secret | Status |
|--------|--------|
| `MAVEN_USERNAME` | Deployed |
| `MAVEN_PASSWORD` | Deployed |
| `MAVEN_GPG_PRIVATE_KEY` | Deployed |
| `MAVEN_GPG_PRIVATE_KEY_PASSPHRASE` | Deployed |

Closes #13

## Test plan

- [x] Generate GPG key (RSA 4096), publish to `keyserver.ubuntu.com`
- [x] Deploy all 4 secrets via terraform apply
- [x] Merge and verify first release publishes to `https://central.sonatype.com/artifact/io.cdktn/cdktn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)