### PR TITLE
fix(cli): Fix input getting split between cdktn and Terraform

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/models/interactive-process.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/interactive-process.ts
@@ -37,11 +37,8 @@ export function spawnInteractive(
   const { args, options } = config;
   const file = config.file;
 
-  const writable = process.stdin.writable;
-
-  // Generally want interactive input for handling various prompts; however,
-  // also need to be able to write specific responses, so create a pipe if not normally possible.
-  options.stdio = [writable ? "inherit" : "pipe", "pipe", "pipe"];
+  // Input and output is processed and modified by the caller.
+  options.stdio = "pipe";
 
   logger.trace(
     `Spawning process with file=${file}, args=${


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #187 

### Description

The fix forces the child Terraform process to have its own piped stdin instead of inheriting the user's TTY.

**The bug**: PR #55 set `stdio[0]` based on `process.stdin.writable`:
- In an interactive terminal, `process.stdin.writable === true`, so it picked `"inherit"`.
- `"inherit"` means the child's stdin **is** the parent's stdin — the same TTY file descriptor.

So when cdktn ran `terraform apply` interactively, both processes were reading from the same TTY:
- cdktn's Ink picker needed keystrokes for Approve/Dismiss/Stop.
- Terraform was sitting on `Enter a value:` waiting for `yes/no`.

Each keystroke went to whichever reader the kernel happened to deliver it to. Roughly half went to Terraform (and got discarded — Terraform was waiting for newline-terminated input, not arrow keys), the rest reached Ink. That's why ~5 of 8 keystrokes vanished and the picker felt broken.

**The fix**: `stdio[0] = "pipe"` gives Terraform its own stdin pipe owned by cdktn. Terraform reads from that pipe, not from the user's TTY. The user's keystrokes go only to cdktn → Ink → the picker. When the user picks Approve/Reject, cdktn writes `"yes\n"` or `"no\n"` into that pipe via `actions.writeLine`, which it was already wired up to do (deploy-machine.ts:233/240).
The original code's comment said "Generally want interactive input for handling various prompts" — but cdktn doesn't actually need to forward user keystrokes to Terraform. It intercepts every prompt via stdout pattern-matching and synthesises the response itself.

Investigation from @X-Guardian 

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
