### PR TITLE
fix(provider-generator): Fix code generation failures caused by case insensitive name collisions

### DIFF
--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -295,6 +295,614 @@ export class BooleanMap extends cdktn.TerraformResource {
 "
 `;
 
+exports[`case-insensitive base name collision: data-oci-devops-repository-mirror-record 1`] = `
+"// https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirror_record
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface DataOciDevopsRepositoryMirrorRecordConfig extends cdktn.TerraformMetaArguments {
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirror_record oci_devops_repository_mirror_record}
+*/
+export class DataOciDevopsRepositoryMirrorRecord extends cdktn.TerraformDataSource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "oci_devops_repository_mirror_record";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a DataOciDevopsRepositoryMirrorRecord resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the DataOciDevopsRepositoryMirrorRecord to import
+  * @param importFromId The id of the existing DataOciDevopsRepositoryMirrorRecord that should be imported. Refer to the {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirror_record#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the DataOciDevopsRepositoryMirrorRecord to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "oci_devops_repository_mirror_record", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirror_record oci_devops_repository_mirror_record} Data Source
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options DataOciDevopsRepositoryMirrorRecordConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: DataOciDevopsRepositoryMirrorRecordConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'oci_devops_repository_mirror_record',
+      terraformGeneratorMetadata: {
+        providerName: 'oci'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // id - computed: true, optional: false, required: false
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+    };
+    return attrs;
+  }
+}
+"
+`;
+
+exports[`case-insensitive base name collision: data-oci-devops-repository-mirrorrecord-history 1`] = `
+"// https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirrorrecord_history
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface DataOciDevopsRepositoryMirrorrecordHistoryConfig extends cdktn.TerraformMetaArguments {
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirrorrecord_history oci_devops_repository_mirrorrecord_history}
+*/
+export class DataOciDevopsRepositoryMirrorrecordHistory extends cdktn.TerraformDataSource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "oci_devops_repository_mirrorrecord_history";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a DataOciDevopsRepositoryMirrorrecordHistory resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the DataOciDevopsRepositoryMirrorrecordHistory to import
+  * @param importFromId The id of the existing DataOciDevopsRepositoryMirrorrecordHistory that should be imported. Refer to the {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirrorrecord_history#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the DataOciDevopsRepositoryMirrorrecordHistory to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "oci_devops_repository_mirrorrecord_history", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/devops_repository_mirrorrecord_history oci_devops_repository_mirrorrecord_history} Data Source
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options DataOciDevopsRepositoryMirrorrecordHistoryConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: DataOciDevopsRepositoryMirrorrecordHistoryConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'oci_devops_repository_mirrorrecord_history',
+      terraformGeneratorMetadata: {
+        providerName: 'oci'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // id - computed: true, optional: false, required: false
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+    };
+    return attrs;
+  }
+}
+"
+`;
+
+exports[`case-insensitive base name collision: data-oci-load-balancer-backend-sets 1`] = `
+"// https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backend_sets
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface DataOciLoadBalancerBackendSetsConfig extends cdktn.TerraformMetaArguments {
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backend_sets oci_load_balancer_backend_sets}
+*/
+export class DataOciLoadBalancerBackendSets extends cdktn.TerraformDataSource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "oci_load_balancer_backend_sets";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a DataOciLoadBalancerBackendSets resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the DataOciLoadBalancerBackendSets to import
+  * @param importFromId The id of the existing DataOciLoadBalancerBackendSets that should be imported. Refer to the {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backend_sets#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the DataOciLoadBalancerBackendSets to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "oci_load_balancer_backend_sets", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backend_sets oci_load_balancer_backend_sets} Data Source
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options DataOciLoadBalancerBackendSetsConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: DataOciLoadBalancerBackendSetsConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'oci_load_balancer_backend_sets',
+      terraformGeneratorMetadata: {
+        providerName: 'oci'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // id - computed: true, optional: false, required: false
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+    };
+    return attrs;
+  }
+}
+"
+`;
+
+exports[`case-insensitive base name collision: data-oci-load-balancer-backendsets-a 1`] = `
+"// https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backendsets
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface DataOciLoadBalancerBackendsetsAConfig extends cdktn.TerraformMetaArguments {
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backendsets oci_load_balancer_backendsets}
+*/
+export class DataOciLoadBalancerBackendsetsA extends cdktn.TerraformDataSource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "oci_load_balancer_backendsets";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a DataOciLoadBalancerBackendsetsA resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the DataOciLoadBalancerBackendsetsA to import
+  * @param importFromId The id of the existing DataOciLoadBalancerBackendsetsA that should be imported. Refer to the {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backendsets#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the DataOciLoadBalancerBackendsetsA to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "oci_load_balancer_backendsets", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/data-sources/load_balancer_backendsets oci_load_balancer_backendsets} Data Source
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options DataOciLoadBalancerBackendsetsAConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: DataOciLoadBalancerBackendsetsAConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'oci_load_balancer_backendsets',
+      terraformGeneratorMetadata: {
+        providerName: 'oci'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // id - computed: true, optional: false, required: false
+  public get id() {
+    return this.getStringAttribute('id');
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+    };
+    return attrs;
+  }
+}
+"
+`;
+
+exports[`case-insensitive base name collision: index.ts 1`] = `
+"// generated by cdktn get
+export * as loadBalancerBackendSet from './load-balancer-backend-set';
+export * as loadBalancerBackendsetA from './load-balancer-backendset-a';
+export * as dataOciDevopsRepositoryMirrorRecord from './data-oci-devops-repository-mirror-record';
+export * as dataOciDevopsRepositoryMirrorrecordHistory from './data-oci-devops-repository-mirrorrecord-history';
+export * as dataOciLoadBalancerBackendSets from './data-oci-load-balancer-backend-sets';
+export * as dataOciLoadBalancerBackendsetsA from './data-oci-load-balancer-backendsets-a';
+
+"
+`;
+
+exports[`case-insensitive base name collision: lazy-index.ts 1`] = `
+"// generated by cdktn get
+Object.defineProperty(exports, 'loadBalancerBackendSet', { get: function () { return require('./load-balancer-backend-set'); } });
+Object.defineProperty(exports, 'loadBalancerBackendsetA', { get: function () { return require('./load-balancer-backendset-a'); } });
+Object.defineProperty(exports, 'dataOciDevopsRepositoryMirrorRecord', { get: function () { return require('./data-oci-devops-repository-mirror-record'); } });
+Object.defineProperty(exports, 'dataOciDevopsRepositoryMirrorrecordHistory', { get: function () { return require('./data-oci-devops-repository-mirrorrecord-history'); } });
+Object.defineProperty(exports, 'dataOciLoadBalancerBackendSets', { get: function () { return require('./data-oci-load-balancer-backend-sets'); } });
+Object.defineProperty(exports, 'dataOciLoadBalancerBackendsetsA', { get: function () { return require('./data-oci-load-balancer-backendsets-a'); } });
+
+"
+`;
+
+exports[`case-insensitive base name collision: load-balancer-backend-set 1`] = `
+"// https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backend_set
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface LoadBalancerBackendSetConfig extends cdktn.TerraformMetaArguments {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backend_set#name LoadBalancerBackendSet#name}
+  */
+  readonly name: string;
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backend_set oci_load_balancer_backend_set}
+*/
+export class LoadBalancerBackendSet extends cdktn.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "oci_load_balancer_backend_set";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a LoadBalancerBackendSet resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the LoadBalancerBackendSet to import
+  * @param importFromId The id of the existing LoadBalancerBackendSet that should be imported. Refer to the {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backend_set#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the LoadBalancerBackendSet to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "oci_load_balancer_backend_set", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backend_set oci_load_balancer_backend_set} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options LoadBalancerBackendSetConfig
+  */
+  public constructor(scope: Construct, id: string, config: LoadBalancerBackendSetConfig) {
+    super(scope, id, {
+      terraformResourceType: 'oci_load_balancer_backend_set',
+      terraformGeneratorMetadata: {
+        providerName: 'oci'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+    this._name = config.name;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // name - computed: false, optional: false, required: true
+  private _name?: string; 
+  public get name() {
+    return this.getStringAttribute('name');
+  }
+  public set name(value: string) {
+    this._name = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get nameInput() {
+    return this._name;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      name: cdktn.stringToTerraform(this._name),
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+      name: {
+        value: cdktn.stringToHclTerraform(this._name),
+        isBlock: false,
+        type: "simple",
+        storageClassType: "string",
+      },
+    };
+
+    // remove undefined attributes
+    return Object.fromEntries(Object.entries(attrs).filter(([_, value]) => value !== undefined && value.value !== undefined ))
+  }
+}
+"
+`;
+
+exports[`case-insensitive base name collision: load-balancer-backendset-a 1`] = `
+"// https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backendset
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface LoadBalancerBackendsetAConfig extends cdktn.TerraformMetaArguments {
+  /**
+  * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backendset#name LoadBalancerBackendsetA#name}
+  */
+  readonly name: string;
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backendset oci_load_balancer_backendset}
+*/
+export class LoadBalancerBackendsetA extends cdktn.TerraformResource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "oci_load_balancer_backendset";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a LoadBalancerBackendsetA resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the LoadBalancerBackendsetA to import
+  * @param importFromId The id of the existing LoadBalancerBackendsetA that should be imported. Refer to the {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backendset#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the LoadBalancerBackendsetA to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "oci_load_balancer_backendset", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/load_balancer_backendset oci_load_balancer_backendset} Resource
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options LoadBalancerBackendsetAConfig
+  */
+  public constructor(scope: Construct, id: string, config: LoadBalancerBackendsetAConfig) {
+    super(scope, id, {
+      terraformResourceType: 'oci_load_balancer_backendset',
+      terraformGeneratorMetadata: {
+        providerName: 'oci'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+    this._name = config.name;
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // name - computed: false, optional: false, required: true
+  private _name?: string; 
+  public get name() {
+    return this.getStringAttribute('name');
+  }
+  public set name(value: string) {
+    this._name = value;
+  }
+  // Temporarily expose input value. Use with caution.
+  public get nameInput() {
+    return this._name;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+      name: cdktn.stringToTerraform(this._name),
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+      name: {
+        value: cdktn.stringToHclTerraform(this._name),
+        isBlock: false,
+        type: "simple",
+        storageClassType: "string",
+      },
+    };
+
+    // remove undefined attributes
+    return Object.fromEntries(Object.entries(attrs).filter(([_, value]) => value !== undefined && value.value !== undefined ))
+  }
+}
+"
+`;
+
 exports[`computed complex attribute 1`] = `
 "// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/computed_complex
 // generated from terraform resource schema

--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/fixtures/case-insensitive-base-name-collision.test.fixture.json
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/fixtures/case-insensitive-base-name-collision.test.fixture.json
@@ -1,0 +1,82 @@
+{
+  "provider_schemas": {
+    "registry.terraform.io/oracle/oci": {
+      "resource_schemas": {
+        "oci_load_balancer_backend_set": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "name": {
+                "type": "string",
+                "required": true
+              }
+            }
+          },
+          "block_types": {}
+        },
+        "oci_load_balancer_backendset": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "name": {
+                "type": "string",
+                "required": true
+              }
+            }
+          },
+          "block_types": {}
+        }
+      },
+      "data_source_schemas": {
+        "oci_devops_repository_mirror_record": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "id": {
+                "type": "string",
+                "computed": true
+              }
+            }
+          },
+          "block_types": {}
+        },
+        "oci_devops_repository_mirrorrecord_history": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "id": {
+                "type": "string",
+                "computed": true
+              }
+            }
+          },
+          "block_types": {}
+        },
+        "oci_load_balancer_backend_sets": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "id": {
+                "type": "string",
+                "computed": true
+              }
+            }
+          },
+          "block_types": {}
+        },
+        "oci_load_balancer_backendsets": {
+          "version": 1,
+          "block": {
+            "attributes": {
+              "id": {
+                "type": "string",
+                "computed": true
+              }
+            }
+          },
+          "block_types": {}
+        }
+      }
+    }
+  }
+}

--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/types.test.ts
@@ -596,3 +596,50 @@ test("map of map of string attribute", async () => {
   );
   expect(output).toMatchSnapshot();
 });
+
+test("case-insensitive base name collision", async () => {
+  const code = new CodeMaker();
+  const workdir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "case-insensitive-base-name-collision.test"),
+  );
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        "fixtures",
+        "case-insensitive-base-name-collision.test.fixture.json",
+      ),
+      "utf-8",
+    ),
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const files = fs.readdirSync(path.join(workdir, "providers/oci"));
+  const topLevelFiles = ["index.ts", "lazy-index.ts"];
+
+  // Verify that colliding base names are disambiguated with a "-a" suffix.
+  expect(files).toContain("load-balancer-backend-set");
+  expect(files).toContain("load-balancer-backendset-a");
+
+  expect(files).toContain("data-oci-load-balancer-backend-sets");
+  expect(files).toContain("data-oci-load-balancer-backendsets-a");
+
+  // No two directories should collide case-insensitively
+  const lowercaseFiles = files.map((f) => f.toLowerCase());
+  const uniqueLowercaseFiles = [...new Set(lowercaseFiles)];
+  expect(lowercaseFiles).toEqual(uniqueLowercaseFiles);
+
+  for (const file of files) {
+    const output = fs.readFileSync(
+      path.join(
+        workdir,
+        "providers/oci/",
+        file,
+        topLevelFiles.includes(file) ? "" : "index.ts",
+      ),
+      "utf-8",
+    );
+    expect(output).toMatchSnapshot(file);
+  }
+});

--- a/packages/@cdktn/provider-generator/src/get/generator/resource-parser.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/resource-parser.ts
@@ -111,7 +111,10 @@ function deduplicateAttributesWithSameName(
 class Parser {
   private structs = new Array<Struct>();
 
-  constructor(private classNames: string[]) {}
+  constructor(
+    private classNames: string[],
+    private usedBaseNames: Map<string, string>,
+  ) {}
 
   private uniqueClassName(className: string): string {
     if (this.classNames.includes(className)) {
@@ -119,6 +122,32 @@ class Parser {
     }
     this.classNames.push(className);
     return className;
+  }
+
+  /**
+   * Ensure base names are unique case-insensitively.
+   *
+   * Affected languages:
+   * - Go: JSII-generated Go package names are fully lowercased, so
+   *   `load-balancer-backendset` and `load-balancer-backend-set` both
+   *   become package `loadbalancerbackendset`, causing a hard build failure:
+   *   "case-insensitive file name collision".
+   * - C#: JSII generates PascalCase directories like
+   *   `LoadBalancerBackendset/` and `LoadBalancerBackendSet/` which the C#
+   *   compiler treats case-insensitively, causing CS2002 and CS0234 errors.
+   */
+  private uniqueBaseName(baseName: string): string {
+    const pascalName = toPascalCase(baseName);
+    const key = pascalName.toLowerCase();
+    const existing = this.usedBaseNames.get(key);
+
+    if (existing !== undefined && existing !== pascalName) {
+      baseName = `${baseName}A`;
+      return this.uniqueBaseName(baseName);
+    }
+
+    this.usedBaseNames.set(key, pascalName);
+    return baseName;
   }
 
   public resourceFrom(
@@ -162,6 +191,7 @@ class Parser {
     }
 
     baseName = sanitizeClassOrNamespaceName(baseName, isProvider);
+    baseName = this.uniqueBaseName(baseName);
 
     const className = this.uniqueClassName(toPascalCase(baseName));
     // avoid naming collision - see https://github.com/hashicorp/terraform-cdk/issues/299
@@ -683,6 +713,7 @@ class Parser {
 
 export class ResourceParser {
   private uniqueClassnames: string[] = [];
+  private uniqueBaseNames: Map<string, string> = new Map();
   private resources: Record<string, ResourceModel> = {};
 
   public parse(
@@ -696,7 +727,7 @@ export class ResourceParser {
       return this.resources[type];
     }
 
-    const parser = new Parser(this.uniqueClassnames);
+    const parser = new Parser(this.uniqueClassnames, this.uniqueBaseNames);
     const resource = parser.resourceFrom(
       fqpn,
       type,


### PR DESCRIPTION
### Related issue

Fixes https://github.com/hashicorp/terraform-cdk/issues/3891

### Description

Some providers (such as the OCI provider) contain resources or aliases to resources that can result in case-insensitive name collisions, causing compiler errors in languages like C# and Go. For example, the OCI provider defines both `oci_load_balancer_backend_set` and `oci_load_balancer_backendset` which get turned into `LoadBalancerBackendSet` and `LoadBalancerBackendset` in C#, causing `CS2002` and `CS0234` compiler errors.

This PR adds some additional name de-duplication by keeping track of lower-cased names, appending an `A` suffix where a duplicate is found, and then re-using the suffixed name to maintain consistency.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
