### PR TITLE
chore: use new docker image in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build-and-package:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJSON(needs.build-example-matrix.outputs.examples)}}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60
@@ -94,7 +94,7 @@ jobs:
       matrix: ${{fromJSON(needs.prepare-integration-tests.outputs.tests)}}
       max-parallel: 30 # too many in parallel will give HTTP 429 errors from GH when checking out the source for example
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
       TERRAFORM_VERSION: ${{ matrix.terraform }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.18.x
+          go-version: 1.25.x
           cache: false # This is disabled because we don't have a go.sum file and setup-go expects it to use caching. Thus, caching is always broken anyways
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,7 +18,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: installing dependencies
@@ -31,7 +31,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: installing dependencies

--- a/.github/workflows/pr-depcheck.yml
+++ b/.github/workflows/pr-depcheck.yml
@@ -9,7 +9,7 @@ jobs:
   depcheck:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       tests: ${{ steps.build-provider-test-matrix.outputs.tests }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-provider-tests.outputs.tests)}}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
       TERRAFORM_VERSION: ${{ inputs.terraform_version }}

--- a/.github/workflows/registry-docs-pr-based.yml
+++ b/.github/workflows/registry-docs-pr-based.yml
@@ -105,7 +105,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 120
@@ -145,7 +145,7 @@ jobs:
       matrix:
         files: ${{fromJSON(needs.cdktnDocsMatrix.outputs.matrix)}}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 360

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       release_status: ${{ steps.get_release_status.outputs.release }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
@@ -155,7 +155,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: installing dependencies
@@ -180,7 +180,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -204,7 +204,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -240,7 +240,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -269,7 +269,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -293,7 +293,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -319,7 +319,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: version

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -22,7 +22,7 @@ jobs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
       version: ${{ steps.get_version.outputs.version }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
@@ -151,7 +151,7 @@ jobs:
       - unit_test
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -175,7 +175,7 @@ jobs:
       - unit_test
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -210,7 +210,7 @@ jobs:
       - unit_test
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -238,7 +238,7 @@ jobs:
       - unit_test
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -259,7 +259,7 @@ jobs:
       - unit_test
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -285,7 +285,7 @@ jobs:
       - release_npm
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: version

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,7 +21,7 @@ jobs:
   unit-test:
     runs-on: depot-ubuntu-24.04-16
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60

--- a/.github/workflows/yarn-upgrade.yml
+++ b/.github/workflows/yarn-upgrade.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Check Out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -110,7 +110,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     strategy:
       fail-fast: false
       matrix:
@@ -212,7 +212,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:4942a4c6ed8286f403c7855dab56b0e11f9a7115e7e0afbcd49d7e69de4d6dc0
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Check Out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Prerequisites & Setup
 
-Tools managed by [mise](https://mise.jdx.dev/) (see `.mise.toml`): Node 20.20, Go 1.18, Python 3.11, Java corretto-20, .NET 6.0, Terraform 1.7.5.
+Tools managed by [mise](https://mise.jdx.dev/) (see `.mise.toml`): Node 20.20, go 1.25, Python 3.11, Java corretto-20, .NET 6.0, Terraform 1.7.5.
 
 Additional tools **not** managed by mise (install manually):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Ensuring your PR titles follow this format helps us quickly identify the purpose
 To build and install `cdk-terrain` locally you need to install:
 
 - Node version (20.0+ - pinned in mise)
-- Go (1.18 - pinned in mise)
+- Go (1.25 - pinned in mise)
 - dotnet (v6.0 - pinned in mise)
 - pipenv (pinned in mise)
 

--- a/examples/go/aws/go.mod
+++ b/examples/go/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/aws
 
-go 1.18
+go 1.25
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.4.3

--- a/examples/go/azure/go.mod
+++ b/examples/go/azure/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/azure
 
-go 1.18
+go 1.25
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.4.3

--- a/examples/go/docker/go.mod
+++ b/examples/go/docker/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/docker
 
-go 1.18
+go 1.25
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.4.3

--- a/examples/go/documentation/go.mod
+++ b/examples/go/documentation/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/documentation
 
-go 1.18
+go 1.25
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.4.3

--- a/examples/go/google-cloudrun/go.mod
+++ b/examples/go/google-cloudrun/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/google-cloudrun
 
-go 1.18
+go 1.25
 
 require github.com/aws/constructs-go/constructs/v10 v10.4.3
 

--- a/examples/go/google/go.mod
+++ b/examples/go/google/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/google
 
-go 1.18
+go 1.25
 
 require github.com/aws/constructs-go/constructs/v10 v10.4.3
 

--- a/examples/go/scaleway/go.mod
+++ b/examples/go/scaleway/go.mod
@@ -1,6 +1,6 @@
 module cdk.tf/go/stack
 
-go 1.18
+go 1.25
 
 require github.com/aws/constructs-go/constructs/v10 v10.4.3
 

--- a/examples/go/ucloud/go.mod
+++ b/examples/go/ucloud/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/examples/go/ucloud
 
-go 1.18
+go 1.25
 
 require (
 	github.com/aws/constructs-go/constructs/v10 v10.4.3

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.18
+go 1.25
 
 use (
 	./examples/go/aws

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@
 [tools]
 node = "20.20"
 python = '3.11'
-go = '1.18'
+go = '1.25'
 java = "prefix:corretto-20"
 dotnet = "6.0"  # Match jsii-superchain DOTNET_CHANNEL
 "pipx:pipenv" = "latest"

--- a/packages/@cdktn/cli-core/templates/go/go.mod
+++ b/packages/@cdktn/cli-core/templates/go/go.mod
@@ -1,6 +1,6 @@
 module cdk.tf/go/stack
 
-go 1.18
+go 1.25
 
 require github.com/aws/constructs-go/constructs/v10 v{{ constructs_version }}
 

--- a/packages/@cdktn/cli-core/templates/python/Pipfile
+++ b/packages/@cdktn/cli-core/templates/python/Pipfile
@@ -4,4 +4,4 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [requires]
-python_version = "3"
+python_version = "3.11"

--- a/packages/@cdktn/cli-core/templates/python/Pipfile
+++ b/packages/@cdktn/cli-core/templates/python/Pipfile
@@ -4,4 +4,4 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [requires]
-python_version = "3"
+python_version = ">=3.9"

--- a/packages/@cdktn/cli-core/templates/python/Pipfile
+++ b/packages/@cdktn/cli-core/templates/python/Pipfile
@@ -4,4 +4,4 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [requires]
-python_version = ">=3.9"
+python_version = "3"

--- a/packages/@cdktn/hcl2json/go.mod
+++ b/packages/@cdktn/hcl2json/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-constructs/cdk-terrain/hcl2json
 
-go 1.23
+go 1.25
 
 require (
 	github.com/hashicorp/hcl/v2 v2.23.0


### PR DESCRIPTION
### Description

Update build jobs to use the newly build docker container in preparation for JSII / node updates

Source commit:
- https://github.com/open-constructs/cdk-terrain/commit/599d6cd56f8e5c315952cafa6033796f6e579767
- Docker Tag page: https://hub.docker.com/r/terraconstructs/jsii-terraform/tags?name=0.22.1-599d6cd56f8e5c315952cafa6033796f6e579767

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
