### PR TITLE
chore(tests): Ensure we terminate Verdaccio

### DIFF
--- a/test/local-registry.sh
+++ b/test/local-registry.sh
@@ -16,8 +16,11 @@ function startLocalRegistry {
   echo "Cleaning storage dir ($storage_dir).."
   rm -rf $storage_dir
 
-  nohup npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &
+  # Enable job control so the background job becomes its own process group leader.
+  set -m
+  npx ${VERDACCIO_PACKAGE:-$default_verdaccio_package} -c $1 &>$tmp_registry_log &
   verdaccio_pid="$!"
+  set +m
   
   # Wait for Verdaccio to boot
   echo "Waiting for local Registry to start"
@@ -32,8 +35,16 @@ function startLocalRegistry {
 }
 
 function stopLocalRegistry {
+  # Noop if we never started Verdaccio
+  [ -z "${verdaccio_pid:-}" ] && return 0
+
   # Restore the original NPM and Yarn registry URLs and stop Verdaccio
   npm set registry "$original_npm_registry_url"
   yarn config set registry "$original_yarn_registry_url"
-  kill $verdaccio_pid
+
+  # Kill Verdaccio's process group.
+  # We ignore errors since Verdaccio may have died or never started successfully.
+  kill -TERM -- "-$verdaccio_pid" 2>/dev/null || true
+
+  unset verdaccio_pid
 }

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -7,23 +7,12 @@ scriptdir=$(cd $(dirname $0) && pwd)
 source "$scriptdir"/local-registry.sh
 
 function cleanup {
+  set +x
   # Restore the original NPM and Yarn registry URLs and stop Verdaccio
   stopLocalRegistry
 }
 
-function handle_error {
-  cleanup
-  exit 1
-}
-
-function handle_exit {
-  cleanup
-  exit
-}
-
-# Cleanup before exit on any termination signal
-trap 'set +x; handle_error' ERR
-trap 'set +x; handle_exit' SIGQUIT SIGTERM SIGINT SIGKILL SIGHUP
+trap cleanup EXIT
 
 export CDKTF_DIST="${scriptdir}/../dist"
 cwd=$PWD


### PR DESCRIPTION
Verdaccio was introduced in 548aa63 so that tests could install the CLI from an npm registry, similar to how real users install it. Unfortunately, we didn't always kill it after we were done.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

Integration tests often leave orphaned verdaccio processes around. This can cause subsequent test runs to fail.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
