### PR TITLE
fix(gha): fix Go releases and update git identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,8 +304,8 @@ jobs:
         run: npx -p publib publib-golang
         env:
           GITHUB_TOKEN: ${{ secrets.TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN }}
-          GIT_USER_NAME: "CDK for Terraform Team"
-          GIT_USER_EMAIL: "github-team-tf-cdk@hashicorp.com"
+          GIT_USER_NAME: "CDK Terrain Bot"
+          GIT_USER_EMAIL: "gh-actions@cdktn.io"
 
   release_sentry:
     name: Finalize the sentry release

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -272,8 +272,8 @@ jobs:
         run: npx -p publib publib-golang
         env:
           GITHUB_TOKEN: ${{ secrets.TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN }}
-          GIT_USER_NAME: "CDK for Terraform Team"
-          GIT_USER_EMAIL: "github-team-tf-cdk@hashicorp.com"
+          GIT_USER_NAME: "CDK Terrain Bot"
+          GIT_USER_EMAIL: "gh-actions@cdktn.io"
 
   release_sentry:
     name: Finalize the sentry release


### PR DESCRIPTION
## Summary

Fixes Go release publishing and updates the git identity for commits to `cdk-terrain-go`.

**Go release fix (issue #54):** The `TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN` PAT was expired, causing `publib-golang` to fail with `could not read Password for 'https://***@github.com': No such device or address`. The PAT has been rotated and the fix was validated by re-running the failed `release_next` job ([successful run](https://github.com/open-constructs/cdk-terrain/actions/runs/23406664375/job/68118687851)).

**Git identity update (issue #36):** Replaces the deactivated HashiCorp identity (`CDK for Terraform Team <github-team-tf-cdk@hashicorp.com>`) with the cdktn bot identity (`CDK Terrain Bot <gh-actions@cdktn.io>`) for Go module commits pushed to `cdk-terrain-go`.

Closes #54
Closes #36

## Test plan

- [x] Rotated PAT and re-ran failed `release_golang` job — succeeded
- [ ] Merge and verify next release commits to `cdk-terrain-go` with new identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)