### PR TITLE
fix(cli): don't check cdktf-cli version

### DIFF
--- a/packages/cdktn-cli/src/bin/cmds/helper/version-check.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/version-check.ts
@@ -74,8 +74,7 @@ export async function latestVersionIfHigher(
     return null;
   }
 
-  // TODO: Check for cdktn-cli after release 1
-  const { stdout, stderr } = await exec("npm view cdktf-cli version");
+  const { stdout, stderr } = await exec("npm view cdktn-cli version");
   if (stderr && stderr.trim().length > 0) {
     console.error(
       `The 'npm view' command generated an error stream with content [${stderr.trim()}]`,


### PR DESCRIPTION
The CLI checks if there's a newer version available on npm. But it's currently checking if there's a newer version of `cdktf-cli`, not `cdktn-cli`. This was intentional while cdktn-cli hadn't had a release yet. But now that it has been released to npm, we can update this check.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #98

### Description

cdktf-cli -> cdktn-cli

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
