### PR TITLE
chore(provider-generator): Update retry to terraform init for transient GitHub errors

### DIFF
--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -48,9 +48,9 @@ const TRANSIENT_INIT_ERROR_PATTERNS = [
  * @param options - spawn options forwarded to `exec` (`cwd` is required so
  *   `terraform init` runs inside the temp dir holding `main.tf.json`)
  * @param maxAttempts - total attempts including the initial call; the number
- *   of retries is `maxAttempts - 1`. Defaults to 3 (1 initial + 2 retries)
+ *   of retries is `maxAttempts - 1`. Defaults to 5 (1 initial + 4 retries)
  * @param baseDelayMs - delay before the first retry. Tests pass `0` to skip
- *   waits. Defaults to 1000ms
+ *   waits. Defaults to 5000ms
  * @param backoffMultiplier - factor applied to the delay on each subsequent
  *   retry (so retries wait `baseDelayMs * multiplier^(attempt-1)`). Defaults
  *   to 2 (1s → 2s → 4s …)
@@ -59,8 +59,8 @@ const TRANSIENT_INIT_ERROR_PATTERNS = [
  */
 export async function terraformInitWithRetry(
   options: { cwd: string },
-  maxAttempts = 3,
-  baseDelayMs = 1000,
+  maxAttempts = 5,
+  baseDelayMs = 5000,
   backoffMultiplier = 2,
 ): Promise<string> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -75,7 +75,7 @@ export async function terraformInitWithRetry(
         throw error;
       }
       const delayMs = baseDelayMs * backoffMultiplier ** (attempt - 1);
-      console.error(
+      console.log(
         `terraform init failed with a transient error, retrying in ${delayMs}ms (attempt ${attempt}/${maxAttempts - 1})`,
       );
       await new Promise((resolve) => setTimeout(resolve, delayMs));


### PR DESCRIPTION
### Description

The `provider-generator` integration tests are still intermittently failing with the following error even with the retry code introduced in https://github.com/open-constructs/cdk-terrain/pull/132.

```
│ Error: Failed to install provider
│ 
│ Error while installing drfaust92/bitbucket v2.51.0: unsuccessful request to
│ https://github.com/DrFaust92/terraform-provider-bitbucket/releases/download/v2.51.0/terraform-provider-bitbucket_2.51.0_linux_amd64.zip:
│ 502 Bad Gateway
```

Example job with failure: https://github.com/open-constructs/cdk-terrain/actions/runs/25098016781/job/73539622159?pr=130#step:13:77

This PR makes the following changes to the retry code:

- Increases the max attempts to 5
- Increases the base delay to 5 seconds
- Update the console retry message from an error to a log (no need for a stack trace)

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
