### PR TITLE
fix(tests): pin Verdaccio registry on publish/install in run-against-dist

### DIFF
--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -45,7 +45,7 @@ echo "Publishing CLI from 'dist'..."
 for pkg in ${CDKTF_DIST}/js/*.tgz
 do
   echo $pkg
-  npm publish --force "$pkg"
+  npm publish --registry=http://localhost:4873/ --force "$pkg"
 done
 
 # install the CLI from dist/js in a temporary area and add to path
@@ -56,7 +56,7 @@ npm init -y > /dev/null
 # There's only one version in our local registry, so we don't need to specify a version here
 # Retry to ride out transient ECONNRESETs from Verdaccio's upstream fetch
 for attempt in 1 2 3; do
-  if npm install --install-strategy=shallow --fetch-retries=5 cdktn-cli; then
+  if npm install --registry=http://localhost:4873/ --install-strategy=shallow --fetch-retries=5 cdktn-cli; then
     break
   fi
   if [ "$attempt" = "3" ]; then


### PR DESCRIPTION
### Description

`run-against-dist` calls `npm set registry "http://localhost:4873"` to point npm at the local Verdaccio registry, then runs `npm publish` and `npm install cdktn-cli`. This works for most contributors, but a `registry=...` line in a user-level `~/.npmrc` overrides what `npm set registry` writes — so on those machines `npm publish` targets the user's configured registry instead of Verdaccio (failing with `ENEEDAUTH` against a public mirror), and `npm install cdktn-cli` resolves the package from the public registry rather than the locally-published `0.0.0` tarball, leading to confusing version mismatches.

### Fix

Pass `--registry=http://localhost:4873/` explicitly on both commands so the script's intent doesn't rely on global npm config state.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
