### PR TITLE
fix(tests): pass --no-compile to pip in python integration tests

### DIFF
--- a/test/python/provider-add-command/test.ts
+++ b/test/python/provider-add-command/test.ts
@@ -77,7 +77,12 @@ describe("provider add command", () => {
 
         driver.copyFile("cdktf-pip.json", "cdktf.json");
         driver.copyFiles("requirements.txt");
-        driver.exec("pip", ["install", "-r", "requirements.txt"]);
+        driver.exec("pip", [
+          "install",
+          "--no-compile",
+          "-r",
+          "requirements.txt",
+        ]);
       });
 
       it("detects correct cdktn version", async () => {

--- a/test/python/provider-upgrade-command/test.ts
+++ b/test/python/provider-upgrade-command/test.ts
@@ -71,13 +71,23 @@ describe("provider upgrade command", () => {
 
         driver.copyFile("cdktf-pip.json", "cdktf.json");
         driver.copyFiles("requirements.txt");
-        driver.exec("pip", ["install", "-r", "requirements.txt"]);
+        driver.exec("pip", [
+          "install",
+          "--no-compile",
+          "-r",
+          "requirements.txt",
+        ]);
       });
 
       test("updates pre-built provider using pip", async () => {
         await driver.exec("echo", [INITIAL_PKG, ">", "requirements.txt"]);
         expect(driver.readLocalFile("requirements.txt")).toContain(INITIAL_PKG);
-        await driver.exec("pip", ["install", "-r", "requirements.txt"]);
+        await driver.exec("pip", [
+          "install",
+          "--no-compile",
+          "-r",
+          "requirements.txt",
+        ]);
 
         await driver.exec("cdktn", ["provider", "upgrade", UPGRADE_TARGET]);
         expect(driver.readLocalFile("requirements.txt")).toContain(


### PR DESCRIPTION
### Description

`pip install -r requirements.txt` in the `provider-add` and `provider-upgrade` Python integration tests has been flaking with `AssertionError: assert os.path.exists(pyc_path)` from pip's wheel installer, mid-install of the JSII-generated `cdktn` / `cdktn-provider-local` wheels.
The assert fires in pip's `.pyc` byte-compilation step ([cpython#86612](https://github.com/python/cpython/issues/86612) / [bpo-42446](https://bugs.python.org/issue42446)) — pip expects a `.pyc` next to every `.py`, but `compileall` skips files under certain Python build configurations, leaving pip's assert with nothing to find.

Example failed job: https://github.com/open-constructs/cdk-terrain/actions/runs/26030565831/job/76518367284?pr=160

### Fix

These tests only read/write `requirements.txt` to assert that `cdktn provider add` / `cdktn provider upgrade` edits it correctly — they never execute the installed packages. Passing `--no-compile` skips the bytecode step entirely and removes the failure mode without changing what's being tested.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
