### PR TITLE
chore: Refine Nx Cache Configuration

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,25 +1,28 @@
 {
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "cacheableOperations": [
-          "build",
-          "package"
-        ]
-      }
-    }
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*"],
+    "production": [
+      "default",
+      "!{projectRoot}/**/*.test.ts",
+      "!{projectRoot}/**/__tests__/**",
+      "!{projectRoot}/tsconfig.test.json"
+    ]
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"],
+      "inputs": ["production", "^production"],
+      "outputs": [
+        "{projectRoot}/build",
+        "{projectRoot}/.jsii"
+      ],
+      "cache": true
     },
     "package": {
-      "dependsOn": [
-        "build"
-      ]
+      "dependsOn": ["build"],
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/dist"],
+      "cache": true
     }
   }
 }


### PR DESCRIPTION
### Related issue

Tightens the Nx cache configuration so that a downstream package's cache invalidates when an upstream package's outputs change, and so cached output files are restored on cache hits rather than only replaying terminal output.

- Adds a `production` namedInput that excludes test files from the cache key.
- Sets `inputs: ["production", "^production"]` on `build` and `package`. The `^production` part is the load-bearing change — Nx hashes dependencies' production files, so changing one package's output now invalidates downstream caches.
- Declares `outputs` per target so cache hits restore the actual produced files.
- Replaces the pre Nx v20 legacy `tasksRunnerOptions.cacheableOperations` block with `cache: true` on each `targetDefaults` entry.

Note: The Nx cache is not used in the CI jobs, so this only currently affects local development.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
