### PR TITLE
chore: Add eslint max-warnings=0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "test:ci": "lerna run --scope 'cdktn*' --scope @cdktn/* test:ci",
         "test:update": "lerna run --concurrency 2 --no-bail --scope 'cdktn*' --scope '@cdktn/*' test:update",
         "watch": "lerna run --parallel  --stream --scope @cdktn/* --scope 'cdktn*' watch-preserve-output",
-        "lint:workspace": "eslint --flag v10_config_lookup_from_file .",
+        "lint:workspace": "eslint --flag v10_config_lookup_from_file --max-warnings=0 .",
         "lint:prettier": "prettier --check .",
         "lint:examples": "node tools/lint-examples.js",
         "link-packages": "lerna exec --scope 'cdktn*' --scope @cdktn/* yarn link",


### PR DESCRIPTION
### Description

Now that we have cleaned up all the eslint warnings, we can add `max-warnings=0` to the `lint:workspace` scripts, so that the lint CI check will fail if any future warnings are introduced.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
