### PR TITLE
chore: clean up leaked temp directories in unit tests - Provider Generator types test fix

### DIFF
--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/types.test.ts
@@ -567,9 +567,7 @@ test("map of map of string attribute", async () => {
 
 test("case-insensitive base name collision", async () => {
   const code = new CodeMaker();
-  const workdir = fs.mkdtempSync(
-    path.join(os.tmpdir(), "case-insensitive-base-name-collision.test"),
-  );
+  const workdir = tmp("case-insensitive-base-name-collision.test");
   const spec = JSON.parse(
     fs.readFileSync(
       path.join(


### PR DESCRIPTION
### Description

The changes introduced by https://github.com/open-constructs/cdk-terrain/pull/165 and https://github.com/open-constructs/cdk-terrain/pull/163 collided, causing the `@cdktn/provider-generator:build` job to fail with: 

```
src/get/__tests__/generator/types.test.ts(571,15): error TS2304: Cannot find name 'os'.
```

Example failure: https://github.com/open-constructs/cdk-terrain/actions/runs/25640634833/job/75278914718

This PR replaces the `mkdtempSync` in the test with the `tmp` helper introduced in #163. 

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
