### PR TITLE
chore: Bump verdaccio version and add npm install retries

### DIFF
--- a/test/local-registry.sh
+++ b/test/local-registry.sh
@@ -5,7 +5,7 @@
 custom_registry_url=localhost:4873
 original_npm_registry_url=`npm get registry`
 original_yarn_registry_url=`yarn config get registry`
-default_verdaccio_package=verdaccio@^6.2.4
+default_verdaccio_package=verdaccio@^6.5.2
 
 function startLocalRegistry {
   # Start local registry

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -54,7 +54,18 @@ staging=$(mktemp -d)
 cd ${staging}
 npm init -y > /dev/null
 # There's only one version in our local registry, so we don't need to specify a version here
-npm install --global-style cdktn-cli
+# Retry to ride out transient ECONNRESETs from Verdaccio's upstream fetch
+for attempt in 1 2 3; do
+  if npm install --install-strategy=shallow --fetch-retries=5 cdktn-cli; then
+    break
+  fi
+  if [ "$attempt" = "3" ]; then
+    echo "npm install failed after 3 attempts"
+    exit 1
+  fi
+  echo "npm install attempt $attempt failed, retrying in $((attempt * 10))s..."
+  sleep $((attempt * 10))
+done
 
 # stop the local registry now that we installed the CLI
 # Some tests install cdktn in an older version from NPM


### PR DESCRIPTION
### Description

The integration tests are intermittently failing with 502 errors when pulling packages from Verdaccio. To try and resolve this, this PR changes the following:

- Bumps the Verdaccio version to the latest `6.5.2` release
- Increases the `npm install` `fetch-retries` to 5 (default 2)
- Wraps the `npm install` with a bash retry block

Also:

- updates the deprecated `global-style` `npm install` option to `install-strategy=shallow`

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
