### PR TITLE
chore: Fix eslint warnings - phase 2

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/cdktf-config.ts
+++ b/packages/@cdktn/cli-core/src/lib/cdktf-config.ts
@@ -33,7 +33,9 @@ export class CdktfConfig {
   constructor(private cdktfConfigPath: string) {}
 
   private readCdktfConfig(): Record<string, unknown> {
-    const cdktfConfig = require(this.cdktfConfigPath);
+    const cdktfConfig = JSON.parse(
+      fs.readFileSync(this.cdktfConfigPath, "utf-8"),
+    );
     if (typeof cdktfConfig !== "object" || cdktfConfig === null) {
       throw Errors.External(
         "cdktf.json is malformed. The root must be a JSON object.",

--- a/packages/@cdktn/cli-core/src/lib/watch.ts
+++ b/packages/@cdktn/cli-core/src/lib/watch.ts
@@ -21,7 +21,7 @@ function getOrWriteDefaultWatchConfig(projectPath = process.cwd()) {
 
   let cdktfJson;
   try {
-    cdktfJson = require(cdktfJsonPath);
+    cdktfJson = JSON.parse(fs.readFileSync(cdktfJsonPath, "utf-8"));
   } catch (err: any) {
     throw Errors.Internal(
       `Could not find cdktf.json file in ${projectPath}`,

--- a/packages/@cdktn/commons/src/checkpoint.ts
+++ b/packages/@cdktn/commons/src/checkpoint.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import https = require("https");
+import * as https from "https";
 import { format } from "url";
 import { v4 as uuidv4 } from "uuid";
 import * as os from "os";
@@ -105,7 +105,7 @@ function getId(
 
   let jsonFile;
   try {
-    jsonFile = require(filePath); // we found the file
+    jsonFile = JSON.parse(fs.readFileSync(filePath, "utf-8")); // we found the file
   } catch {
     // we found no file, create one if we're forcing a creation
     if (forceCreation) {

--- a/packages/@cdktn/commons/src/debug.ts
+++ b/packages/@cdktn/commons/src/debug.ts
@@ -6,12 +6,14 @@ import { logger } from "./logging";
 import { exec } from "./util";
 import { terraformVersion } from "./terraform";
 import { DISPLAY_VERSION } from "./version";
-import { pathExists } from "fs-extra";
+import { pathExists, readFileSync } from "fs-extra";
 import { getGradlePackageVersion, isGradleProject } from "./gradle";
 
 export function getLanguage(projectPath = process.cwd()): string | undefined {
   try {
-    const cdktfJson = require(path.resolve(projectPath, "cdktf.json"));
+    const cdktfJson = JSON.parse(
+      readFileSync(path.resolve(projectPath, "cdktf.json"), "utf-8"),
+    );
     return cdktfJson.language;
   } catch {
     // We can not detect the language

--- a/packages/@cdktn/hcl2cdk/test/convertProject.test.ts
+++ b/packages/@cdktn/hcl2cdk/test/convertProject.test.ts
@@ -239,7 +239,11 @@ describe.skip("convertProject", () => {
     fs.writeFileSync(
       path.resolve(targetPath, "cdktf.json"),
       JSON.stringify(
-        cdktfJson(require(path.resolve(targetPath, "cdktf.json"))),
+        cdktfJson(
+          JSON.parse(
+            fs.readFileSync(path.resolve(targetPath, "cdktf.json"), "utf-8"),
+          ),
+        ),
       ),
       "utf8",
     );

--- a/packages/cdktn-cli/build.ts
+++ b/packages/cdktn-cli/build.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-const esbuild = require("esbuild");
+import * as esbuild from "esbuild";
 import * as fs from "fs-extra";
 
 const enableWatch = process.argv.find((arg) => arg === "--watch") === "--watch";
@@ -52,7 +52,7 @@ const nativeNodeModulesPlugin = {
   },
 };
 
-const config = {
+const config: esbuild.BuildOptions = {
   entryPoints: ["src/bin/cdktn.ts", "src/bin/cmds/handlers.ts"],
   outbase: "src",
   bundle: true,

--- a/packages/cdktn-cli/src/bin/cdktn.ts
+++ b/packages/cdktn-cli/src/bin/cdktn.ts
@@ -13,6 +13,19 @@ import {
   collectDebugInformation,
   CDKTF_DISABLE_PLUGIN_CACHE_ENV,
 } from "@cdktn/commons";
+import initCmd from "./cmds/init";
+import getCmd from "./cmds/get";
+import convertCmd from "./cmds/convert";
+import deployCmd from "./cmds/deploy";
+import destroyCmd from "./cmds/destroy";
+import diffCmd from "./cmds/diff";
+import listCmd from "./cmds/list";
+import loginCmd from "./cmds/login";
+import synthCmd from "./cmds/synth";
+import watchCmd from "./cmds/watch";
+import outputCmd from "./cmds/output";
+import debugCmd from "./cmds/debug";
+import providerCmd from "./cmds/provider";
 
 const ensurePluginCache = (): string => {
   const pluginCachePath =
@@ -72,19 +85,19 @@ const customCompletion = function (
 
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 yargs
-  .command(require("./cmds/init"))
-  .command(require("./cmds/get"))
-  .command(require("./cmds/convert"))
-  .command(require("./cmds/deploy"))
-  .command(require("./cmds/destroy"))
-  .command(require("./cmds/diff"))
-  .command(require("./cmds/list"))
-  .command(require("./cmds/login"))
-  .command(require("./cmds/synth"))
-  .command(require("./cmds/watch"))
-  .command(require("./cmds/output"))
-  .command(require("./cmds/debug"))
-  .command(require("./cmds/provider"))
+  .command(initCmd)
+  .command(getCmd)
+  .command(convertCmd)
+  .command(deployCmd)
+  .command(destroyCmd)
+  .command(diffCmd)
+  .command(listCmd)
+  .command(loginCmd)
+  .command(synthCmd)
+  .command(watchCmd)
+  .command(outputCmd)
+  .command(debugCmd)
+  .command(providerCmd)
   .recommendCommands()
   .exitProcess(false)
   .wrap(yargs.terminalWidth())

--- a/packages/cdktn-cli/src/bin/cmds/convert.ts
+++ b/packages/cdktn-cli/src/bin/cmds/convert.ts
@@ -67,4 +67,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/debug.ts
+++ b/packages/cdktn-cli/src/bin/cmds/debug.ts
@@ -25,4 +25,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/deploy.ts
+++ b/packages/cdktn-cli/src/bin/cmds/deploy.ts
@@ -124,4 +124,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/destroy.ts
+++ b/packages/cdktn-cli/src/bin/cmds/destroy.ts
@@ -101,4 +101,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/diff.ts
+++ b/packages/cdktn-cli/src/bin/cmds/diff.ts
@@ -93,4 +93,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/get.ts
+++ b/packages/cdktn-cli/src/bin/cmds/get.ts
@@ -54,4 +54,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/helper/check-directory.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/check-directory.ts
@@ -1,11 +1,12 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
+import * as fs from "fs";
 import * as path from "path";
 import { Errors } from "@cdktn/commons";
 export function isCdktfProjectDirectory(directory: string): boolean {
   try {
     const cdktfPath = path.join(directory, "cdktf.json");
-    const cdktf = require(cdktfPath);
+    const cdktf = JSON.parse(fs.readFileSync(cdktfPath, "utf-8"));
     return cdktf.language && cdktf.app;
   } catch {
     return false;

--- a/packages/cdktn-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/init.ts
@@ -245,7 +245,9 @@ This means that your Terraform state file will be stored locally on disk in a fi
     );
 
     const renderedCdktfJson = cdktfJson(
-      require(path.resolve(destination, "cdktf.json")),
+      JSON.parse(
+        fs.readFileSync(path.resolve(destination, "cdktf.json"), "utf-8"),
+      ),
     );
     fs.writeFileSync(
       path.resolve(destination, "cdktf.json"),

--- a/packages/cdktn-cli/src/bin/cmds/helper/terraform-login.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/terraform-login.ts
@@ -1,6 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import * as fs from "fs";
+import * as os from "os";
 import { confirm, password } from "@inquirer/prompts";
 import * as open from "open";
 import * as chalk from "chalk";
@@ -8,7 +9,7 @@ import * as terraformCloudClient from "./terraform-cloud-client";
 import { Errors, logger } from "@cdktn/commons";
 
 const chalkColour = new chalk.Instance();
-const homedir = require("os").homedir();
+const homedir = os.homedir();
 const terraformCredentialsFilePath = `${homedir}/.terraform.d/credentials.tfrc.json`;
 
 const nonIteractiveLoginWithNoTokenError = (invalid: boolean) =>

--- a/packages/cdktn-cli/src/bin/cmds/helper/utilities.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/utilities.ts
@@ -1,8 +1,11 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import * as fs from "fs-extra";
+import { createRequire } from "node:module";
 import path from "path";
 import * as pkgUp from "pkg-up";
+
+const localRequire = createRequire(__filename);
 
 export const readPackageJson = () => {
   const pkgPath = pkgUp.sync({ cwd: __dirname });
@@ -28,9 +31,9 @@ export const requireHandlers = () => {
   // otherwise return the file path relative to the project root
   const filePath = path.join(__dirname, "..", "handlers.js");
   if (fs.existsSync(filePath)) {
-    return require(filePath);
+    return localRequire(filePath);
   }
-  return require(
+  return localRequire(
     path.join(projectRootPath(), "bundle", "bin", "cmds", "handlers.js"),
   );
 };

--- a/packages/cdktn-cli/src/bin/cmds/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/init.ts
@@ -72,4 +72,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/list.ts
+++ b/packages/cdktn-cli/src/bin/cmds/list.ts
@@ -33,4 +33,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/login.ts
+++ b/packages/cdktn-cli/src/bin/cmds/login.ts
@@ -38,4 +38,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/output.ts
+++ b/packages/cdktn-cli/src/bin/cmds/output.ts
@@ -64,4 +64,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/provider-add.ts
+++ b/packages/cdktn-cli/src/bin/cmds/provider-add.ts
@@ -31,4 +31,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/provider-list.ts
+++ b/packages/cdktn-cli/src/bin/cmds/provider-list.ts
@@ -23,4 +23,4 @@ class ProviderListCommand extends BaseCommand {
   }
 }
 
-module.exports = new ProviderListCommand();
+export default new ProviderListCommand();

--- a/packages/cdktn-cli/src/bin/cmds/provider-upgrade.ts
+++ b/packages/cdktn-cli/src/bin/cmds/provider-upgrade.ts
@@ -25,4 +25,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/provider.ts
+++ b/packages/cdktn-cli/src/bin/cmds/provider.ts
@@ -1,6 +1,10 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import yargs from "yargs";
+import getCmd from "./get";
+import providerAddCmd from "./provider-add";
+import providerUpgradeCmd from "./provider-upgrade";
+import providerListCmd from "./provider-list";
 
 class Command implements yargs.CommandModule {
   public readonly command = "provider";
@@ -9,14 +13,14 @@ class Command implements yargs.CommandModule {
 
   public readonly builder = (args: yargs.Argv) =>
     args
-      .command(require("./get"))
-      .command(require("./provider-add"))
-      .command(require("./provider-upgrade"))
-      .command(require("./provider-list"));
+      .command(getCmd)
+      .command(providerAddCmd)
+      .command(providerUpgradeCmd)
+      .command(providerListCmd);
 
   public readonly handler = () => {
     yargs.showHelp();
   };
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/synth.ts
+++ b/packages/cdktn-cli/src/bin/cmds/synth.ts
@@ -49,4 +49,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/packages/cdktn-cli/src/bin/cmds/watch.ts
+++ b/packages/cdktn-cli/src/bin/cmds/watch.ts
@@ -60,4 +60,4 @@ class Command extends BaseCommand {
   }
 }
 
-module.exports = new Command();
+export default new Command();

--- a/test/csharp/edge/test.ts
+++ b/test/csharp/edge/test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import * as path from "path";
 import * as fs from "fs-extra";
-const { execSync } = require("child_process");
+import { execSync } from "child_process";
 import { QueryableStack, TestDriver, onlyJson } from "../../test-helper";
 
 describe("csharp full integration test synth", () => {

--- a/test/csharp/no-color-command-option-test/test.ts
+++ b/test/csharp/no-color-command-option-test/test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as execa from "execa";
+import execa from "execa";
 import * as hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 

--- a/test/csharp/no-color-command-option-test/test.ts
+++ b/test/csharp/no-color-command-option-test/test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import execa from "execa";
-import * as hasAnsi from "has-ansi";
+import hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 
 describe("no-color option for cdktn deploy, diff, destroy", () => {

--- a/test/go/no-color-command-option-test/test.ts
+++ b/test/go/no-color-command-option-test/test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as execa from "execa";
+import execa from "execa";
 import * as hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 

--- a/test/go/no-color-command-option-test/test.ts
+++ b/test/go/no-color-command-option-test/test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import execa from "execa";
-import * as hasAnsi from "has-ansi";
+import hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 
 describe("no-color option for cdktn deploy, diff, destroy", () => {

--- a/test/java/no-color-command-option-test/test.ts
+++ b/test/java/no-color-command-option-test/test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import execa from "execa";
-import * as hasAnsi from "has-ansi";
+import hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 
 // No-Color in Gradle is either defined through command line options (--console=plain)

--- a/test/java/no-color-command-option-test/test.ts
+++ b/test/java/no-color-command-option-test/test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as execa from "execa";
+import execa from "execa";
 import * as hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 

--- a/test/package.json
+++ b/test/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/fs-extra": "^8.1.5",
+    "@types/has-ansi": "^5.0.2",
     "@types/jest": "30.0.0",
     "@types/yazl": "^3.3.1",
     "execa": "^5.1.1",

--- a/test/python/no-color-command-option-test/test.ts
+++ b/test/python/no-color-command-option-test/test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as execa from "execa";
+import execa from "execa";
 import * as hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 

--- a/test/python/no-color-command-option-test/test.ts
+++ b/test/python/no-color-command-option-test/test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import execa from "execa";
-import * as hasAnsi from "has-ansi";
+import hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 
 describe("no-color option for cdktn deploy, diff, destroy", () => {

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -5,11 +5,11 @@ import { spawn, execSync } from "child_process";
 import * as execa from "execa";
 import { spawn as crossSpawn } from "cross-spawn";
 
-const os = require("os");
-const path = require("path");
-const fs = require("fs");
-const fse = require("fs-extra");
-const stripAnsi = require("strip-ansi");
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+import * as fse from "fs-extra";
+import stripAnsi from "strip-ansi";
 
 function execSyncLogErrors(...args: Parameters<typeof execSync>) {
   try {

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { TemplateServer } from "./template-server";
 import { spawn, execSync } from "child_process";
-import * as execa from "execa";
+import execa from "execa";
 import { spawn as crossSpawn } from "cross-spawn";
 
 import * as os from "os";

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/test/typescript/no-color-command-option-test/test.ts
+++ b/test/typescript/no-color-command-option-test/test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as execa from "execa";
+import execa from "execa";
 import * as hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 

--- a/test/typescript/no-color-command-option-test/test.ts
+++ b/test/typescript/no-color-command-option-test/test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import execa from "execa";
-import * as hasAnsi from "has-ansi";
+import hasAnsi from "has-ansi";
 import { onPosix, TestDriver } from "../../test-helper";
 
 describe("no-color option for cdktn deploy, diff, destroy", () => {

--- a/test/typescript/watch/test.ts
+++ b/test/typescript/watch/test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import { TestDriver } from "../../test-helper";
-import stripAnsi = require("strip-ansi");
+import stripAnsi from "strip-ansi";
 import { ChildProcess } from "child_process";
 
 const onPosix = process.platform !== "win32" ? test : test.skip;

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -824,6 +824,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/has-ansi@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/has-ansi/-/has-ansi-5.0.2.tgz#21d874bfb4a9534db0d279645a3af0964650965e"
+  integrity sha512-umJQ393eDf2R9eBdRxZTyXlRDq82ZVT9/tNfF3H3d2GDIBQILq/LZXHSvwXaH2OSvaSHVe2BX3s+IdoFHQ8zmg==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"


### PR DESCRIPTION
### Description

This PR fixes the second phase of eslint warnings:

- `require()`to `import` refactor

### Changes

- Group A (7 files) - replaced dynamic `require(JSON-path)` with `JSON.parse(fs.readFileSync(path, "utf-8"))`: `cdktf-config.ts`, `watch.ts`, `checkpoint.ts`, `debug.ts` (commons), `check-directory.ts`, `init.ts` (`helper`), `convertProject.test.ts`
- Group B (6 files) - replaced static module `require()` with ESM `import`: `build.ts` (`esbuild`), `checkpoint.ts` (`https`), `terraform-login.ts` (`os`), `test/test-helper.ts` (5 imports), `test/csharp/edge/test.ts`, `test/typescript/watch/test.ts`
- Group C (17 files) - converted `yargs` subcommand registration to ESM: 16 cmd files (`module.exports = new Command()` to `export default new Command())` plus `cdktn.ts` and `provider.ts` (now use `import x from "./cmds/x"; yargs.command(x)`)
- Group D (1 file) - use `createRequire` from `node:module` to replace the `require` to keep the lazy-load behavior.

#### Test infra fixes

- Added `test/tsconfig.json` (`esModuleInterop`, target `es2020`) so the test directory typechecks under the new ESM-style imports.
- Switched `test-helper.ts` and 5 `no-color-command-option-test/test.ts` files (typescript/go/python/java/csharp) from `import * as execa` to `import execa from "execa"` to satisfy `esModuleInterop`.
- `has-ansi`: same fix applied to the same 5 files (`import * as hasAnsi` → `import hasAnsi`). Added `@types/has-ansi@^5.0.2` to `test/package.json` to silence the TS7016 hint.

This reduces the eslint warnings down to 7.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
