### PR TITLE
chore: Add retry to build-example

### DIFF
--- a/tools/build-example.js
+++ b/tools/build-example.js
@@ -47,9 +47,36 @@ async function runInExample(command) {
   }
 }
 
+/**
+ * Runs a command in the example, retrying on failure with linear backoff
+ * (10s, 20s, ...). Used to ride out transient 5xx responses when terraform
+ * downloads providers during `cdktn get`.
+ *
+ * @param {string} command The lerna script to run in the example.
+ * @param {number} [attempts=3] Maximum number of attempts before giving up.
+ * @param {number} [backoffSeconds=10] Base delay in seconds; multiplied by
+ *   the attempt number for linear backoff.
+ * @returns {Promise<void>} Resolves when the command succeeds; rejects with
+ *   the last error if every attempt fails.
+ */
+async function runWithRetry(command, attempts = 3, backoffSeconds = 10) {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await runInExample(command);
+    } catch (error) {
+      if (attempt === attempts) throw error;
+      const delaySeconds = attempt * backoffSeconds;
+      console.error(
+        `${command} attempt ${attempt} failed, retrying in ${delaySeconds}s...`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delaySeconds * 1000));
+    }
+  }
+}
+
 async function main() {
   await runInExample(`reinstall`);
-  await runInExample(`build`);
+  await runWithRetry(`build`);
   await runInExample(`beforeSynth`);
   await runInExample(`synth`);
 }

--- a/tools/build-example.js
+++ b/tools/build-example.js
@@ -49,17 +49,17 @@ async function runInExample(command) {
 
 /**
  * Runs a command in the example, retrying on failure with linear backoff
- * (10s, 20s, ...). Used to ride out transient 5xx responses when terraform
+ * (30s, 60s, 90s, ...). Used to ride out transient 5xx responses when terraform
  * downloads providers during `cdktn get`.
  *
  * @param {string} command The lerna script to run in the example.
- * @param {number} [attempts=3] Maximum number of attempts before giving up.
- * @param {number} [backoffSeconds=10] Base delay in seconds; multiplied by
+ * @param {number} [attempts=5] Maximum number of attempts before giving up.
+ * @param {number} [backoffSeconds=30] Base delay in seconds; multiplied by
  *   the attempt number for linear backoff.
  * @returns {Promise<void>} Resolves when the command succeeds; rejects with
  *   the last error if every attempt fails.
  */
-async function runWithRetry(command, attempts = 3, backoffSeconds = 10) {
+async function runWithRetry(command, attempts = 5, backoffSeconds = 30) {
   for (let attempt = 1; attempt <= attempts; attempt++) {
     try {
       return await runInExample(command);


### PR DESCRIPTION
### Description

The Examples integration tests are intermittently failing, receiving 502 errors when downloading providers from GitHub.

Example Failure job: https://github.com/open-constructs/cdk-terrain/actions/runs/24967060426/job/73104226295?pr=124

This PR adds a `runWithRetry` function to the `build.example.js` script so that these failures are retried with a linear backoff to help prevent the CI workflow failing.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
