### PR TITLE
chore: Update docker image to have Go 1.25 and Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-FROM public.ecr.aws/jsii/superchain:1-bookworm-slim-node20-nightly@sha256:cd75861281b3f9d503629a87e3529026b588500a752ae60b16c5f226344de2a7
+FROM public.ecr.aws/jsii/superchain:1-bookworm-slim-node22-nightly@sha256:06598e70ca71c3b8ebf3a8d6836449c682da10610026211c2d1b475974bb9d7b
 
 USER root
 


### PR DESCRIPTION
### Description

Updating to JSII 5.9 requires go 1.25. The updated jsii superchain image contains that version.
Also updating to use node 22 as node 20 will become EoL in a couple weeks.

We'll then need a subsequent PR to actually use the new image before then making PRs to actually update JSII/Node.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
