### PR TITLE
fix(cli): pass languageOptions to `get`

### DIFF
--- a/packages/cdktn-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktn-cli/src/bin/cmds/handlers.ts
@@ -349,6 +349,7 @@ export async function get(argv: {
         force,
         silent: argv.silent,
         providerSchemaCachePath: argv.experimentalProviderSchemaCachePath,
+        languageOptions: config.languageOptions,
       }),
     );
   } finally {
@@ -705,6 +706,7 @@ export async function providerUpgrade(argv: any) {
     const constructsOptions: GetOptions = {
       codeMakerOutput: config.codeMakerOutput,
       targetLanguage: language,
+      languageOptions: config.languageOptions,
       jsiiParallelism: 1,
     };
 

--- a/packages/cdktn-cli/src/bin/cmds/ui/get.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/get.tsx
@@ -11,6 +11,7 @@ import { GetOptions } from "@cdktn/provider-generator";
 import {
   IsErrorType,
   Language,
+  LanguageOptions,
   sendTelemetry,
   TerraformDependencyConstraint,
 } from "@cdktn/commons";
@@ -19,6 +20,7 @@ import { get, GetStatus as Status } from "@cdktn/cli-core";
 interface GetConfig {
   codeMakerOutput: string;
   language: Language;
+  languageOptions?: LanguageOptions;
   constraints: TerraformDependencyConstraint[];
   parallelism: number;
   force?: boolean;
@@ -34,6 +36,7 @@ export const Get = ({
   force,
   silent = false,
   providerSchemaCachePath,
+  languageOptions,
 }: GetConfig): React.ReactElement => {
   const [currentStatus, setCurrentStatus] = React.useState<Status>(
     Status.STARTING,
@@ -44,6 +47,7 @@ export const Get = ({
     codeMakerOutput: codeMakerOutput,
     targetLanguage: language,
     jsiiParallelism: parallelism,
+    languageOptions,
   };
 
   React.useEffect(() => {

--- a/test/typescript/import-extension/cdktf.json
+++ b/test/typescript/import-extension/cdktf.json
@@ -1,0 +1,11 @@
+{
+  "language": "typescript",
+  "app": "npx ts-node main.ts",
+  "terraformProviders": [
+    "null@ ~> 3.1.0"
+  ],
+  "languageOptions": {
+    "importExtension": ".js"
+  },
+  "context": {}
+}

--- a/test/typescript/import-extension/main.ts
+++ b/test/typescript/import-extension/main.ts
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Construct } from "constructs";
+import { App, TerraformStack, Testing } from "cdktn";
+
+export class Empty extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+}
+
+const app = Testing.stubVersion(new App({ stackTraces: false }));
+new Empty(app, "dummy");
+app.synth();

--- a/test/typescript/import-extension/test.ts
+++ b/test/typescript/import-extension/test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver } from "../../test-helper";
+
+describe("languageOptions.importExtension", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    await driver.setupTypescriptProject();
+  });
+
+  test(".js importExtension", () => {
+    // The provider-level index re-exports child modules. With .js configured,
+    // every relative import should carry the suffix.
+    const providerIndex = driver.readLocalFile(".gen/providers/null/index.ts");
+    expect(providerIndex).toMatch(/from '\.\/[^']+\.js'/);
+    expect(providerIndex).not.toMatch(/from '\.\/[^']+\/index';/);
+  });
+
+  test("lazy-index remains CommonJS regardless of importExtension", () => {
+    // lazy-index uses runtime require() and must not adopt the ESM suffix —
+    // it's loaded by the cdktn runtime, not by a TS/ESM resolver.
+    const lazyIndex = driver.readLocalFile(".gen/providers/null/lazy-index.ts");
+    expect(lazyIndex).toMatch(/require\('\.\/[^']+'\)/);
+    expect(lazyIndex).not.toMatch(/require\('\.\/[^']+\.js'\)/);
+  });
+});


### PR DESCRIPTION
We added this as an option in #151 but neglected to pass it through everywhere in the CLI. The result is that `cdktn get` was not respecting `languageOptions.importExtension`.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Description

Pass `languageOptions` on `GetOptions`.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
