### PR TITLE
chore: tell users to search for cdktn on npm

### DIFF
--- a/examples/typescript/aws-move/help
+++ b/examples/typescript/aws-move/help
@@ -36,7 +36,7 @@
   
   cdktf provider add "aws@~>3.0" null kreuzwerker/docker
 
-  You can find all prebuilt providers on npm: https://www.npmjs.com/search?q=keywords:cdktf
+  You can find all prebuilt providers on npm: https://www.npmjs.com/search?q=keywords:cdktn
   You can also install these providers directly through npm:
 
   npm install @cdktf/provider-aws

--- a/packages/@cdktn/cli-core/templates/typescript/help
+++ b/packages/@cdktn/cli-core/templates/typescript/help
@@ -36,7 +36,7 @@
   
   cdktn provider add "aws@~>3.0" null kreuzwerker/docker
 
-  You can find all prebuilt providers on npm: https://www.npmjs.com/search?q=keywords:cdktf
+  You can find all prebuilt providers on npm: https://www.npmjs.com/search?q=keywords:cdktn
   You can also install these providers directly through npm:
 
   npm install @cdktn/provider-aws


### PR DESCRIPTION
Don't use the cdktf keyword when searching npm. Use cdktn instead.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Description

Link to https://www.npmjs.com/search?q=keywords:cdktn instead of https://www.npmjs.com/search?q=keywords:cdktf

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain/tree/main/website) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
