### PR TITLE
chore: Add `lint-staged` to knip ignored dependencies

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -6,6 +6,7 @@
   "workspaces": {
     ".": {
       "ignoreDependencies": [
+        "lint-staged", // used by husky
         // TODO: triage and remove entries — each is a declared dep with no detected usage.
         "changelog-parser",
         "eslint-plugin-import",


### PR DESCRIPTION
### Description

Add `lint-staged` to the `knip` `ignoredDependencies` list, so that it is not reported as unused, as it is referenced in the husky pre-commit configuration.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
