### PR TITLE
chore: Fix eslint warnings - phase 1

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktn/cli-core/src/lib/cdktf-project.ts
@@ -211,7 +211,6 @@ export class CdktfProject {
           return [
             key,
             // This is passed in to make typescript happy only
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             (_: V) => {
               value(update);
 

--- a/packages/@cdktn/cli-core/src/lib/dependencies/prebuilt-providers.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/prebuilt-providers.ts
@@ -47,7 +47,7 @@ async function fetchWrapped<T>(url: string): Promise<T> {
       agent,
       headers: { "User-Agent": "OpenConstructs/cdktn-cli" },
     });
-  } catch (e) {
+  } catch {
     // Fetch only fails here because of connectivity issues
     logger.error(
       "Unable to request pre-built provider information: Network error, please check if you're connected to the internet and try again",

--- a/packages/@cdktn/cli-core/src/lib/server/terraform-logs.ts
+++ b/packages/@cdktn/cli-core/src/lib/server/terraform-logs.ts
@@ -4,7 +4,7 @@ function extractJsonLogLineIfPresent(logLine: string): string {
   try {
     const extractedMessage = JSON.parse(logLine)["@message"];
     return extractedMessage ? extractedMessage.trim() : logLine;
-  } catch (e) {
+  } catch {
     return logLine;
   }
 }

--- a/packages/@cdktn/cli-core/src/lib/terraform-provider-lock.ts
+++ b/packages/@cdktn/cli-core/src/lib/terraform-provider-lock.ts
@@ -36,7 +36,7 @@ export class TerraformProviderLock {
     try {
       await fs.stat(this.lockFilePath);
       return true;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/packages/@cdktn/hcl2cdk/src/__tests__/expressionToTs.test.ts
+++ b/packages/@cdktn/hcl2cdk/src/__tests__/expressionToTs.test.ts
@@ -974,7 +974,7 @@ EOF`;
   test("convert using operations while containing substring", async () => {
     const expression =
       // prettier-ignore
-      '"${length(var.image_id) > 4 && substr(var.image_id, 0, 4) == \"ami-\"}"';
+      '"${length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"}"';
     const scope = getScope({});
     const result = await convertTerraformExpressionToTs(
       scope,

--- a/packages/@cdktn/hcl2cdk/src/generation.ts
+++ b/packages/@cdktn/hcl2cdk/src/generation.ts
@@ -165,7 +165,7 @@ export const valueToTs = async (
               }
 
               if (key === "dynamic") {
-                const { for_each, ...others } = value as any;
+                const { for_each: _for_each, ...others } = value as any;
                 const dynamicRef = Object.keys(others)[0];
                 return t.objectProperty(
                   t.identifier(
@@ -844,7 +844,7 @@ export async function modules(
   item: Module,
   graph: DirectedGraph,
 ) {
-  const [{ source, version, ...props }] = item;
+  const [{ source, version: _version, ...props }] = item;
 
   const moduleConstraint = new TerraformModuleConstraint(source);
 
@@ -935,7 +935,7 @@ export async function provider(
   item: Provider[0],
   graph: DirectedGraph,
 ) {
-  const { version, ...props } = item;
+  const { version: _version, ...props } = item;
 
   const importKey = key === "null" ? "NullProvider" : key;
 

--- a/packages/@cdktn/hcl2cdk/src/jsii-rosetta-workarounds.ts
+++ b/packages/@cdktn/hcl2cdk/src/jsii-rosetta-workarounds.ts
@@ -111,7 +111,7 @@ export function replaceGoImports(code: string) {
     .map((line) => {
       // Replace using lines with lib
       const fromImportLibRegex =
-        /import \"github.com\/aws-samples\/dummy\/gen\/providers\/([^\/]*)(?:\/lib)?\/(.*)\"/;
+        /import "github.com\/aws-samples\/dummy\/gen\/providers\/([^/]*)(?:\/lib)?\/(.*)"/;
       const matchLib = line.match(fromImportLibRegex);
       if (matchLib) {
         const [, provider, resource] = matchLib;
@@ -120,7 +120,7 @@ export function replaceGoImports(code: string) {
 
       // Replace using lines
       const fromImportRegex =
-        /import \"github.com\/aws-samples\/dummy\/gen\/providers\/([^\/]+)\/(.*)\"/;
+        /import "github.com\/aws-samples\/dummy\/gen\/providers\/([^/]+)\/(.*)"/;
       const match = line.match(fromImportRegex);
       if (match) {
         const [, provider, resource] = match;
@@ -128,7 +128,7 @@ export function replaceGoImports(code: string) {
       }
 
       const importModulesRegex =
-        /import (.*) \"github.com\/aws-samples\/dummy\/gen\/modules\/(.*)\"/;
+        /import (.*) "github.com\/aws-samples\/dummy\/gen\/modules\/(.*)"/;
       const matchModules = line.match(importModulesRegex);
       if (matchModules) {
         const [, name, module] = matchModules;

--- a/packages/@cdktn/hcl2cdk/src/references.ts
+++ b/packages/@cdktn/hcl2cdk/src/references.ts
@@ -179,7 +179,7 @@ export async function findUsedReferences(
 
   if (item && "dynamic" in item) {
     const dyn = (item as any)["dynamic"];
-    const { for_each, ...others } = dyn;
+    const { for_each: _for_each, ...others } = dyn;
     const dynamicRef = Object.keys(others)[0];
     return await findUsedReferences([...nodeIds, dynamicRef], dyn);
   }

--- a/packages/@cdktn/hcl2json/test/util.test.ts
+++ b/packages/@cdktn/hcl2json/test/util.test.ts
@@ -5,9 +5,9 @@ import { replaceQuotes } from "../src/util";
 
 describe("replaceQuotes", () => {
   test("replaces a simple quote", () => {
-    expect(replaceQuotes(`"foo\"bar"`)).toEqual(`"foo\\"bar"`);
+    expect(replaceQuotes(`"foo"bar"`)).toEqual(`"foo\\"bar"`);
   });
   test("replaces a simple quote twice", () => {
-    expect(replaceQuotes(`"foo\"bar\""`)).toEqual(`"foo\\"bar\\""`);
+    expect(replaceQuotes(`"foo"bar""`)).toEqual(`"foo\\"bar\\""`);
   });
 });

--- a/packages/@cdktn/provider-generator/src/__tests__/provider.test.ts
+++ b/packages/@cdktn/provider-generator/src/__tests__/provider.test.ts
@@ -50,7 +50,7 @@ function resourceTypesPresentInSnapshot(
   const files = Object.keys(snapshot);
   for (const file of files) {
     const match = file.match(
-      `/providers\/${providerNameInPath}\/(.*?)\/index\.ts/`,
+      `/providers/${providerNameInPath}/(.*?)/index.ts/`,
     );
     // avoids any not resources from being pushed
     if (

--- a/packages/cdktn-cli/src/bin/cmds/convert.ts
+++ b/packages/cdktn-cli/src/bin/cmds/convert.ts
@@ -11,7 +11,7 @@ function readCdktfJson(cwd = process.cwd()): { language: string } | undefined {
   try {
     const cdktfJsonPath = path.join(cwd, "cdktf.json");
     return fs.readJsonSync(cdktfJsonPath);
-  } catch (e) {
+  } catch {
     return undefined;
   }
 }

--- a/packages/cdktn-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktn-cli/src/bin/cmds/handlers.ts
@@ -113,7 +113,7 @@ export async function convert({
   let input: string | undefined = undefined;
   try {
     input = await readStreamAsString(process.stdin);
-  } catch (e) {
+  } catch {
     logger.debug(`No TTY stream passed to convert, using interactive input`);
     try {
       input = await editor({
@@ -122,7 +122,7 @@ export async function convert({
         postfix: ".tf",
         waitForUseInput: true,
       });
-    } catch (err) {
+    } catch {
       throw Errors.Usage(
         "No Terraform code to convert was provided. Please provide Terraform code to convert as stdin or run the command again and let the CLI open the editor.",
       );
@@ -431,7 +431,7 @@ export async function login(argv: { tfeHostname: string }) {
   try {
     token = await readStreamAsString(process.stdin);
     token = token.replace(/\n/g, "");
-  } catch (e) {
+  } catch {
     logger.debug(`No TTY stream passed to login`);
   }
 

--- a/packages/cdktn-cli/src/bin/cmds/helper/terraform-login.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/terraform-login.ts
@@ -134,7 +134,7 @@ the following file for use by subsequent Terraform commands:
       const terraformCredentials: TerraformCredentialsFile = credentialsFile;
 
       return terraformCredentials;
-    } catch (e) {
+    } catch {
       logger.debug(
         `Could not find terraform credentials file at ${terraformCredentialsFilePath}`,
       );

--- a/test/typescript/watch/test.ts
+++ b/test/typescript/watch/test.ts
@@ -89,7 +89,6 @@ const screenOutput = (
     timeout = 30_000,
   ): Promise<string> => {
     return new Promise((resolve, reject) => {
-      let timeoutId: NodeJS.Timeout; // timeout must be cancelled to allow Jest to terminate
       const subscription = (line: string | undefined, exit: boolean) => {
         if (exit) {
           reject(new Error("exited before waitForLine finished"));
@@ -100,7 +99,8 @@ const screenOutput = (
           clearTimeout(timeoutId);
         }
       };
-      timeoutId = setTimeout(() => {
+      // timeout must be cancelled to allow Jest to terminate
+      const timeoutId: NodeJS.Timeout = setTimeout(() => {
         reject(new Error("waitForLine timed out"));
       }, timeout);
       subscriber = subscription;


### PR DESCRIPTION
### Description

This PR fixes the first phase of eslint warnings:

- 16 `no-useless-escape` warnings
- 8 `caught-error` renames (`catch (e)` to `catch`)
- 4 unused destructure renames (`for_each`, `version` to `_for_each`, `_version`)
- 1 `prefer-const` (restructured `let timeoutId` to `const`)
- 1 unused `eslint-disable` directive

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
