### PR TITLE
fix: Configurable dist artifact name to fix release workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -11,6 +11,11 @@ on:
         default: pr
         required: false
         type: string
+      dist_artifact_name:
+        description: Name of the dist artifact created
+        default: dist-integration
+        required: false
+        type: string
 
 concurrency:
   group: ${{ inputs.concurrency_group_prefix }}-integration-${{ github.head_ref }}
@@ -71,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !inputs.skip_setup }}
         with:
-          name: dist-integration
+          name: ${{ inputs.dist_artifact_name }}
           path: dist
       - name: Upload edge-provider bindings
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -143,7 +148,7 @@ jobs:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist-integration
+          name: ${{ inputs.dist_artifact_name }}
           path: dist
       - name: Download edge-provider bindings
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -228,7 +233,7 @@ jobs:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist-integration
+          name: ${{ inputs.dist_artifact_name }}
           path: dist
       - name: Download edge-provider bindings
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -16,6 +16,11 @@ on:
         default: 1.6.5
         type: string
         required: false
+      dist_artifact_name:
+        description: Name of the dist artifact created
+        default: dist-provider-integration
+        required: false
+        type: string
 
 concurrency:
   group: ${{ inputs.concurrency_group_prefix }}-provider-integration-${{ github.head_ref }}
@@ -77,7 +82,7 @@ jobs:
         if: ${{ !inputs.skip_setup }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist-provider-integration
+          name: ${{ inputs.dist_artifact_name }}
           path: dist
       - name: Build provider test matrix
         id: build-provider-test-matrix
@@ -103,7 +108,7 @@ jobs:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist-provider-integration
+          name: ${{ inputs.dist_artifact_name }}
           path: dist
       - name: ensure correct user
         run: chown -R root /__w/cdk-terrain
@@ -161,7 +166,7 @@ jobs:
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist-provider-integration
+          name: ${{ inputs.dist_artifact_name }}
           path: dist
       - name: Get cache directory paths
         id: global-cache-dir-path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
     with:
       skip_setup: true
       concurrency_group_prefix: release
+      dist_artifact_name: dist
     secrets: inherit
 
   provider_integration_test:
@@ -97,6 +98,7 @@ jobs:
     with:
       concurrency_group_prefix: release
       skip_setup: true
+      dist_artifact_name: dist
     secrets: inherit
 
   examples:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -125,6 +125,7 @@ jobs:
     with:
       skip_setup: true
       concurrency_group_prefix: release-next
+      dist_artifact_name: dist
     secrets: inherit
 
   provider_integration_test:
@@ -134,6 +135,7 @@ jobs:
     with:
       skip_setup: true
       concurrency_group_prefix: release-next
+      dist_artifact_name: dist
     secrets: inherit
 
   examples:


### PR DESCRIPTION
### Description

Current release@next and release workflows are failing due to not finding the `dist` artifact.
An example error:
```Unable to download artifact(s): Artifact not found for name: dist-integration``` from https://github.com/open-constructs/cdk-terrain/actions/runs/26048945491/job/76581472254

This is a result of recent optimizations for PR workflows which renamed the `dist` artifact. The release related workflows creating the artifact at a slightly different time and still using the name `dist`.

This PR allows for optionally overriding the `dist` artifact name in the integration and provider-integration workflows with the release workflows using `dist` as the name to match the rest of the flow.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
