### PR TITLE
chore: Remove edited from the examples workflow pull_request types

### DIFF
--- a/.github/workflows/examples-pr.yml
+++ b/.github/workflows/examples-pr.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - synchronize
       - labeled
       - unlabeled


### PR DESCRIPTION
### Description

The examples integration test GitHub workflows currently has the `edited` type in their `pull_request.types` configuration. This means that if the pull request title or description or updated, then the test are re-run. This makes no sense, especially as they take a long time and are currently flaky.

This PR removed the `edited` type from this workflow.

This was missed from https://github.com/open-constructs/cdk-terrain/pull/121

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
