### PR TITLE
chore(gha): Enable NPM OIDC Publishing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,11 @@ on:
         default: dist-integration
         required: false
         type: string
+      edge_bindings_artifact_name:
+        description: Name of the edge provider bindings artifact created
+        default: edge-provider-bindings
+        required: false
+        type: string
 
 concurrency:
   group: ${{ inputs.concurrency_group_prefix }}-integration-${{ github.head_ref }}
@@ -82,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !inputs.skip_setup }}
         with:
-          name: edge-provider-bindings
+          name: ${{ inputs.edge_bindings_artifact_name }}
           path: packages/@cdktn/provider-generator/edge-provider-bindings
       - name: installing test dependencies
         run: |
@@ -153,7 +158,7 @@ jobs:
       - name: Download edge-provider bindings
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: edge-provider-bindings
+          name: ${{ inputs.edge_bindings_artifact_name }}
           path: test/edge-provider-bindings
       - name: install test dependencies
         run: cd test && yarn install --frozen-lockfile --prefer-offline
@@ -238,7 +243,7 @@ jobs:
       - name: Download edge-provider bindings
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: edge-provider-bindings
+          name: ${{ inputs.edge_bindings_artifact_name }}
           path: test/edge-provider-bindings
       # tmp fix for https://github.com/npm/cli/issues/4980
       - name: update npm

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -43,8 +43,7 @@ jobs:
       image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     permissions:
       contents: read
-      # --- npm OIDC trusted publishing (uncomment after configuring trusted publishers on npmjs.com) ---
-      # id-token: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,8 +61,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          # --- npm OIDC trusted publishing (uncomment + remove NPM_TOKEN above after configuring trusted publishers on npmjs.com) ---
-          # NPM_TRUSTED_PUBLISHER: "true"
+          NPM_TRUSTED_PUBLISHER: "true"
 
   release_pypi:
     name: Release to PyPi (${{ inputs.channel }})

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -16,8 +16,6 @@ on:
         type: string
         default: ""
     secrets:
-      NPM_TOKEN:
-        required: true
       TWINE_USERNAME:
         required: true
       TWINE_PASSWORD:
@@ -59,7 +57,6 @@ jobs:
       - name: Release
         run: yarn publib-npm
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           NPM_TRUSTED_PUBLISHER: "true"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
       skip_setup: true
       concurrency_group_prefix: release
       dist_artifact_name: dist-release
+      edge_bindings_artifact_name: edge-provider-bindings-release
     secrets: inherit
 
   provider_integration_test:
@@ -278,6 +279,7 @@ jobs:
       skip_setup: true
       concurrency_group_prefix: release-next
       dist_artifact_name: dist-next
+      edge_bindings_artifact_name: edge-provider-bindings-next
     secrets: inherit
 
   provider_integration_test_next:


### PR DESCRIPTION
### Description

Enables NPM OIDC publishing (already configured) so that we no longer need to use a token.

Also fixes an issue introduced in #192 by making the edge provider binding artifact name configurable.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
