### PR TITLE
chore: add migration context to bug report issue templates [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-prebuilt-providers.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-prebuilt-providers.yml
@@ -67,6 +67,33 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: migration-context
+    attributes:
+      label: Migration Context
+      description: |
+        Did you previously use `cdktf` / `cdktf-cli` (the upstream HashiCorp project)?
+        If so, did you experience this same issue there?
+        This helps us determine if this is a pre-existing bug or a regression introduced during the cdktn migration.
+      options:
+        - I did not use cdktf before
+        - I used cdktf and saw the same issue there
+        - I used cdktf and did NOT see this issue there (possible regression)
+        - Not sure / don't remember
+    validations:
+      required: true
+
+  - type: input
+    id: upstream-issue
+    attributes:
+      label: Upstream cdktf Issue
+      description: |
+        If you experienced this issue in the original `cdktf` / `cdktf-cli`, is there an existing bug report on the archived [hashicorp/terraform-cdk](https://github.com/hashicorp/terraform-cdk/issues) repository?
+      placeholder: |
+        https://github.com/hashicorp/terraform-cdk/issues/1234
+    validations:
+      required: false
+
   - type: textarea
     id: providers
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -67,6 +67,33 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: migration-context
+    attributes:
+      label: Migration Context
+      description: |
+        Did you previously use `cdktf` / `cdktf-cli` (the upstream HashiCorp project)?
+        If so, did you experience this same issue there?
+        This helps us determine if this is a pre-existing bug or a regression introduced during the cdktn migration.
+      options:
+        - I did not use cdktf before
+        - I used cdktf and saw the same issue there
+        - I used cdktf and did NOT see this issue there (possible regression)
+        - Not sure / don't remember
+    validations:
+      required: true
+
+  - type: input
+    id: upstream-issue
+    attributes:
+      label: Upstream cdktf Issue
+      description: |
+        If you experienced this issue in the original `cdktf` / `cdktf-cli`, is there an existing bug report on the archived [hashicorp/terraform-cdk](https://github.com/hashicorp/terraform-cdk/issues) repository?
+      placeholder: |
+        https://github.com/hashicorp/terraform-cdk/issues/1234
+    validations:
+      required: false
+
   - type: textarea
     id: providers
     attributes:


### PR DESCRIPTION
## Summary

- Adds a required **Migration Context** dropdown to both bug report templates (`bug-report.yml` and `bug-report-prebuilt-providers.yml`), asking reporters whether they previously used `cdktf` and if they saw the same bug there
- Adds an optional **Upstream cdktf Issue** input field for linking to existing reports on the archived `hashicorp/terraform-cdk` repo
- Helps triage whether bugs are pre-existing upstream issues or regressions from the `cdktn` rename/migration

Prompted by [this comment on #72](https://github.com/open-constructs/cdk-terrain/issues/72#issuecomment-4174046570).

## Validation

Templates validated locally against the [SchemaStore GitHub Issue Forms schema](https://json.schemastore.org/github-issue-forms.json):

```
$ uvx check-jsonschema \
    --schemafile "https://json.schemastore.org/github-issue-forms.json" \
    .github/ISSUE_TEMPLATE/bug-report.yml \
    .github/ISSUE_TEMPLATE/bug-report-prebuilt-providers.yml
```

Only pre-existing `assignees: []` type warnings (SchemaStore schema expects string, GitHub accepts empty arrays). No errors from our changes.

## Test plan

- [ ] Verify templates render correctly on the GitHub "New Issue" page
- [ ] Confirm the migration context dropdown appears between Versions and Providers sections
- [ ] Confirm the upstream issue input appears after the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)