### PR TITLE
chore: Remove unused dependencies from packages - phase 1

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,12 +15,7 @@
     },
     "packages/cdktn": {
       "entry": ["lib/index.ts"],
-      "project": ["lib/**/*.ts", "test/**/*.ts"],
-      "ignoreDependencies": [
-        // TODO: triage and remove entries — each is a declared dep with no detected usage.
-        "@types/minimatch",
-        "jsii-docgen"
-      ]
+      "project": ["lib/**/*.ts", "test/**/*.ts"]
     },
     "packages/cdktn-cli": {
       "entry": ["src/bin/cdktn.ts"],
@@ -128,52 +123,25 @@
       ]
     },
     "packages/@cdktn/commons": {
-      "project": ["src/**/*.ts"],
-      "ignoreDependencies": [
-        // TODO: triage and remove entries — each is a declared dep with no detected usage.
-        "lint-staged"
-      ]
+      "project": ["src/**/*.ts"]
     },
     "packages/@cdktn/hcl-tools": {
       "project": ["src/**/*.ts"]
     },
     "packages/@cdktn/hcl2cdk": {
-      "project": ["src/**/*.ts", "test/**/*.ts"],
-      "ignoreDependencies": [
-        // TODO: triage and remove entries — each is a declared dep with no detected usage.
-        "@types/glob"
-      ]
+      "project": ["src/**/*.ts", "test/**/*.ts"]
     },
     "packages/@cdktn/hcl2json": {
       "project": ["src/**/*.ts", "test/**/*.ts"]
     },
     "packages/@cdktn/provider-generator": {
-      "project": ["src/**/*.ts"],
-      "ignoreDependencies": [
-        // TODO: triage and remove entries — each is a declared dep with no detected usage.
-        "@types/deepmerge",
-        "@types/glob",
-        "@types/node",
-        "@types/reserved-words"
-      ]
+      "project": ["src/**/*.ts"]
     },
     "packages/@cdktn/provider-schema": {
-      "project": ["src/**/*.ts"],
-      "ignoreDependencies": [
-        // TODO: triage and remove entries — each is a declared dep with no detected usage.
-        "@types/follow-redirects",
-        "@types/uuid",
-        "lint-staged"
-      ]
+      "project": ["src/**/*.ts"]
     },
     "tools/generate-function-bindings": {
-      "project": ["scripts/**/*.ts"],
-      "ignoreDependencies": [
-        // TODO: triage and remove entries — each is a declared dep with no detected usage.
-        "@cdktn/provider-generator",
-        "cdktn",
-        "log4js"
-      ]
+      "project": ["scripts/**/*.ts"]
     }
   }
 }

--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -58,7 +58,6 @@
     "@types/uuid": "9.0.8",
     "@types/validator": "13.15.10",
     "jest": "^30.3.0",
-    "lint-staged": "^15.5.2",
     "ts-jest": "29.4.9",
     "tsc-files": "1.1.4",
     "typescript": "5.4.5"

--- a/packages/@cdktn/hcl2cdk/package.json
+++ b/packages/@cdktn/hcl2cdk/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@types/deep-equal": "1.0.4",
-    "@types/glob": "8.1.0",
     "@types/jest": "30.0.0",
     "@types/node": "20.19.37",
     "@types/prettier": "2.7.3",

--- a/packages/@cdktn/provider-generator/package.json
+++ b/packages/@cdktn/provider-generator/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@cdktn/commons": "0.0.0",
     "@cdktn/provider-schema": "0.0.0",
-    "@types/node": "18.19.101",
     "codemaker": "1.128.0",
     "fs-extra": "8.1.0",
     "glob": "10.5.0",
@@ -47,12 +46,9 @@
     "jsii-pacmak": "1.128.0"
   },
   "devDependencies": {
-    "@types/deepmerge": "2.2.3",
     "@types/fs-extra": "8.1.5",
-    "@types/glob": "7.2.0",
     "@types/jest": "30.0.0",
     "@types/node": "20.19.37",
-    "@types/reserved-words": "0.1.4",
     "jest": "^30.3.0",
     "ts-jest": "29.4.9",
     "typescript": "5.4.5"

--- a/packages/@cdktn/provider-schema/package.json
+++ b/packages/@cdktn/provider-schema/package.json
@@ -46,13 +46,10 @@
     "fs-extra": "11.3.4"
   },
   "devDependencies": {
-    "@types/follow-redirects": "1.14.4",
     "@types/fs-extra": "11.0.4",
     "@types/json-stable-stringify": "1.2.0",
-    "@types/uuid": "9.0.8",
     "jest": "^30.3.0",
     "json-stable-stringify": "1.3.0",
-    "lint-staged": "^15.5.2",
     "ts-jest": "29.4.9",
     "tsc-files": "1.1.4",
     "typescript": "5.4.5"

--- a/packages/cdktn/package.json
+++ b/packages/cdktn/package.json
@@ -4,7 +4,6 @@
     "description": "Cloud Development Kit for Terraform",
     "scripts": {
         "build": "jsii --silence-warnings reserved-word",
-        "docs": "node ./scripts/generate-documentation.js",
         "watch": "jsii -w --silence-warnings reserved-word",
         "watch-preserve-output": "tsc -w --preserveWatchOutput",
         "package": "jsii-pacmak && bash ./go-copyright-header.sh",
@@ -71,13 +70,11 @@
     "devDependencies": {
         "@types/jest": "30.0.0",
         "@types/json-stable-stringify": "1.2.0",
-        "@types/minimatch": "5.1.2",
         "@types/node": "18.19.130",
         "@types/semver": "7.7.1",
         "constructs": "10.6.0",
         "jest": "^30.3.0",
         "jsii": "5.9.37",
-        "jsii-docgen": "10.11.16",
         "jsii-pacmak": "1.128.0",
         "ts-jest": "29.4.9",
         "typescript": "5.4.5"

--- a/tools/generate-function-bindings/package.json
+++ b/tools/generate-function-bindings/package.json
@@ -33,15 +33,12 @@
   "license": "MPL-2.0",
   "dependencies": {
     "@babel/parser": "7.27.2",
-    "@cdktn/commons": "0.0.0",
-    "cdktn": "0.0.0",
-    "log4js": "^6.7.0"
+    "@cdktn/commons": "0.0.0"
   },
   "devDependencies": {
     "@babel/generator": "^7.20.4",
     "@babel/template": "^7.18.10",
     "@babel/types": "^7.20.2",
-    "@cdktn/provider-generator": "0.0.0",
     "ts-node": "^10.9.1",
     "typescript": "5.4.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,7 +1513,7 @@
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.127.0.tgz#5e5c1d38b0d5444b55158d03186c4a35b875af4c"
   integrity sha512-LJiQLjlyQuMx1KyoKDdU9SlxNe/3xnllPSTlb6alPL84aYAcrGQX82XX7v554AudesIZHp5p5u0bupTK+v3QWA==
 
-"@jsii/spec@1.128.0", "@jsii/spec@^1.127.0", "@jsii/spec@^1.128.0":
+"@jsii/spec@1.128.0", "@jsii/spec@^1.127.0":
   version "1.128.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.128.0.tgz#c7a536a070d455c8e2639517169c9d0ea6d51b25"
   integrity sha512-sv4JP3Ap7Vagh+yoCZ7mkfoKNY3ivV43QQPLzOYaNLgrTW86S+rqfiwTG/ouLn9qSaIC300vDpnT5V9uBGserA==
@@ -2679,7 +2679,7 @@
   resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz#94ae78fab4a38d73086e962d0b65c30d816bfb0a"
   integrity sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==
 
-"@types/minimatch@*", "@types/minimatch@5.1.2", "@types/minimatch@^5.1.2":
+"@types/minimatch@*", "@types/minimatch@^5.1.2":
   version "5.1.2"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
@@ -7897,20 +7897,6 @@ jsesc@^3.0.2:
   resolved "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-jsii-docgen@10.11.16:
-  version "10.11.16"
-  resolved "https://registry.yarnpkg.com/jsii-docgen/-/jsii-docgen-10.11.16.tgz#e57b87f8e17957df27e973aa108acf8e6a5e253a"
-  integrity sha512-k1EnGdwQjYMoYfNqS3lkWwu/tnLTQc50j4Caf2PKpeK0Wv5fpuIFFuxISWgjrblyq7POJv04iz5jS4At0RMfyw==
-  dependencies:
-    "@jsii/spec" "^1.128.0"
-    case "^1.6.3"
-    fast-glob "^3.3.3"
-    fs-extra "^10.1.0"
-    jsii-reflect "^1.128.0"
-    json-stream-stringify "^3.1.6"
-    semver "^7.7.4"
-    yargs "^16.2.0"
-
 jsii-pacmak@1.112.0, jsii-pacmak@^1.112.0:
   version "1.112.0"
   resolved "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.112.0.tgz#5002e788f584c2155e11d2b40fcff43ff8040380"
@@ -8072,11 +8058,6 @@ json-stable-stringify@*, json-stable-stringify@1.3.0:
     isarray "^2.0.5"
     jsonify "^0.0.1"
     object-keys "^1.1.1"
-
-json-stream-stringify@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/json-stream-stringify/-/json-stream-stringify-3.1.6.tgz#ebe32193876fb99d4ec9f612389a8d8e2b5d54d4"
-  integrity sha512-x7fpwxOkbhFCaJDJ8vb1fBY3DdSa4AlITaz+HHILQJzdPMnHEFjxPwVUi1ALIbcIxDE0PNe/0i7frnY8QnBQog==
 
 json-stringify-nice@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
### Description

Following on from #120 which introduced knip and parked the existing findings in `ignoreDependencies` as TODOs, this PR works through the "declared dep with no detected usage" entries for the following packages:

| Package | Dependency | Reason |
|---|---|---|
| `cdktn` | `@types/minimatch` | `minimatch` itself is not a dependency of this package; no imports. |
| `cdktn` | `jsii-docgen` | Only referenced by a `docs` script that pointed at a non-existent `./scripts/generate-documentation.js`. The actual doc generator lives in `tools/documentation-generation/` with its own `jsii-docgen` dep. Dead script also removed. |
| `@cdktn/commons` | `lint-staged` | `lint-staged` is invoked from the root `.husky/pre-commit` hook (`npx lint-staged`). The per-package `lint-staged` *config block* is consumed at runtime by the root binary — but having `lint-staged` as a per-package devDep is not required. |
| `@cdktn/hcl2cdk` | `@types/glob` (`8.1.0`) | Stale: `glob@10` ships built-in types (`"types"` field in its package.json). The standalone `@types/glob` package only exists for `glob` ≤ 7. |
| `@cdktn/provider-generator` | `@types/node` (from `dependencies`) | Duplicated — also declared (at a newer version) in `devDependencies`. Removed the older `dependencies` entry; types don't belong in runtime deps for a non-JSII package. |
| `@cdktn/provider-generator` | `@types/deepmerge` | `deepmerge` itself is not declared in this package; no imports. |
| `@cdktn/provider-generator` | `@types/glob` (`7.2.0`) | Same as above — `glob@10` ships its own types. |
| `@cdktn/provider-generator` | `@types/reserved-words` | `reserved-words` itself is not declared in this package; no imports. |
| `@cdktn/provider-schema` | `lint-staged` | Same as `@cdktn/commons` — invoked from root, per-package install is dead weight. |
| `@cdktn/provider-schema` | `@types/follow-redirects` | `follow-redirects` itself is not declared in this package; no imports. |
| `@cdktn/provider-schema` | `@types/uuid` | `uuid` itself is not declared in this package; no imports. |
| `tools/generate-function-bindings` | `cdktn` | Only appears as a `"cdktn"` string literal inside `path.resolve(...)` for filesystem navigation; not imported. |
| `tools/generate-function-bindings` | `log4js` | No imports. |
| `tools/generate-function-bindings` | `@cdktn/provider-generator` | No imports. |


### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
