### PR TITLE
fix: Temporarily pin nomad provider to 2.5.2

### DIFF
--- a/test/provider-tests/providers.json
+++ b/test/provider-tests/providers.json
@@ -5,7 +5,7 @@
     "kubernetes": "kubernetes",
     "consul": "consul",
     "vault": "vault",
-    "nomad": "nomad",
+    "nomad": "nomad@ ~> 2.5.2",
     "external": "external",
     "openstack": "terraform-providers/openstack",
     "oci": "hashicorp/oci@~> 7.23.0",

--- a/test/typescript/providers/cdktf.json
+++ b/test/typescript/providers/cdktf.json
@@ -3,7 +3,7 @@
   "app": "npx ts-node main.ts",
   "terraformProviders": [
     "aws",
-    "nomad",
+    "nomad@ ~> 2.5.2",
     "kubernetes"
   ],
   "context": {}


### PR DESCRIPTION
### Description

Workaround https://github.com/hashicorp/terraform-provider-nomad/issues/609

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
