### PR TITLE
fix(cli): support pre-built provider metadata with cdktn key

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/dependencies/prebuilt-providers.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/prebuilt-providers.ts
@@ -122,6 +122,24 @@ type PackageJson = {
       version: string;
     };
   };
+  // Pre-built providers using cdktn now generate provider information under cdktn key
+  // At some point support for the cdktf key will be dropped
+  cdktn?: {
+    // provider is optional as we might set other cdktn related fields in the future
+    // for other libs (i.e. construct packages) while still using the cdktn key
+    provider?: {
+      /**
+       * name of the provider, will resolve to the full name as in the Terraform schema.
+       * e.g. registry.terraform.io/hashicorp/aws
+       */
+      name: string;
+      /**
+       * the actual version that was used to build the provider
+       * e.g. 4.12.1
+       */
+      version: string;
+    };
+  };
   peerDependencies?: {
     cdktf?: string;
     cdktn?: string;
@@ -146,7 +164,13 @@ type NpmPackageResult = {
 type NpmPackageSingleVersionResult = {
   name: string;
   version: string;
-  cdktf: {
+  cdktf?: {
+    provider: {
+      name: string;
+      version: string;
+    };
+  };
+  cdktn?: {
     provider: {
       name: string;
       version: string;
@@ -191,14 +215,15 @@ export async function getAllPrebuiltProviderVersions(
 
   const versions = Object.entries(result.versions)
     .map(([version, packageJson]) => {
-      const provider = packageJson.cdktf?.provider;
+      const provider =
+        packageJson.cdktn?.provider ?? packageJson.cdktf?.provider;
       if (
         !provider ||
         (!packageJson.peerDependencies?.cdktf &&
           !packageJson.peerDependencies?.cdktn)
       ) {
         logger.trace(
-          `skipping version ${version} of ${packageName} as it does not have a cdktf.provider or peerDependencies.cdktf/cdktn in package.json`,
+          `skipping version ${version} of ${packageName} as it does not have a cdktn/cdktf.provider or peerDependencies.cdktf/cdktn in package.json`,
         );
         return undefined;
       }
@@ -305,7 +330,7 @@ export async function getPrebuiltProviderVersionInformation(
   const url = `https://registry.npmjs.org/${packageName}/${packageVersion}`;
   const result = await cachedFetch<NpmPackageSingleVersionResult>(url);
 
-  let providerName = result.cdktf.provider.name;
+  let providerName = result.cdktn?.provider.name ?? result.cdktf?.provider.name;
   if (providerName) {
     providerName = providerName.replace("registry.terraform.io/", "");
     providerName = providerName.replace("hashicorp/", "");
@@ -315,7 +340,8 @@ export async function getPrebuiltProviderVersionInformation(
     packageName: result.name,
     packageVersion: result.version,
     providerName,
-    providerVersion: result.cdktf.provider.version,
+    providerVersion:
+      result.cdktn?.provider.version ?? result.cdktf?.provider.version,
     cdktfVersion: result.peerDependencies["cdktf"],
     cdktnVersion: result.peerDependencies["cdktn"],
   };

--- a/packages/@cdktn/cli-core/src/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/dependencies/prebuilt-providers.test.ts
@@ -20,7 +20,7 @@ function buildNpmResponse(
   return {
     versions: {
       [version]: {
-        cdktf: {
+        [useCdktn ? "cdktn" : "cdktf"]: {
           provider: {
             name: `registry.terraform.io/hashicorp/${name}`,
             version: "0.3.1",


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #51 

### Description

Update CLI metadata parsing to support both keys with backward compatibility:

1. Prefer cdktn.provider when present
2. Fallback to cdktf.provider

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
