### PR TITLE
chore: add typecheck CI gate, fail fast on type errors

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -40,3 +40,8 @@ jobs:
       - name: run workspace linting
         run: |
           yarn lint:workspace
+
+  typecheck:
+    uses: ./.github/workflows/typecheck.yml
+    with:
+      concurrency_group_prefix: ${{ inputs.concurrency_group_prefix }}

--- a/.github/workflows/pr-integration.yml
+++ b/.github/workflows/pr-integration.yml
@@ -11,7 +11,15 @@ on:
       - reopened
 
 jobs:
+  typecheck:
+    name: "Typecheck (gate)"
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-integration') && !contains(github.event.pull_request.labels.*.name, 'ci/unit-only') }}
+    uses: ./.github/workflows/typecheck.yml
+    with:
+      concurrency_group_prefix: pr-integration
+
   integration_test:
+    needs: typecheck
     name: "Integration Tests - PR"
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-integration') && !contains(github.event.pull_request.labels.*.name, 'ci/unit-only') }}
     uses: ./.github/workflows/integration.yml
@@ -22,7 +30,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: "Integration Tests - PR - Result"
-    needs: [integration_test]
+    needs: [typecheck, integration_test]
     steps:
       - run: exit 1
         if: >-

--- a/.github/workflows/pr-unit.yml
+++ b/.github/workflows/pr-unit.yml
@@ -11,7 +11,15 @@ on:
       - reopened
 
 jobs:
+  typecheck:
+    name: "Typecheck (gate)"
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-unit') }}
+    uses: ./.github/workflows/typecheck.yml
+    with:
+      concurrency_group_prefix: pr-unit
+
   all_unit_tests:
+    needs: typecheck
     name: "All Unit Tests"
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-unit') }}
     uses: ./.github/workflows/unit.yml
@@ -37,6 +45,7 @@ jobs:
     secrets: inherit
 
   cdktn_cli_core:
+    needs: typecheck
     name: "@cdktn/cli Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/@cdktn/cli-core') }}
     uses: ./.github/workflows/unit.yml
@@ -51,6 +60,7 @@ jobs:
     secrets: inherit
 
   cdktn_commons:
+    needs: typecheck
     name: "@cdktn/commons Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/@cdktn/commons') }}
     uses: ./.github/workflows/unit.yml
@@ -65,6 +75,7 @@ jobs:
     secrets: inherit
 
   cdktn_hcl2cdk:
+    needs: typecheck
     name: "@cdktn/hcl2cdk Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/@cdktn/hcl2cdk') }}
     uses: ./.github/workflows/unit.yml
@@ -79,6 +90,7 @@ jobs:
     secrets: inherit
 
   cdktn_hcl2json:
+    needs: typecheck
     name: "@cdktn/hcl2json Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/@cdktn/hcl2json') }}
     uses: ./.github/workflows/unit.yml
@@ -93,6 +105,7 @@ jobs:
     secrets: inherit
 
   cdktn_provider_generator:
+    needs: typecheck
     name: "@cdktn/provider-generator Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/@cdktn/provider-generator') }}
     uses: ./.github/workflows/unit.yml
@@ -107,6 +120,7 @@ jobs:
     secrets: inherit
 
   cdktn_cli:
+    needs: typecheck
     name: "cdktn-cli Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/cdktn-cli') }}
     uses: ./.github/workflows/unit.yml
@@ -121,6 +135,7 @@ jobs:
     secrets: inherit
 
   cdktn:
+    needs: typecheck
     name: "cdktn Unit Tests"
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ci/run-unit/cdktn') }}
     uses: ./.github/workflows/unit.yml
@@ -140,6 +155,7 @@ jobs:
     name: Unit Tests - PR - Result
     needs:
       [
+        typecheck,
         all_unit_tests,
         cdktn,
         cdktn_cli,

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,51 @@
+name: Typecheck
+on:
+  workflow_call:
+    inputs:
+      concurrency_group_prefix:
+        default: pr
+        required: false
+        type: string
+
+concurrency:
+  group: ${{ inputs.concurrency_group_prefix }}-typecheck-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    container:
+      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "Add Git safe.directory" # Go 1.18+ embeds repo info in builds; @cdktn/hcl2json fails without this
+        run: git config --global --add safe.directory /__w/cdk-terrain/cdk-terrain
+      - name: ensure correct user
+        run: chown -R root /__w/cdk-terrain
+      - name: Get cache directory paths
+        id: global-cache-dir-path
+        run: |
+          echo "yarn=$(yarn cache dir)" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/go
+          echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.yarn }}
+          key: yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-typecheck
+          restore-keys: |
+            yarn-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}-
+            yarn-${{ runner.os }}-
+      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.go }}
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-typecheck
+          restore-keys: |
+            go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
+            go-${{ runner.os }}-
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+      - name: type check (yarn build)
+        run: yarn build
+        env:
+          GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}


### PR DESCRIPTION
### Description

- Adds a reusable `typecheck` workflow that runs `yarn build` (the existing tsc-based pipeline) with cached yarn + go directories.
- `pr-unit.yml` and `pr-integration.yml` now gate their test jobs on the typecheck job — if types are broken, the slow test matrices don't run at all.
- `linting.yml` also calls the typecheck workflow, so type errors surface as part of the linting CI alongside prettier and eslint.

## Motivation

Type errors were previously only caught at the end of the unit-test matrix (via each package's `pretest: yarn build` hook). On a broken-types PR you'd wait 10+ minutes for a matrix of jobs to all fail individually. With this change:

- A single `typecheck` job (~30s warm cache) gates the rest.
- Downstream jobs are skipped if typecheck fails, cutting CI time on broken PRs.
- Type-checking now runs on every PR regardless of path filter — previously `build.yml` was gated on `packages/**`, so PRs touching only `examples/`, `tools/`, or `test/` could slip through.

## What's changed

- New file `.github/workflows/typecheck.yml` — reusable workflow (`workflow_call`) running `yarn build` with the same yarn + go caches as `build.yml` (keys suffixed `-typecheck` to keep them isolated; same `hashFiles('**/yarn.lock')` / `hashFiles('**/go.sum')` so warmth is shared with adjacent jobs).
- `.github/workflows/linting.yml` — adds a `typecheck` job that calls `typecheck.yml`. Sits alongside `prettier` and `lint`.
- `.github/workflows/pr-unit.yml` — adds a `typecheck` gate; the existing 8 test jobs (`all_unit_tests` + 7 label-triggered per-package jobs) now `needs: typecheck`. Final `results` job updated to also depend on `typecheck`.
- `.github/workflows/pr-integration.yml` — adds a `typecheck` gate; `integration_test` now `needs: typecheck`. `results` updated.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
