### PR TITLE
chore: Fix Java flaky integration test

### DIFF
--- a/packages/@cdktn/provider-generator/src/get/constructs-maker.ts
+++ b/packages/@cdktn/provider-generator/src/get/constructs-maker.ts
@@ -205,7 +205,10 @@ export async function generateJsiiLanguage(
     if (opts.java) {
       const source = path.resolve(path.join(staging, "dist/java/src/"));
       const target = path.join(opts.java.outdir, "src/");
-      await fs.mkdirp(target); // make sure target directory exists
+      // Pre-create shared package directories.
+      const packageDir = opts.java.package.replace(/\./g, "/");
+      await fs.mkdirp(path.join(target, "main/java", packageDir));
+      await fs.mkdirp(path.join(target, "main/resources", packageDir));
       await fs.copy(source, target, { recursive: true, overwrite: false });
     }
 


### PR DESCRIPTION
### Description

The Java integration tests are intermittently failing with the following error:

```
    ⠧ downloading and generating modules and providers...

      at TestDriver.<anonymous> (test-helper.ts:134:17)
          at Generator.throw (<anonymous>)

  console.error
    [Error: EEXIST: file already exists, mkdir 'src/main/resources'] {
      errno: -17,
      code: 'EEXIST',
      syscall: 'mkdir',
      path: 'src/main/resources'
    }
```

Example failing job: https://github.com/open-constructs/cdk-terrain/actions/runs/25044674250/job/73357533671?pr=129

This looks like a race condition creating the shared package resource directories for the Java provider bindings.

### Fix

In the `provider-generator` package, pre-create the `src/main/java/<packageDir>` directories using `mkdirp` which is `EEXIST` tolerant, before copying the files.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
