### PR TITLE
chore: CI build-example-matrix: replace lerna with node script

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,11 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: set-examples
-        run: |
-          tfDefault=$(cat .terraform.versions.json | jq -r '.default')
-          examples=$(npx lerna list --scope "@examples/*" | jq  -R -s -c --arg tfDefault "${tfDefault}" 'split("\n") | map(select(length > 0)) | { target: values, terraform: [$tfDefault], hclOutput: [false, true] }')
-          echo $examples
-          echo "examples=$examples" >> $GITHUB_OUTPUT
+        run: echo "examples=$(node tools/build-example-matrix.mjs)" | tee -a $GITHUB_OUTPUT
 
   examples:
     needs: build-example-matrix

--- a/tools/build-example-matrix.mjs
+++ b/tools/build-example-matrix.mjs
@@ -14,6 +14,13 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+/**
+ * Repository root. The script is invoked from the repo root in CI (and via
+ * `node tools/build-example-matrix.mjs` locally), so `process.cwd()` is the
+ * authoritative location without hard-coding the script's relative path.
+ *
+ * @type {string}
+ */
 const repoRoot = process.cwd();
 
 /**
@@ -41,8 +48,7 @@ function findPackageJsonFiles(dir, results = []) {
 
 /**
  * Returns whether a parsed package.json is marked private. Tolerates the
- * boolean `true` and the string `"true"` (some workspaces use the string
- * form, which lerna also treats as private).
+ * boolean `true` and the string `"true"`
  *
  * @param {{ private?: boolean | string }} pkg Parsed package.json contents.
  * @returns {boolean} `true` if the package should be excluded from the matrix.
@@ -51,10 +57,23 @@ function isPrivate(pkg) {
   return pkg.private === true || pkg.private === "true";
 }
 
+/**
+ * Default Terraform version pulled from `.terraform.versions.json`. Used as
+ * the single entry in the matrix's `terraform` axis so every example runs
+ * against the project-wide default.
+ *
+ * @type {string}
+ */
 const tfDefault = JSON.parse(
   readFileSync(join(repoRoot, ".terraform.versions.json"), "utf8"),
 ).default;
 
+/**
+ * Sorted list of `@examples/*` workspace names that should appear in the
+ * matrix. Workspaces with a truthy `private` field are excluded.
+ *
+ * @type {string[]}
+ */
 const targets = findPackageJsonFiles(join(repoRoot, "examples"))
   .map((file) => JSON.parse(readFileSync(file, "utf8")))
   .filter((pkg) => pkg.name && pkg.name.startsWith("@examples/"))
@@ -62,6 +81,13 @@ const targets = findPackageJsonFiles(join(repoRoot, "examples"))
   .map((pkg) => pkg.name)
   .sort();
 
+/**
+ * GitHub Actions matrix object combining the example list with the default
+ * Terraform version and both HCL output modes. Serialised to stdout so the
+ * workflow can append it to `$GITHUB_OUTPUT`.
+ *
+ * @type {{ target: string[], terraform: string[], hclOutput: boolean[] }}
+ */
 const matrix = {
   target: targets,
   terraform: [tfDefault],

--- a/tools/build-example-matrix.mjs
+++ b/tools/build-example-matrix.mjs
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+// Builds the GitHub Actions matrix for the examples workflow.
+// Walks examples/ for package.json files named @examples/*, skips ones with
+// a truthy "private" field (boolean true or the string "true"), and prints
+// a JSON matrix combining the example list with the default terraform
+// version and both HCL output modes.
+//
+// Runs without dependencies installed so the matrix step can be cheap.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const repoRoot = process.cwd();
+
+/**
+ * Recursively walks `dir`, collecting absolute paths of every `package.json`
+ * found. Skips `node_modules` directories so installed dependencies don't
+ * pollute the result.
+ *
+ * @param {string} dir Directory to walk.
+ * @param {string[]} [results=[]] Accumulator for matched paths; pass when
+ *   recursing, omit at the top-level call.
+ * @returns {string[]} Absolute paths of every discovered `package.json`.
+ */
+function findPackageJsonFiles(dir, results = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findPackageJsonFiles(full, results);
+    } else if (entry.isFile() && entry.name === "package.json") {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Returns whether a parsed package.json is marked private. Tolerates the
+ * boolean `true` and the string `"true"` (some workspaces use the string
+ * form, which lerna also treats as private).
+ *
+ * @param {{ private?: boolean | string }} pkg Parsed package.json contents.
+ * @returns {boolean} `true` if the package should be excluded from the matrix.
+ */
+function isPrivate(pkg) {
+  return pkg.private === true || pkg.private === "true";
+}
+
+const tfDefault = JSON.parse(
+  readFileSync(join(repoRoot, ".terraform.versions.json"), "utf8"),
+).default;
+
+const targets = findPackageJsonFiles(join(repoRoot, "examples"))
+  .map((file) => JSON.parse(readFileSync(file, "utf8")))
+  .filter((pkg) => pkg.name && pkg.name.startsWith("@examples/"))
+  .filter((pkg) => !isPrivate(pkg))
+  .map((pkg) => pkg.name)
+  .sort();
+
+const matrix = {
+  target: targets,
+  terraform: [tfDefault],
+  hclOutput: [false, true],
+};
+
+process.stdout.write(JSON.stringify(matrix));


### PR DESCRIPTION
### Description

### Why

The `build-example-matrix` CI job currently runs `npx lerna list` to obtain a list of example projects to run the example integration tests on. Because a prior `yarn install` has not been run,  `npx` doesn't use the `lerna` version pinned in this repo's `package.json` but resolves and downloads its own copy of the latest matching version every CI run. That means:

- The matrix step depends on whatever lerna `npx` happens to fetch, not the version we've tested against.
- A breaking change in upstream lerna (or in the nx plugin lerna 8 activates on invocation) could silently change matrix behaviour or fail the job entirely, with no lockfile change to flag it.
- This is also susceptible to supply-chain attacks.

We could add a `yarn install` step, but this would add more runtime to the CI when it is not required.

### Changes

- Replace the inline `npx lerna list … | jq …` shell pipeline in [.github/workflows/examples.yml](.github/workflows/examples.yml) with a single `node tools/build-example-matrix.mjs` invocation piped through `tee -a $GITHUB_OUTPUT`.
- Add `tools/build-example-matrix.mjs` that walks `examples/`, reads each `package.json`, filters out private workspaces  and emits the matrix as JSON.

The new script has no dependencies and produces the same output.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
