### PR TITLE
chore: Fix eslint warnings - phase 4

### DIFF
--- a/packages/cdktn-cli/src/bin/cmds/ui/get.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/get.tsx
@@ -85,7 +85,7 @@ export const Get = ({
         ),
       );
     }
-  }, [currentStatus]);
+  }, [currentStatus, exit, codeMakerOutput]);
 
   const isGenerating: boolean = currentStatus != Status.DONE;
   const statusText = `${currentStatus}...`;

--- a/packages/cdktn-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/hooks/cdktf-project.ts
@@ -139,6 +139,9 @@ export function useCdktfProject<T>(
       .catch((err) => {
         exit(new Error(err));
       });
+    // The project is created and started once on mount. Re-running on dep
+    // changes would spawn duplicate projects and re-invoke `projectCallback`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {

--- a/packages/cdktn-cli/src/bin/cmds/ui/watch.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/watch.tsx
@@ -70,6 +70,9 @@ export const Watch = ({
         setCurrentState(state);
       },
     );
+    // Watch is started once on mount; re-running with new deps would spawn a
+    // second watcher. The session uses the props captured at mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
### Description

This PR fixes the fourth phase of eslint warnings:

- `react-hooks/exhaustive-deps`

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
