### PR TITLE
chore: Fix eslint warnings - phase 5

### DIFF
--- a/examples/typescript/documentation/data-sources.ts
+++ b/examples/typescript/documentation/data-sources.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 // DOCS_BLOCK_START:datasources,remote-state-datasources
-import { TerraformStack } from "cdktn";
+import { TerraformOutput, TerraformStack } from "cdktn";
 import { Construct } from "constructs";
 import { AwsProvider } from "@cdktf/provider-aws/lib/provider";
 // DOCS_BLOCK_END:datasources,remote-state-datasources
@@ -29,6 +29,9 @@ export class DataSourcesStack extends TerraformStack {
 
     // DOCS_BLOCK_START:datasources
     const region = new DataAwsRegion(this, "region");
+    new TerraformOutput(this, "region_name", {
+      value: region.name,
+    });
     // DOCS_BLOCK_END:datasources
 
     // DOCS_BLOCK_START:remote-state-datasources

--- a/examples/typescript/documentation/providers.ts
+++ b/examples/typescript/documentation/providers.ts
@@ -50,7 +50,7 @@ export class ProvidersStack extends TerraformStack {
     new ZoneRecord(this, "web-www", {
       zoneName: "example.com",
       name: "web",
-      value: instance.publicIp,
+      value: Token.asString(instance.publicIp),
       type: "A",
     });
     // DOCS_BLOCK_END:providers-import-classes


### PR DESCRIPTION
### Description

This PR fixes the fifth phase of eslint warnings:

- `no-unused-vars` in examples

### Changes

- `data-sources.ts` - added `TerraformOutput` to demonstrate accessing data source attributes (`region.name`). 
- `providers.ts` - wrapped `instance.publicIp` with `Token.asString(...)` in the existing `ZoneRecord.value`.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
