### PR TITLE
fix(cli): restore non-bundled dependencies

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -25,7 +25,16 @@
         // Read at runtime via pkg.dependencies.constructs lookup in
         // @cdktn/cli-core/src/lib/init.ts (after esbuild bundles, pkg-up
         // resolves cdktn-cli's package.json — not cli-core's).
-        "constructs"
+        "constructs",
+        // Not bundled with esbuild
+        // Reference is otherwise lost as cli-core (what actually references it) is bundled.
+        "@cdktn/hcl-tools",
+        // Not bundled with esbuild
+        // Reference is otherwise lost as provider-schema (what actually references it) is bundled.
+        "@cdktn/hcl2json",
+        // Not bundled with esbuild due to a bug with 1.x versions during bundling.
+        // Reference is otherwise lost as ink (what actually references it) is bundled.
+        "yoga-layout-prebuilt"
       ]
     },
     "packages/@cdktn/cli-core": {

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -47,11 +47,13 @@
     "@cdktn/hcl-tools": "0.0.0",
     "@cdktn/hcl2cdk": "0.0.0",
     "@cdktn/hcl2json": "0.0.0",
-    "cdktn": "0.0.0",
-    "jsii": "5.9.37",
-    "jsii-pacmak": "1.128.0",
     "yargs": "17.7.2",
     "yoga-layout-prebuilt": "1.10.0"
+  },
+  "peerDependencies": {
+    "cdktn": "0.0.0",
+    "jsii": "5.9.37",
+    "jsii-pacmak": "1.128.0"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -43,9 +43,7 @@
   ],
   "dependencies": {
     "@types/node": "20.19.1",
-    "constructs": "10.6.0"
-  },
-  "peerDependencies": {
+    "constructs": "10.6.0",
     "@cdktn/hcl-tools": "0.0.0",
     "@cdktn/hcl2cdk": "0.0.0",
     "@cdktn/hcl2json": "0.0.0",

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -53,17 +53,21 @@ echo "Installing CLI from 'dist'..."
 staging=$(mktemp -d)
 cd ${staging}
 npm init -y > /dev/null
+# Use the same package manager (and version) the rest of the repo uses
+package_manager=$(node -p "require('${cdktf_root}/package.json').packageManager")
+package_manager_name=${package_manager%%@*}
+corepack use "$package_manager"
 # There's only one version in our local registry, so we don't need to specify a version here
 # Retry to ride out transient ECONNRESETs from Verdaccio's upstream fetch
 for attempt in 1 2 3; do
-  if npm install --registry=http://localhost:4873/ --install-strategy=shallow --fetch-retries=5 cdktn-cli; then
+  if "$package_manager_name" add cdktn-cli --registry=http://localhost:4873/; then
     break
   fi
   if [ "$attempt" = "3" ]; then
-    echo "npm install failed after 3 attempts"
+    echo "CLI install failed after 3 attempts"
     exit 1
   fi
-  echo "npm install attempt $attempt failed, retrying in $((attempt * 10))s..."
+  echo "CLI install attempt $attempt failed, retrying in $((attempt * 10))s..."
   sleep $((attempt * 10))
 done
 
@@ -75,7 +79,11 @@ stopLocalRegistry
 export TEST_PATH_CDKTF_CLI=${staging}/node_modules/.bin
 export PATH=$TEST_PATH_CDKTF_CLI:$PATH
 
-echo "Installed CDKTN-CLI version: $(cdktn --version)"
+if ! cdktn_version=$(cdktn --version); then
+  echo "ERROR: 'cdktn --version' failed after install. See the output above for the underlying error."
+  exit 1
+fi
+echo "Installed CDKTN-CLI version: ${cdktn_version}"
 
 # restore working directory
 cd $cwd


### PR DESCRIPTION
### Description

https://github.com/open-constructs/cdk-terrain/pull/158 introduced a bug as not all dependencies are bundled. See: https://github.com/open-constructs/cdk-terrain/blob/c86b27a58bbbf790a43c87067fa79638d2f01bd7/packages/cdktn-cli/build.ts#L65-L74

This manifests when not installing the cli package globally in a couple ways.

1. Warnings during install:
  ```warning " > cdktn-cli@0.23.1" has unmet peer dependency "@cdktn/hcl-tools@0.23.1".
warning " > cdktn-cli@0.23.1" has unmet peer dependency "@cdktn/hcl2cdk@0.23.1".
warning " > cdktn-cli@0.23.1" has unmet peer dependency "@cdktn/hcl2json@0.23.1".
warning " > cdktn-cli@0.23.1" has incorrect peer dependency "jsii@5.9.37".
warning " > cdktn-cli@0.23.1" has incorrect peer dependency "jsii-pacmak@1.128.0".
warning " > cdktn-cli@0.23.1" has unmet peer dependency "yargs@17.7.2".
warning " > cdktn-cli@0.23.1" has unmet peer dependency "yoga-layout-prebuilt@1.10.0".
``` 
2. Runtime errors:
  ```Cannot find module '@cdktn/hcl2cdk'
Require stack:
- /home/runner/work/cdktn-provider-newrelic/cdktn-provider-newrelic/node_modules/cdktn-cli/bundle/bin/cmds/handlers.js
- /home/runner/work/cdktn-provider-newrelic/cdktn-provider-newrelic/node_modules/cdktn-cli/bundle/bin/cdktn.js
```
See https://github.com/cdktn-io/cdktn-provider-newrelic/actions/runs/26081498272/job/76684009982 for more details

This PR restores the external dependencies as full dependencies so they should retain a valid reference.
- Left `cdktn` as a peer dependency since using the cli library without that doesn't really make sense and the point of not bundling is to match up the actually used version.
- Left `jsii` / `jsii-pacmac` as peer dependencies as they are only required for non-TypeScript use

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
