### PR TITLE
chore: Fix eslint warnings - phase 3

### DIFF
--- a/packages/@cdktn/provider-generator/src/get/generator/emitter/resource-emitter.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/emitter/resource-emitter.ts
@@ -149,9 +149,11 @@ export class ResourceEmitter {
       `public constructor(scope: Construct, id: string, config: ${resource.configStruct.attributeType})`,
     );
 
-    resource.isProvider
-      ? this.emitProviderSuper(resource)
-      : this.emitResourceSuper(resource);
+    if (resource.isProvider) {
+      this.emitProviderSuper(resource);
+    } else {
+      this.emitResourceSuper(resource);
+    }
 
     // initialize config properties
     for (const att of resource.configStruct.assignableAttributes) {

--- a/packages/@cdktn/provider-generator/src/get/generator/emitter/struct-emitter.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/emitter/struct-emitter.ts
@@ -145,8 +145,7 @@ export class StructEmitter {
             if (!attTypeStruct)
               throw new Error(`${structTypeName} is not a struct`);
 
-            structsToImport[fileToImport] ??
-              (structsToImport[fileToImport] = []);
+            structsToImport[fileToImport] ??= [];
 
             const attReferences = att.getReferencedTypes(
               struct instanceof ConfigStruct,


### PR DESCRIPTION
### Description

This PR fixes the third phase of eslint warnings:

- `@typescript-eslint/no-unused-expressions`

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
