### PR TITLE
chore(provider-generator): enable typescript declarationMap

### DIFF
--- a/packages/@cdktn/provider-generator/tsconfig.json
+++ b/packages/@cdktn/provider-generator/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
+    "declarationMap": true,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,


### PR DESCRIPTION


### Description

Sets `declarationMap: true` in `packages/@cdktn/provider-generator/tsconfig.json` so `tsc` emits `.d.ts.map` files alongside the type declarations.

With declaration maps, consumer IDEs (VS Code, JetBrains, etc.) follow `Go to Definition` / Cmd-click from a downstream package straight to the `.ts` source instead of stopping at the `.d.ts`. Every other `@cdktn/*` package already sets this flag, `provider-generator` was the only exception.

#### Effects

- Build emits `.d.ts.map` alongside each `.d.ts`. Negligible tarball size increase.
- No runtime behaviour change.
- No public API change.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
