### PR TITLE
chore: cdktn tests: isolate test outdirs to fix mkdirSync race

### DIFF
--- a/packages/cdktn/test/app.test.ts
+++ b/packages/cdktn/test/app.test.ts
@@ -31,7 +31,7 @@ test("context can be passed through CDKTF_CONTEXT", () => {
     key1: "val1",
     key2: "val2",
   });
-  const prog = new App();
+  const prog = Testing.app({ stubVersion: false, enableFutureFlags: false });
   const node = prog.node;
   expect(node.tryGetContext("key1")).toEqual("val1");
   expect(node.tryGetContext("key2")).toEqual("val2");
@@ -42,7 +42,9 @@ test("context can be passed through CDKTF_CONTEXT", () => {
     key1: "val1",
     key2: "val2",
   });
-  const prog = new App({
+  const prog = Testing.app({
+    stubVersion: false,
+    enableFutureFlags: false,
     context: {
       key1: "val3",
       key2: "val4",
@@ -54,7 +56,7 @@ test("context can be passed through CDKTF_CONTEXT", () => {
 });
 
 test("cdktfVersion is accessible in context", () => {
-  const prog = new App();
+  const prog = Testing.app({ stubVersion: false, enableFutureFlags: false });
   const node = prog.node;
   expect(node.tryGetContext("cdktfVersion")).toEqual(version);
 });

--- a/packages/cdktn/test/assets.test.ts
+++ b/packages/cdktn/test/assets.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { App, TerraformHclModule, TerraformStack, Testing } from "../lib";
+import { TerraformHclModule, TerraformStack, Testing } from "../lib";
 import * as path from "path";
 import { TerraformModuleAsset } from "../lib/terraform-module-asset";
 
@@ -8,12 +8,10 @@ describe("createAssetsFromLocalModules", () => {
   test("remote source without skipAssetCreationFromLocalModules", () => {
     const remoteSource = "terraform-aws-modules/eks/aws";
 
-    const app = Testing.stubVersion(
-      new App({
-        stackTraces: false,
-        context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
-      }),
-    );
+    const app = Testing.app({
+      enableFutureFlags: false,
+      context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
+    });
     const stack = new TerraformStack(app, "MyStack");
 
     const moduleOptionsNotExists = new TerraformHclModule(
@@ -30,12 +28,10 @@ describe("createAssetsFromLocalModules", () => {
   test("remote source with skipAssetCreationFromLocalModules set to true", () => {
     const remoteSource = "terraform-aws-modules/eks/aws";
 
-    const app = Testing.stubVersion(
-      new App({
-        stackTraces: false,
-        context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
-      }),
-    );
+    const app = Testing.app({
+      enableFutureFlags: false,
+      context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
+    });
     const stack = new TerraformStack(app, "MyStack");
 
     const moduleOptionsTrue = new TerraformHclModule(
@@ -53,12 +49,10 @@ describe("createAssetsFromLocalModules", () => {
   test("remote source with skipAssetCreationFromLocalModules set to false", () => {
     const remoteSource = "terraform-aws-modules/eks/aws";
 
-    const app = Testing.stubVersion(
-      new App({
-        stackTraces: false,
-        context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
-      }),
-    );
+    const app = Testing.app({
+      enableFutureFlags: false,
+      context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
+    });
     const stack = new TerraformStack(app, "MyStack");
 
     const moduleOptionsFalse = new TerraformHclModule(
@@ -76,15 +70,13 @@ describe("createAssetsFromLocalModules", () => {
   test("local source without skipAssetCreationFromLocalModules", () => {
     const localSource = "../";
 
-    const app = Testing.stubVersion(
-      new App({
-        stackTraces: false,
-        context: {
-          cdktfJsonPath: path.resolve(__dirname, "fixtures/app"),
-          cdktfRelativeModules: [localSource],
-        },
-      }),
-    );
+    const app = Testing.app({
+      enableFutureFlags: false,
+      context: {
+        cdktfJsonPath: path.resolve(__dirname, "fixtures/app"),
+        cdktfRelativeModules: [localSource],
+      },
+    });
     const stack = new TerraformStack(app, "MyStack");
 
     const moduleOptionsNotExists = new TerraformHclModule(
@@ -105,15 +97,13 @@ describe("createAssetsFromLocalModules", () => {
     const localSource = "../";
     const cdktfJsonPath = path.resolve(__dirname, "fixtures/app");
 
-    const app = Testing.stubVersion(
-      new App({
-        stackTraces: false,
-        context: {
-          cdktfJsonPath,
-          cdktfRelativeModules: [localSource],
-        },
-      }),
-    );
+    const app = Testing.app({
+      enableFutureFlags: false,
+      context: {
+        cdktfJsonPath,
+        cdktfRelativeModules: [localSource],
+      },
+    });
     const stack = new TerraformStack(app, "MyStack");
 
     const moduleOptionsTrue = new TerraformHclModule(
@@ -134,12 +124,10 @@ describe("createAssetsFromLocalModules", () => {
   test("local source with skipAssetCreationFromLocalModules set to true", () => {
     const localSource = "../";
 
-    const app = Testing.stubVersion(
-      new App({
-        stackTraces: false,
-        context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
-      }),
-    );
+    const app = Testing.app({
+      enableFutureFlags: false,
+      context: { cdktfJsonPath: path.resolve(__dirname, "fixtures/app") },
+    });
     const stack = new TerraformStack(app, "MyStack");
 
     const moduleOptionsFalse = new TerraformHclModule(

--- a/packages/cdktn/test/manifest.test.ts
+++ b/packages/cdktn/test/manifest.test.ts
@@ -23,7 +23,7 @@ test("get stack manifest", () => {
   const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
   const manifest = new Manifest("0.0.0", outdir, false);
 
-  const app = new App();
+  const app = Testing.app({ stubVersion: false, enableFutureFlags: false });
   const stackManifest = manifest.forStack(
     new TerraformStack(app, "this-is-a-stack"),
   );
@@ -45,7 +45,7 @@ test("write manifest", () => {
   const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktf.outdir."));
   const manifest = new Manifest("0.0.0", outdir, false);
 
-  const app = new App();
+  const app = Testing.app({ stubVersion: false, enableFutureFlags: false });
   manifest.forStack(new TerraformStack(app, "this-is-a-stack"));
 
   manifest.writeToFile();

--- a/packages/cdktn/test/stack.test.ts
+++ b/packages/cdktn/test/stack.test.ts
@@ -3,7 +3,6 @@
 import {
   TerraformResource,
   TerraformStack,
-  App,
   Testing,
   TerraformOutput,
   LocalBackend,
@@ -13,9 +12,7 @@ import { TestProvider } from "./helper";
 import { Construct } from "constructs";
 
 test("stack synthesis merges all elements into a single output", () => {
-  const app = Testing.stubVersion(
-    Testing.enableFutureFlags(new App({ stackTraces: false })),
-  );
+  const app = Testing.app();
   const stack = new TerraformStack(app, "MyStack");
 
   new TestProvider(stack, "test-provider", {
@@ -63,7 +60,7 @@ test("stack synthesis merges all elements into a single output", () => {
 });
 
 test("stack synthesis no flags", () => {
-  const app = Testing.stubVersion(new App({ stackTraces: false }));
+  const app = Testing.app({ enableFutureFlags: false });
   const stack = new TerraformStack(app, "MyStack");
 
   new TestProvider(stack, "test-provider", {
@@ -88,7 +85,7 @@ test("stack synthesis no flags", () => {
 });
 
 test("stack validation returns error when provider is missing", () => {
-  const app = Testing.stubVersion(new App({ stackTraces: false }));
+  const app = Testing.app({ enableFutureFlags: false });
   const stack = new TerraformStack(app, "MyStack");
 
   new MyResource(stack, "Resource1", {
@@ -106,7 +103,7 @@ test("stack validation returns error when provider is missing", () => {
 });
 
 test("stack validation returns no error when provider is not set", () => {
-  const app = Testing.stubVersion(new App({ stackTraces: false }));
+  const app = Testing.app({ enableFutureFlags: false });
   const stack = new TerraformStack(app, "MyStack");
 
   new MyResource(stack, "Resource1", {
@@ -118,7 +115,7 @@ test("stack validation returns no error when provider is not set", () => {
 });
 
 test("getting Stack for construct which was added to root app returns friendly error", () => {
-  const app = Testing.stubVersion(new App({ stackTraces: false }));
+  const app = Testing.app({ enableFutureFlags: false });
   new TerraformStack(app, "MyStack");
 
   expect(() => new LocalBackend(app, {})).toThrowErrorMatchingInlineSnapshot(`
@@ -133,14 +130,14 @@ test("getting Stack for construct which was added to root app returns friendly e
 
 describe("output id map", () => {
   test("output id map is empty when no outputs are added", () => {
-    const app = Testing.stubVersion(new App({ stackTraces: false }));
+    const app = Testing.app({ enableFutureFlags: false });
     const stack = new TerraformStack(app, "MyStack");
 
     expect(stack.toTerraform()["//"].outputs).toEqual({});
   });
 
   test("output id map is populated when outputs are added", () => {
-    const app = Testing.stubVersion(new App({ stackTraces: false }));
+    const app = Testing.app({ enableFutureFlags: false });
     const stack = new TerraformStack(app, "MyStack");
 
     new TerraformOutput(stack, "output1", {
@@ -165,7 +162,7 @@ describe("output id map", () => {
   });
 
   test("output id map is populated with nested custom constructs", () => {
-    const app = Testing.stubVersion(new App({ stackTraces: false }));
+    const app = Testing.app({ enableFutureFlags: false });
     const stack = new TerraformStack(app, "MyStack");
 
     class MyCustomConstruct extends Construct {

--- a/packages/cdktn/test/upgrade-id-aspect.test.ts
+++ b/packages/cdktn/test/upgrade-id-aspect.test.ts
@@ -21,7 +21,7 @@ describe("MigrateIds", () => {
         constructPath: "staging/vpc",
         level: "@cdktf/warn",
         message: `Found module with new id vpc. Moving this module requires a manual state migration.
-If this module has not been moved yet, run "terraform state mv module.staging_vpc_C4EA2553 module.vpc" in the output directory "cdktf.out/stacks/staging" to migrate the existing state to its new id.
+If this module has not been moved yet, run "terraform state mv module.staging_vpc_C4EA2553 module.vpc" in the output directory "${app.outdir}/stacks/staging" to migrate the existing state to its new id.
 Refer to the following page for more information: https://cdktn.io/docs/examples-and-guides/refactoring#moving-or-renaming-modules`,
       },
     ]);

--- a/packages/cdktn/test/upgrade-id-aspect.test.ts
+++ b/packages/cdktn/test/upgrade-id-aspect.test.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { App, Aspects, MigrateIds, TerraformStack, Testing } from "../lib";
+import { Aspects, MigrateIds, TerraformStack, Testing } from "../lib";
 import { TestModule } from "./helper";
 
 describe("MigrateIds", () => {
   it("should add warning annoations for modules", () => {
-    const app = Testing.stubVersion(new App({ stackTraces: false }));
+    const app = Testing.app({ enableFutureFlags: false });
     const stack = new TerraformStack(app, "staging");
     new TestModule(stack, "vpc", {
       moduleParameter: "moduleValue",


### PR DESCRIPTION
### Description

## Why

`packages/cdktn/test/*.test.ts` has multiple test files that construct `new App({ stackTraces: false })` without an explicit `outdir`. `App` defaults `outdir` to `cdktf.out` in the working directory, so every jest worker for the cdktn package targets the same `cdktf.out/` directory. The `App` constructor guards directory creation with:

```ts
if (!fs.existsSync(this.outdir)) {
  fs.mkdirSync(this.outdir);
}
```

There is a narrow TOCTOU window between `existsSync` returning `false` and `mkdirSync` being called: if a sibling jest worker calls `mkdirSync` for the same path during that window, the second worker throws:

```
EEXIST: file already exists, mkdir 'cdktf.out'
  at new mkdirSync (lib/app.ts:123:10)
```

The shared cwd-relative outdir is also a latent correctness issue: tests can interfere with each other's synthesised output without anyone noticing.

Example Job failure: https://github.com/open-constructs/cdk-terrain/actions/runs/25370001238/job/74390757224?pr=159#step:13:25

Testing.app() (in `packages/cdktn/lib/testing/index.ts` already exists and already does the right thing — it allocates a fresh `mkdtempSync(...)` outdir when none is passed. The fix is purely to migrate callers off `new App(...)` and onto `Testing.app(...)`.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
