### PR TITLE
fix(lib): fail on constructs outside of stacks (under feature flag)

### DIFF
--- a/packages/cdktn/lib/app.ts
+++ b/packages/cdktn/lib/app.ts
@@ -7,7 +7,12 @@ import { DISABLE_STACK_TRACE_IN_METADATA } from "./annotations";
 import { Manifest } from "./manifest";
 import { ISynthesisSession } from "./synthesize";
 import { TerraformStack } from "./terraform-stack";
-import { appValidationFailure, noAppFound } from "./errors";
+import {
+  appValidationFailure,
+  constructsOutsideOfStacks,
+  noAppFound,
+} from "./errors";
+import { FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS } from "./features";
 
 const APP_SYMBOL = Symbol.for("cdktf/App");
 export const CONTEXT_ENV = "CDKTF_CONTEXT_JSON";
@@ -156,6 +161,15 @@ export class App extends Construct {
     const stacks = this.node
       .findAll()
       .filter<TerraformStack>(TerraformStack.isStack);
+
+    if (this.node.tryGetContext(FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS)) {
+      const orphans = this.node.children.filter(
+        (child) => !TerraformStack.isStack(child),
+      );
+      if (orphans.length > 0) {
+        throw constructsOutsideOfStacks(orphans.map((o) => o.node.path));
+      }
+    }
 
     stacks.forEach((stack) => stack.prepareStack());
     stacks.forEach((stack) => stack.synthesizer.synthesize(session));

--- a/packages/cdktn/lib/errors.ts
+++ b/packages/cdktn/lib/errors.ts
@@ -14,6 +14,14 @@ Learn more about the App: https://cdktn.io/docs/concepts/cdktn-architecture#app-
     `,
   );
 
+export const constructsOutsideOfStacks = (paths: string[]) => {
+  const bulletList = paths.map((p) => `  - ${p}`).join("\n");
+  return new Error(
+    `Found constructs outside of a TerraformStack (did you pass scope=app instead of scope=stack?):\n${bulletList}
+`,
+  );
+};
+
 export const appValidationFailure = (errorList: string) =>
   new Error(
     `App-level validation failed with the following errors:\n  ${errorList}

--- a/packages/cdktn/lib/features.ts
+++ b/packages/cdktn/lib/features.ts
@@ -29,4 +29,6 @@
 export const FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS =
   "cdktn:failOnConstructsOutsideOfStacks";
 
-export const FUTURE_FLAGS = {};
+export const FUTURE_FLAGS = {
+  FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS: true,
+};

--- a/packages/cdktn/lib/features.ts
+++ b/packages/cdktn/lib/features.ts
@@ -22,4 +22,11 @@
  *
  * Tests must cover the default (disabled) case and the future (enabled) case.
  */
+/**
+ * When enabled, synthesis will throw an error if any constructs are scoped
+ * directly to the App instead of to a TerraformStack.
+ */
+export const FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS =
+  "cdktn:failOnConstructsOutsideOfStacks";
+
 export const FUTURE_FLAGS = {};

--- a/packages/cdktn/lib/features.ts
+++ b/packages/cdktn/lib/features.ts
@@ -27,8 +27,8 @@
  * directly to the App instead of to a TerraformStack.
  */
 export const FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS =
-  "cdktn:failOnConstructsOutsideOfStacks";
+  "failOnConstructsOutsideOfStacks";
 
 export const FUTURE_FLAGS = {
-  FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS: true,
+  [FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS]: "true",
 };

--- a/packages/cdktn/test/app.test.ts
+++ b/packages/cdktn/test/app.test.ts
@@ -177,7 +177,9 @@ test("app synth executes Aspects", () => {
   `);
 });
 
-test("app synth silently ignores constructs scoped to app instead of a stack", () => {
+class MyResource extends TerraformResource {}
+
+test("app synth silently ignores constructs scoped to app instead of a stack by default", () => {
   const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
   const app = Testing.stubVersion(new App({ stackTraces: false, outdir }));
   const stack = new TerraformStack(app, "MyStack");
@@ -189,8 +191,6 @@ test("app synth silently ignores constructs scoped to app instead of a stack", (
   // Resource incorrectly scoped to the app — silently dropped
   new TestResource(app, "OrphanedResource", { name: "orphan" });
 
-  // This behavior is undesired, and this test just shows it.
-  // See https://github.com/open-constructs/cdk-terrain/issues/57
   expect(() => app.synth()).not.toThrow();
 
   const stackSynth = JSON.parse(
@@ -215,7 +215,30 @@ test("app synth silently ignores constructs scoped to app instead of a stack", (
   ).toBe(false);
 });
 
-class MyResource extends TerraformResource {}
+test("synthesis throws when a construct is scoped to app and failOnConstructsOutsideOfStacks is enabled", () => {
+  const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
+  const app = Testing.stubVersion(
+    new App({
+      stackTraces: false,
+      outdir,
+      context: { "cdktn:failOnConstructsOutsideOfStacks": true },
+    }),
+  );
+  const stack = new TerraformStack(app, "MyStack");
+  new TestProvider(stack, "TestProvider", {});
+
+  // Resource properly scoped to the stack
+  new TestResource(stack, "StackResource", { name: "in-stack" });
+
+  // Resource incorrectly scoped to the app
+  new TestResource(app, "OrphanedResource", { name: "orphan" });
+
+  expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
+    "Found constructs outside of a TerraformStack (did you pass scope=app instead of scope=stack?):
+      - OrphanedResource
+    "
+  `);
+});
 
 describe("Cross Stack references", () => {
   class OriginStack extends TerraformStack {

--- a/packages/cdktn/test/app.test.ts
+++ b/packages/cdktn/test/app.test.ts
@@ -221,7 +221,7 @@ test("synthesis throws when a construct is scoped to app and failOnConstructsOut
     new App({
       stackTraces: false,
       outdir,
-      context: { "cdktn:failOnConstructsOutsideOfStacks": true },
+      context: { "failOnConstructsOutsideOfStacks": true },
     }),
   );
   const stack = new TerraformStack(app, "MyStack");

--- a/packages/cdktn/test/app.test.ts
+++ b/packages/cdktn/test/app.test.ts
@@ -12,6 +12,7 @@ import {
   DataTerraformRemoteState,
   Fn,
 } from "../lib";
+import { FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS } from "../lib/features";
 
 import { version } from "../package.json";
 import fs = require("fs");
@@ -221,7 +222,7 @@ test("synthesis throws when a construct is scoped to app and failOnConstructsOut
     new App({
       stackTraces: false,
       outdir,
-      context: { "failOnConstructsOutsideOfStacks": true },
+      context: { [FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS]: "true" },
     }),
   );
   const stack = new TerraformStack(app, "MyStack");


### PR DESCRIPTION
### Related issue

Fixes #57

### Description

Adds extra validation (enabled with a feature flag) that catches constructs outside of stacks. Such constructs aren't rendered in output of any stack, which is misleading. One can assume that there's some app's implicit stack or that the resource will somehow be rendered and deployed, but it's not true. This change is a step towards stricter validation of this case.

⚠️ BREAKING CHANGE
If the feature flag is enabled, apps having constructs with the app itself as their scope will fail to synthesize. Only constructs with stacks or their descendants as their scope are legal.

### Checklist

- [X] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [X] I have run the linter on my code locally
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works if applicable
- [X] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
