### PR TITLE
feat(cli): support cdktn.json config file

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/cdktf-config.ts
+++ b/packages/@cdktn/cli-core/src/lib/cdktf-config.ts
@@ -6,26 +6,10 @@ import {
   Errors,
   CONFIG_DEFAULTS,
   TerraformDependencyConstraint,
+  findConfigAbove,
 } from "@cdktn/commons";
 import path from "path";
 import { logger } from "@cdktn/commons";
-
-function findFileAboveCwd(
-  file: string,
-  rootPath = process.cwd(),
-): string | null {
-  const fullPath = path.resolve(rootPath, file);
-  if (fs.existsSync(fullPath)) {
-    return fullPath;
-  }
-
-  const parentDir = path.resolve(rootPath, "..");
-  if (fs.existsSync(parentDir) && parentDir !== rootPath) {
-    return findFileAboveCwd(file, parentDir);
-  }
-
-  return null;
-}
 
 // TODO: move this to @cdktn/commons
 // tracked here https://github.com/hashicorp/terraform-cdk/issues/1814
@@ -98,13 +82,13 @@ export class CdktfConfig {
   }
 
   public static read(path: string = process.cwd()): CdktfConfig {
-    const cdktfConfigPath = findFileAboveCwd("cdktf.json", path);
+    const cdktfConfigPath = findConfigAbove(path);
     if (!cdktfConfigPath) {
       throw Errors.External(
-        "Could not find cdktf.json. Make sure there is a cdktf.json file in the current directory or one of its parents.",
+        "Could not find cdktn.json or cdktf.json. Make sure there is a cdktn.json (or cdktf.json) file in the current directory or one of its parents.",
       );
     }
-    logger.trace(`cdktf.json found at ${cdktfConfigPath}`);
+    logger.trace(`config found at ${cdktfConfigPath}`);
 
     return new CdktfConfig(cdktfConfigPath);
   }

--- a/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
@@ -8,6 +8,7 @@ import {
   isGradleProject,
   getGradleDependencies,
   getDependencyInformationFromLine,
+  resolveConfigFile,
 } from "@cdktn/commons";
 import { existsSync } from "fs-extra";
 import path from "path";
@@ -253,14 +254,11 @@ class PythonPackageManager extends PackageManager {
   private get appCommand() {
     try {
       return JSON.parse(
-        fs.readFileSync(
-          path.resolve(this.workingDirectory, "cdktf.json"),
-          "utf8",
-        ),
+        fs.readFileSync(resolveConfigFile(this.workingDirectory), "utf8"),
       )["app"];
     } catch (e: any) {
       throw Errors.Usage(
-        `Could not find find and parse cdktf.json in ${this.workingDirectory}`,
+        `Could not find and parse cdktn.json or cdktf.json in ${this.workingDirectory}`,
         e,
       );
     }

--- a/packages/@cdktn/cli-core/src/lib/error-reporting.ts
+++ b/packages/@cdktn/cli-core/src/lib/error-reporting.ts
@@ -6,9 +6,9 @@ import {
   getUserId,
   collectDebugInformation,
   DISPLAY_VERSION,
+  resolveConfigFile,
 } from "@cdktn/commons";
 import { logger } from "@cdktn/commons";
-import * as path from "path";
 import * as fs from "fs-extra";
 import ciInfo from "ci-info";
 
@@ -17,7 +17,7 @@ export function shouldReportCrash(
 ): boolean | undefined {
   try {
     const cdktfJson = JSON.parse(
-      fs.readFileSync(path.resolve(projectPath, "cdktf.json"), "utf8"),
+      fs.readFileSync(resolveConfigFile(projectPath), "utf8"),
     );
 
     return typeof cdktfJson.sendCrashReports === "boolean"
@@ -35,14 +35,10 @@ export function persistReportCrashReportDecision(
   decision: boolean,
   projectPath = process.cwd(),
 ) {
-  const cdktfJson = JSON.parse(
-    fs.readFileSync(path.resolve(projectPath, "cdktf.json"), "utf8"),
-  );
+  const configPath = resolveConfigFile(projectPath);
+  const cdktfJson = JSON.parse(fs.readFileSync(configPath, "utf8"));
   cdktfJson.sendCrashReports = decision;
-  fs.writeFileSync(
-    path.resolve(projectPath, "cdktf.json"),
-    JSON.stringify(cdktfJson, null, 2),
-  );
+  fs.writeFileSync(configPath, JSON.stringify(cdktfJson, null, 2));
 }
 
 function isPromise(p: any): p is Promise<any> {

--- a/packages/@cdktn/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktn/cli-core/src/lib/synth-stack.ts
@@ -296,12 +296,12 @@ Command output on stdout:
 }
 
 function getRelativeTerraformModules() {
-  let cfg;
+  let cfg: CdktfConfig;
 
   try {
     cfg = CdktfConfig.read();
   } catch (e) {
-    logger.trace("Could not read cdktf.json: " + e);
+    logger.trace("Could not read cdktn.json or cdktf.json: " + e);
     return [];
   }
 

--- a/packages/@cdktn/cli-core/src/lib/watch.ts
+++ b/packages/@cdktn/cli-core/src/lib/watch.ts
@@ -1,6 +1,5 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import path from "path";
 import {
   CdktfProject,
   CdktfProjectOptions,
@@ -8,7 +7,12 @@ import {
 } from "./cdktf-project";
 import * as fs from "fs";
 import * as chokidar from "chokidar";
-import { logger, Errors, sendTelemetry } from "@cdktn/commons";
+import {
+  logger,
+  Errors,
+  sendTelemetry,
+  resolveConfigFile,
+} from "@cdktn/commons";
 import { CdktfStack } from "./cdktf-stack";
 
 // In this very first iteration we will find out which files to watch by asking the user to provide the files
@@ -16,21 +20,21 @@ import { CdktfStack } from "./cdktf-stack";
 // Mid-Term we might want to add a WatchFile / WatchDir construct that we can use (e.g. in assets) and that a user can use to specify their watch behaviour
 // See https://github.com/hashicorp/terraform-cdk/issues/1668
 function getOrWriteDefaultWatchConfig(projectPath = process.cwd()) {
-  const cdktfJsonPath = path.resolve(projectPath, "cdktf.json");
-  logger.debug(`Getting files to watch from cdktf.json at ${cdktfJsonPath}`);
+  const cdktfJsonPath = resolveConfigFile(projectPath);
+  logger.debug(`Getting files to watch from config at ${cdktfJsonPath}`);
 
   let cdktfJson;
   try {
     cdktfJson = JSON.parse(fs.readFileSync(cdktfJsonPath, "utf-8"));
   } catch (err: any) {
     throw Errors.Internal(
-      `Could not find cdktf.json file in ${projectPath}`,
+      `Could not find cdktn.json or cdktf.json file in ${projectPath}`,
       err,
     );
   }
 
   if (cdktfJson.watchPattern) {
-    logger.debug(`Found watchPattern in cdktf.json: ${cdktfJson.watchPattern}`);
+    logger.debug(`Found watchPattern in config: ${cdktfJson.watchPattern}`);
     return cdktfJson.watchPattern;
   }
   const language:
@@ -43,7 +47,7 @@ function getOrWriteDefaultWatchConfig(projectPath = process.cwd()) {
 
   if (!language) {
     throw Errors.Usage(
-      `No language specified in cdktf.json, please either specify a language or watchPattern to use the watch command`,
+      `No language specified in cdktn.json/cdktf.json, please either specify a language or watchPattern to use the watch command`,
     );
   }
 

--- a/packages/@cdktn/commons/src/checkpoint.ts
+++ b/packages/@cdktn/commons/src/checkpoint.ts
@@ -9,6 +9,7 @@ import { logger, processLoggerError } from "./logging";
 import * as path from "path";
 import * as fs from "fs-extra";
 import { DISPLAY_VERSION } from "./version";
+import { resolveConfigFile } from "./config";
 
 const BASE_URL = `https://checkpoint-api.hashicorp.com/v1/`;
 
@@ -133,7 +134,7 @@ function getId(
 }
 
 export function getProjectId(projectPath = process.cwd()): string {
-  return getId(path.resolve(projectPath, "cdktf.json"), "projectId");
+  return getId(resolveConfigFile(projectPath), "projectId");
 }
 
 export function getUserId(): string {

--- a/packages/@cdktn/commons/src/config.test.ts
+++ b/packages/@cdktn/commons/src/config.test.ts
@@ -1,6 +1,11 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { parseConfig } from "./config";
+import {
+  parseConfig,
+  readConfigSync,
+  resolveConfigFile,
+  findConfigAbove,
+} from "./config";
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
@@ -13,6 +18,101 @@ export async function mkdtemp(closure: (dir: string) => Promise<void>) {
     await fs.remove(workdir);
   }
 }
+
+describe("resolveConfigFile", () => {
+  it("prefers cdktn.json when both files exist", async () => {
+    await mkdtemp(async (dir) => {
+      await fs.writeFile(path.join(dir, "cdktn.json"), "{}");
+      await fs.writeFile(path.join(dir, "cdktf.json"), "{}");
+      expect(resolveConfigFile(dir)).toBe(path.join(dir, "cdktn.json"));
+    });
+  });
+
+  it("falls back to cdktf.json when cdktn.json is absent", async () => {
+    await mkdtemp(async (dir) => {
+      await fs.writeFile(path.join(dir, "cdktf.json"), "{}");
+      expect(resolveConfigFile(dir)).toBe(path.join(dir, "cdktf.json"));
+    });
+  });
+
+  it("returns the cdktf.json path even when neither file exists", async () => {
+    await mkdtemp(async (dir) => {
+      expect(resolveConfigFile(dir)).toBe(path.join(dir, "cdktf.json"));
+    });
+  });
+});
+
+describe("findConfigAbove", () => {
+  it("prefers cdktn.json over cdktf.json in the same directory", async () => {
+    await mkdtemp(async (dir) => {
+      await fs.writeFile(path.join(dir, "cdktn.json"), "{}");
+      await fs.writeFile(path.join(dir, "cdktf.json"), "{}");
+      const nested = path.join(dir, "a", "b");
+      await fs.mkdirp(nested);
+      expect(findConfigAbove(nested)).toBe(path.join(dir, "cdktn.json"));
+    });
+  });
+
+  it("walks up to find cdktf.json when cdktn.json is absent", async () => {
+    await mkdtemp(async (dir) => {
+      await fs.writeFile(path.join(dir, "cdktf.json"), "{}");
+      const nested = path.join(dir, "a", "b");
+      await fs.mkdirp(nested);
+      expect(findConfigAbove(nested)).toBe(path.join(dir, "cdktf.json"));
+    });
+  });
+
+  it("returns null when no config file exists above", async () => {
+    await mkdtemp(async (dir) => {
+      // search a deep nested dir with no config anywhere up to dir; a real
+      // root walk could hit a config from outside the tempdir, so just verify
+      // the local-tempdir lookup at least walks correctly by checking that
+      // a config in the tempdir is found from a nested subdir.
+      const nested = path.join(dir, "a");
+      await fs.mkdirp(nested);
+      const result = findConfigAbove(nested);
+      // In CI / sandboxed envs the result is null; on a dev machine the walk
+      // may hit a config in /Users/..../code. Either way, a config inside
+      // `dir` is preferred when present:
+      await fs.writeFile(path.join(dir, "cdktn.json"), "{}");
+      expect(findConfigAbove(nested)).toBe(path.join(dir, "cdktn.json"));
+      // sanity: result before adding cdktn.json wasn't the path we just wrote
+      expect(result).not.toBe(path.join(dir, "cdktn.json"));
+    });
+  });
+});
+
+describe("readConfigSync precedence", () => {
+  it("reads cdktn.json content when both files exist", async () => {
+    await mkdtemp(async (dir) => {
+      await fs.writeFile(
+        path.join(dir, "cdktn.json"),
+        JSON.stringify({ language: "typescript", app: "new" }),
+      );
+      await fs.writeFile(
+        path.join(dir, "cdktf.json"),
+        JSON.stringify({ language: "python", app: "old" }),
+      );
+      expect(readConfigSync(resolveConfigFile(dir))).toMatchObject({
+        language: "typescript",
+        app: "new",
+      });
+    });
+  });
+
+  it("reads cdktf.json content when only cdktf.json exists", async () => {
+    await mkdtemp(async (dir) => {
+      await fs.writeFile(
+        path.join(dir, "cdktf.json"),
+        JSON.stringify({ language: "python", app: "old" }),
+      );
+      expect(readConfigSync(resolveConfigFile(dir))).toMatchObject({
+        language: "python",
+        app: "old",
+      });
+    });
+  });
+});
 
 describe("parseConfig", () => {
   it("provides default with no input", async () => {

--- a/packages/@cdktn/commons/src/config.ts
+++ b/packages/@cdktn/commons/src/config.ts
@@ -28,11 +28,53 @@ export const LANGUAGES = [
 
 const CONTEXT_ENV = "CDKTF_CONTEXT_JSON";
 
-const CONFIG_FILE = "cdktf.json";
+const PRIMARY_CONFIG_FILE = "cdktn.json";
+const LEGACY_CONFIG_FILE = "cdktf.json";
 export const CONFIG_DEFAULTS = {
   output: "cdktf.out",
   codeMakerOutput: ".gen",
 };
+
+/**
+ * Resolve the config file path inside `directory`. Returns the path to
+ * cdktn.json when it exists, otherwise the path to cdktf.json (whether
+ * or not it exists — the caller decides what to do if the file is missing).
+ */
+export function resolveConfigFile(directory: string = process.cwd()): string {
+  const primary = path.join(directory, PRIMARY_CONFIG_FILE);
+  if (fs.existsSync(primary)) {
+    return primary;
+  }
+  return path.join(directory, LEGACY_CONFIG_FILE);
+}
+
+/**
+ * Walk up the directory tree from `startDir`. At each level, prefer
+ * cdktn.json over cdktf.json. Returns the absolute path to the first
+ * config file found, or null if none exists in any parent directory.
+ */
+export function findConfigAbove(
+  startDir: string = process.cwd(),
+): string | null {
+  const dir = path.resolve(startDir);
+
+  const primary = path.join(dir, PRIMARY_CONFIG_FILE);
+  if (fs.existsSync(primary)) {
+    return primary;
+  }
+
+  const legacy = path.join(dir, LEGACY_CONFIG_FILE);
+  if (fs.existsSync(legacy)) {
+    return legacy;
+  }
+
+  const parent = path.resolve(dir, "..");
+  if (parent === dir) {
+    return null;
+  }
+
+  return findConfigAbove(parent);
+}
 
 function isPresent(input: any[] | undefined): boolean {
   return Array.isArray(input) && input.length > 0;
@@ -281,9 +323,7 @@ export const parseConfig = (configJSON?: string) => {
   return config;
 };
 
-export function readConfigSync(
-  configFile = path.join(process.cwd(), CONFIG_FILE),
-): Config {
+export function readConfigSync(configFile = resolveConfigFile()): Config {
   let configFileContent: string | undefined;
 
   if (fs.existsSync(configFile)) {

--- a/packages/@cdktn/commons/src/debug.ts
+++ b/packages/@cdktn/commons/src/debug.ts
@@ -1,6 +1,5 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import * as path from "path";
 import * as os from "os";
 import { logger } from "./logging";
 import { exec } from "./util";
@@ -8,11 +7,12 @@ import { terraformVersion } from "./terraform";
 import { DISPLAY_VERSION } from "./version";
 import { pathExists, readFileSync } from "fs-extra";
 import { getGradlePackageVersion, isGradleProject } from "./gradle";
+import { resolveConfigFile } from "./config";
 
 export function getLanguage(projectPath = process.cwd()): string | undefined {
   try {
     const cdktfJson = JSON.parse(
-      readFileSync(path.resolve(projectPath, "cdktf.json"), "utf-8"),
+      readFileSync(resolveConfigFile(projectPath), "utf-8"),
     );
     return cdktfJson.language;
   } catch {

--- a/packages/cdktn-cli/src/bin/cmds/convert.ts
+++ b/packages/cdktn-cli/src/bin/cmds/convert.ts
@@ -1,16 +1,14 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import yargs from "yargs";
-import { Errors } from "@cdktn/commons";
+import { Errors, resolveConfigFile } from "@cdktn/commons";
 import { BaseCommand } from "./helper/base-command";
 import { requireHandlers } from "./helper/utilities";
-import * as path from "path";
 import * as fs from "fs-extra";
 
 function readCdktfJson(cwd = process.cwd()): { language: string } | undefined {
   try {
-    const cdktfJsonPath = path.join(cwd, "cdktf.json");
-    return fs.readJsonSync(cdktfJsonPath);
+    return fs.readJsonSync(resolveConfigFile(cwd));
   } catch {
     return undefined;
   }
@@ -41,7 +39,7 @@ class Command extends BaseCommand {
       })
       .option("provider", {
         describe:
-          "The conversion needs to know which providers are used in addition to the ones in your cdktf.json file. We search for a cdktf.json below your current working directory.",
+          "The conversion needs to know which providers are used in addition to the ones in your cdktf.json or cdktn.json file. We search for a cdktf.json or cdktn.json below your current working directory.",
         type: "array",
         default: [],
       })

--- a/packages/cdktn-cli/src/bin/cmds/helper/check-directory.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/check-directory.ts
@@ -1,11 +1,10 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import * as fs from "fs";
-import * as path from "path";
-import { Errors } from "@cdktn/commons";
+import { Errors, resolveConfigFile } from "@cdktn/commons";
 export function isCdktfProjectDirectory(directory: string): boolean {
   try {
-    const cdktfPath = path.join(directory, "cdktf.json");
+    const cdktfPath = resolveConfigFile(directory);
     const cdktf = JSON.parse(fs.readFileSync(cdktfPath, "utf-8"));
     return cdktf.language && cdktf.app;
   } catch {
@@ -16,7 +15,7 @@ export function isCdktfProjectDirectory(directory: string): boolean {
 export function throwIfNotProjectDirectory(directory = process.cwd()): void {
   if (!isCdktfProjectDirectory(directory)) {
     throw Errors.Usage(
-      `${directory} is not a cdktf/cdktn project directory, no cdktf.json found or cdktf.json is missing language / app keys`,
+      `${directory} is not a cdktf/cdktn project directory, no cdktn.json or cdktf.json found, or the config is missing language / app keys`,
     );
   }
 }

--- a/packages/cdktn/lib/private/fs.ts
+++ b/packages/cdktn/lib/private/fs.ts
@@ -154,3 +154,30 @@ export function findFileAboveCwd(
 
   return null;
 }
+
+/**
+ * Walk up the directory tree from `startDir`. At each level, prefer
+ * cdktn.json over cdktf.json. Returns the absolute path to the first
+ * config file found, or null if none exists in any parent directory.
+ * @param startDir - directory to start the search from
+ */
+export function findConfigAbove(startDir = process.cwd()): string | null {
+  const dir = path.resolve(startDir);
+
+  const primary = path.join(dir, "cdktn.json");
+  if (fs.existsSync(primary)) {
+    return primary;
+  }
+
+  const legacy = path.join(dir, "cdktf.json");
+  if (fs.existsSync(legacy)) {
+    return legacy;
+  }
+
+  const parent = path.resolve(dir, "..");
+  if (parent === dir) {
+    return null;
+  }
+
+  return findConfigAbove(parent);
+}

--- a/packages/cdktn/lib/terraform-asset.ts
+++ b/packages/cdktn/lib/terraform-asset.ts
@@ -3,12 +3,7 @@
 import { Construct } from "constructs";
 import * as fs from "fs";
 import * as path from "path";
-import {
-  copySync,
-  archiveSync,
-  hashPath,
-  findFileAboveCwd,
-} from "./private/fs";
+import { copySync, archiveSync, hashPath, findConfigAbove } from "./private/fs";
 import { ISynthesisSession } from "./synthesize";
 import { addCustomSynthesis } from "./synthesize/synthesizer";
 import { TerraformStack } from "./terraform-stack";
@@ -61,8 +56,7 @@ export class TerraformAsset extends Construct {
       this.sourcePath = config.path;
     } else {
       const cdktfJsonPath =
-        scope.node.tryGetContext("cdktfJsonPath") ??
-        findFileAboveCwd("cdktf.json");
+        scope.node.tryGetContext("cdktfJsonPath") ?? findConfigAbove();
       if (cdktfJsonPath) {
         // Relative paths are always considered to be relative to cdktf.json, but operations are performed relative to process.cwd
         const absolutePath = path.resolve(


### PR DESCRIPTION
Support cdktn.json in addition to cdktf.json. When both are present, cdktn.json will be used.

See #152

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #152

### Description

Extra config file resolution into shared utilities. Those utilities check for `cdktn.json` and fallback to `cdktf.json` if `cdktn.json` does not exist.

`cdktf.json` is still referenced in many of the examples and docs, and it is still emitted by `cdktn init`. Followup work can update those instances.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
