### PR TITLE
fix(cli): forward stderr output in spawnInteractive

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/models/interactive-process.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/interactive-process.ts
@@ -85,7 +85,7 @@ export function spawnInteractive(
   p.stderr?.on("data", (chunk: Buffer) => {
     onData(chunk.toLocaleString());
   });
-  
+
   const exitCode = new Promise<number>((resolve) => {
     p.once("close", (code: number) => {
       if (code !== 0) {

--- a/packages/@cdktn/cli-core/src/lib/models/interactive-process.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/interactive-process.ts
@@ -82,6 +82,10 @@ export function spawnInteractive(
     onData(chunk.toLocaleString());
   });
 
+  p.stderr?.on("data", (chunk: Buffer) => {
+    onData(chunk.toLocaleString());
+  });
+  
   const exitCode = new Promise<number>((resolve) => {
     p.once("close", (code: number) => {
       if (code !== 0) {


### PR DESCRIPTION
### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

After the rename from `cdktf` to `cdktn`, the `init` command switched from using
`node-pty` (`spawnPty`) to regular `cross-spawn` (`spawnInteractive`). With `node-pty`,
stdout and stderr are merged into a single PTY stream, so `p.onData(...)` captured all
output automatically. With `cross-spawn`, stderr is a separate file descriptor that
requires an explicit listener.

The `spawnInteractive` function subscribed to `p.stdout` but never subscribed to
`p.stderr`, so all Terraform error output was silently discarded. This caused deployment
failures to only show the exit code (`Invoking Terraform CLI failed with exit code 1`)
with no further detail.

The fix adds the missing `p.stderr` listener so error output is forwarded through
`onData`, matching the previous behaviour.

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes