### PR TITLE
chore(tests): Add test for Node type stripping

### DIFF
--- a/test/typescript/node-type-stripping/cdktf.json
+++ b/test/typescript/node-type-stripping/cdktf.json
@@ -1,0 +1,11 @@
+{
+  "language": "typescript",
+  "app": "node main.ts",
+  "terraformProviders": [
+    "null@3.3.0"
+  ],
+  "languageOptions": {
+    "importExtension": ".ts"
+  },
+  "context": {}
+}

--- a/test/typescript/node-type-stripping/main.ts
+++ b/test/typescript/node-type-stripping/main.ts
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import type { Construct } from "constructs";
+import { App, TerraformStack, Testing } from "cdktn";
+
+import { provider } from "./.gen/providers/null/index.ts";
+
+export class Empty extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    new provider.NullProvider(this, "null", {});
+  }
+}
+
+const app = Testing.stubVersion(new App({ stackTraces: false }));
+new Empty(app, "esm");
+app.synth();

--- a/test/typescript/node-type-stripping/test.ts
+++ b/test/typescript/node-type-stripping/test.ts
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver } from "../../test-helper";
+
+describe("Node type stripping", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    await driver.setupTypescriptProject();
+  });
+
+  test("synth", async () => {
+    await driver.synth();
+  });
+});


### PR DESCRIPTION
Add a test that runs synth in Node without ts-node or any other transpilation. This exercises both
https://nodejs.org/api/typescript.html#type-stripping and ESM support.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #100, since I think we can say that, if you run with the correct `languageOptions`, we support ESM.  

### Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
