### PR TITLE
fix(tests): Fix app.test and json-to-hcl.test race condition

### DIFF
--- a/packages/cdktn/test/app.test.ts
+++ b/packages/cdktn/test/app.test.ts
@@ -336,22 +336,11 @@ describe("Cross Stack references", () => {
   });
 
   it("infers the correct path for local state", () => {
-    const tfStatePath = path.resolve(
-      process.cwd(),
-      `terraform.OriginStack.tfstate`,
-    );
     new TestResource(testStack, "Resource", {
       name: originStack.resource.stringValue,
     });
 
-    // Would error if the path was not correct
-    fs.writeFileSync(tfStatePath, "foo", "utf8");
-
-    try {
-      app.synth();
-    } finally {
-      fs.rmSync(tfStatePath);
-    }
+    app.synth();
 
     const { originStackSynth, targetStackSynth } = getStackSynths(app);
 


### PR DESCRIPTION
Fixes #77 

### Description

This PR fixes a race condition between `app.test` and `json-to-hcl.test` whereby `app.test` is polluting the current work directory with a temporary state file and then deleting it whilst `json-to-hcl.test` is copying the working directory. As the tests are configured to run in parallel, if these run together, the `json-to-hcl.test` test can sometimes fail with a 'ENOENT: no such file or dir' error during its file copy.

The fix is to remove the use of the temporary state file in the working directory of `app.test`, as it is not needed for the test to pass.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
