### PR TITLE
chore: Update test providers to support darwin arm64

### DIFF
--- a/packages/@cdktn/provider-generator/lib/__tests__/provider.test.ts
+++ b/packages/@cdktn/provider-generator/lib/__tests__/provider.test.ts
@@ -151,15 +151,15 @@ describe("Provider", () => {
   it("generates constructs for two providers with same name", async () => {
     const constraint = new TerraformProviderConstraint({
       name: "bitbucket",
-      namespace: "Runelab",
-      version: "2.1.0",
-      source: "Runelab/bitbucket",
+      namespace: "DrFaust92",
+      version: "2.51.0",
+      source: "DrFaust92/bitbucket",
     });
     const constraint2 = new TerraformProviderConstraint({
       name: "abitbucket",
-      namespace: "aeirola",
-      version: "2.0.2",
-      source: "aeirola/bitbucket",
+      namespace: "andsafe-AG",
+      version: "2.5.0",
+      source: "andsafe-AG/bitbucket",
     });
     return await mkdtemp(async (workdir) => {
       const jsiiPath = path.join(workdir, ".jsii");

--- a/packages/cdktn-cli/src/test/cmds/convert.test.ts
+++ b/packages/cdktn-cli/src/test/cmds/convert.test.ts
@@ -36,7 +36,7 @@ describe("convert command", () => {
     await mkdtemp(async (cwd) => {
       await fs.writeFile(
         path.resolve(cwd, "cdktf.json"),
-        JSON.stringify({ terraformProviders: ["hashicorp/null@~> 2.0"] }),
+        JSON.stringify({ terraformProviders: ["hashicorp/null@~> 3.0"] }),
       );
       const result = await execa(cdktfBin, ["convert"], {
         stdio: "pipe",


### PR DESCRIPTION
### Description

The following Terraform providers/versions used within the tests do not have a `darwin-arm64` build so the tests fail on arm64 Apple Macs. This PR replaces them with up-to-date provider versions that do have `darwin-arm64` builds.

| Current Provider | Current Version | New Provider | New Version
|--------|--------|--------|--------
| `Runelab/bitbucket` | `2.1.0`|  `DrFaust92/bitbucket` | `2.51.0`
| `aeirola/bitbucket` | `2.0.2`| `andsafe-AG/bitbucket` | `2.5.0`
| `hashicorp/null` | `@~> 2.0` | `hashicorp/null` | `@~> 3.0`

The `provider.test.ts.snap` was was regenerated for the new bitbucket provider versions.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
