### PR TITLE
fix(gha): Need to grant permission on workflow call job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,6 +331,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish_release:
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - prepare-release
       - integration_test
@@ -381,6 +384,9 @@ jobs:
   # Release — next
   # ---------------------------------------------------------------------------
   publish_next:
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - prepare-next
       - integration_test_next


### PR DESCRIPTION
### Description

New release workflow failing as the permissions for id-token also need to exist on the calling job.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
