### PR TITLE
chore(provider-generator): Add retry to terraform init for transient GitHub errors

### DIFF
--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+
+jest.mock("@cdktn/commons", () => ({
+  exec: jest.fn(),
+}));
+
+import { exec } from "@cdktn/commons";
+import { terraformInitWithRetry } from "../provider-schema";
+
+const execMock = exec as unknown as jest.Mock;
+
+function transientError(message = "502 Bad Gateway from github.com") {
+  const err: any = new Error("non-zero exit code 1");
+  err.stderr = message;
+  return err;
+}
+
+function fatalError(message = "Error: Invalid provider version") {
+  const err: any = new Error("non-zero exit code 1");
+  err.stderr = message;
+  return err;
+}
+
+describe("terraformInitWithRetry", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    execMock.mockReset();
+    consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("returns immediately on first-attempt success", async () => {
+    execMock.mockResolvedValueOnce("ok");
+
+    const result = await terraformInitWithRetry({ cwd: "/tmp/x" }, 3, 0);
+
+    expect(result).toBe("ok");
+    expect(execMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on transient stderr and eventually succeeds", async () => {
+    execMock
+      .mockRejectedValueOnce(transientError())
+      .mockRejectedValueOnce(transientError("ECONNRESET"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await terraformInitWithRetry({ cwd: "/tmp/x" }, 3, 0);
+
+    expect(result).toBe("ok");
+    expect(execMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on non-transient errors", async () => {
+    execMock.mockRejectedValueOnce(fatalError());
+
+    await expect(
+      terraformInitWithRetry({ cwd: "/tmp/x" }, 3, 0),
+    ).rejects.toMatchObject({ stderr: expect.stringContaining("Invalid") });
+
+    expect(execMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws after exhausting retries on persistent transient errors", async () => {
+    execMock.mockRejectedValue(transientError("503 Service Unavailable"));
+
+    await expect(
+      terraformInitWithRetry({ cwd: "/tmp/x" }, 3, 0),
+    ).rejects.toMatchObject({ stderr: expect.stringContaining("503") });
+
+    expect(execMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -23,6 +23,67 @@ import {
 
 const terraformBinaryName = process.env.TERRAFORM_BINARY_NAME || "terraform";
 
+// Provider binaries are downloaded from GitHub release CDNs during
+// `terraform init`, which intermittently returns 5xx. Retry on those
+// signatures only — real config/schema errors should still fail fast.
+const TRANSIENT_INIT_ERROR_PATTERNS = [
+  /\b50[234]\b/,
+  /Bad Gateway/i,
+  /Service Unavailable/i,
+  /Gateway Timeout/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /EAI_AGAIN/i,
+  /unexpected EOF/i,
+];
+
+/**
+ * Runs `terraform init` and retries on transient HTTP/network failures.
+ *
+ * Provider binaries are pulled from GitHub's release CDN, which
+ * intermittently returns 5xx. The retry only fires when stderr matches a
+ * known transient pattern — real errors (bad version, schema parse, etc.)
+ * still fail on the first attempt.
+ *
+ * @param options - spawn options forwarded to `exec` (`cwd` is required so
+ *   `terraform init` runs inside the temp dir holding `main.tf.json`)
+ * @param maxAttempts - total attempts including the initial call; the number
+ *   of retries is `maxAttempts - 1`. Defaults to 3 (1 initial + 2 retries)
+ * @param baseDelayMs - delay before the first retry. Tests pass `0` to skip
+ *   waits. Defaults to 1000ms
+ * @param backoffMultiplier - factor applied to the delay on each subsequent
+ *   retry (so retries wait `baseDelayMs * multiplier^(attempt-1)`). Defaults
+ *   to 2 (1s → 2s → 4s …)
+ * @returns stdout from the successful `terraform init` invocation
+ * @internal exposed for testing
+ */
+export async function terraformInitWithRetry(
+  options: { cwd: string },
+  maxAttempts = 3,
+  baseDelayMs = 1000,
+  backoffMultiplier = 2,
+): Promise<string> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await exec(terraformBinaryName, ["init"], options);
+    } catch (error: any) {
+      const stderr: string = error?.stderr ?? "";
+      const transient = TRANSIENT_INIT_ERROR_PATTERNS.some((p) =>
+        p.test(stderr),
+      );
+      if (!transient || attempt === maxAttempts) {
+        throw error;
+      }
+      const delayMs = baseDelayMs * backoffMultiplier ** (attempt - 1);
+      console.error(
+        `terraform init failed with a transient error, retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts - 1})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw new Error("unreachable");
+}
+
 /**
  * Fully Qualified provider name in the format:
  * like e.g. registry.terraform.io/hashicorp/aws
@@ -205,7 +266,7 @@ export async function readProviderSchema(
     const filePath = path.join(outdir, "main.tf.json");
     await fs.writeFile(filePath, JSON.stringify(config));
 
-    await exec(terraformBinaryName, ["init"], { cwd: outdir });
+    await terraformInitWithRetry({ cwd: outdir });
     providerSchema = JSON.parse(
       await exec(terraformBinaryName, ["providers", "schema", "-json"], {
         cwd: outdir,


### PR DESCRIPTION
### Description

The `provider-generator` integration tests are intermittently failing with following error:

```
Error: Failed to install provider
 
Error while installing andsafe-ag/bitbucket v2.5.0: unsuccessful request to
https://github.com/andsafe-AG/terraform-provider-bitbucket/releases/download/v2.5.0/terraform-provider-bitbucket_2.5.0_linux_amd64.zip:
502 Bad Gateway
```

These are transient GitHub errors and should be retried.

### Fix

Warp `terraform init` in `readProviderSchema` with a retry that fires on transient HTTP/network failures (`5xx` gateway, `ECONNRESET`/`ETIMEDOUT`/`EAI_AGAIN`, unexpected `EOF`). 

- Up to 3 attempts with exponential backoff
- Pattern match is on stderr only — anything that doesn't match is rethrown immediately

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
