### PR TITLE
fix(cli): Pin init template to TypesScript 5.x

### DIFF
--- a/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
@@ -30,7 +30,7 @@ exports.post = (ctx) => {
 
   installDeps([npm_cdktf, `constructs@10`], false, silent);
   installDeps(
-    ["@types/node", "typescript", "jest", "@types/jest", "ts-jest", "ts-node"],
+    ["@types/node", "typescript@5.x", "jest", "@types/jest", "ts-jest", "ts-node"],
     true,
     silent
   );


### PR DESCRIPTION
### Description

Currently initializing a TypeScript project using TypeScript 6 causes issues due to `ts-jest` not yet supporting it. (See https://github.com/kulshekhar/ts-jest/issues/5232).

This is a short term solution to unblock the next release. Hopefully the upstream dependency will be fixed, but if not we can look into alternative solutions.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
