### PR TITLE
chore(tests): don't require other language builds

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/init.ts
+++ b/packages/@cdktn/cli-core/src/lib/init.ts
@@ -68,7 +68,11 @@ export async function init({
   providersForceLocal,
   silent,
 }: InitArgs) {
-  const deps: any = await determineDeps(cdktfVersion, dist);
+  const deps: any = await determineDeps(
+    cdktfVersion,
+    dist,
+    path.basename(templatePath),
+  );
 
   const futureFlags = Object.entries(FUTURE_FLAGS)
     .map(([key, value]) => `    "${key}": "${value}"`)
@@ -107,9 +111,24 @@ export interface Deps {
   cdktf_version: string;
   constructs_version: string;
 }
+type DistKey = Exclude<keyof Deps, "cdktf_version" | "constructs_version">;
+
+// Each built-in template only consumes the dist artifact for its own
+// language. Skipping the others lets `cdktn init --dist` work when only
+// some language dists are present (e.g. CI ran `yarn package:js` only).
+const distKeysByTemplate: Record<string, DistKey[]> = {
+  typescript: ["npm_cdktf"],
+  python: ["pypi_cdktf"],
+  "python-pip": ["pypi_cdktf"],
+  java: ["mvn_cdktf"],
+  csharp: ["nuget_cdktf"],
+  go: ["go_cdktf"],
+};
+
 export async function determineDeps(
   version: string = pkg.version,
   dist?: string,
+  template?: string,
 ): Promise<Deps> {
   // TS: cdktf-0.10.1-dev.2160938258
   // Py: cdktf-0.10.1.dev1658821493.whl
@@ -136,7 +155,16 @@ export async function determineDeps(
       go_cdktf: path.resolve(dist, "go", `cdktn`),
     };
 
-    for (const file of Object.values(ret)) {
+    // If we know the template, only validate its artifact; otherwise fall
+    // back to validating everything (preserves prior behavior for unknown /
+    // remote templates).
+    const keysToValidate: DistKey[] =
+      template && distKeysByTemplate[template]
+        ? distKeysByTemplate[template]
+        : (Object.keys(ret) as DistKey[]);
+
+    for (const key of keysToValidate) {
+      const file = ret[key];
       if (!(await fs.pathExists(file))) {
         throw Errors.Internal(
           `unable to find ${file} under the "dist" directory (${dist})`,

--- a/test/run-against-dist
+++ b/test/run-against-dist
@@ -34,12 +34,21 @@ startLocalRegistry "$scriptdir"/verdaccio.yaml
 
 cd ${CDKTF_DIST}
 
-# verify this is indeed a "dist" directory
-if [ ! -d "js" ] || [ ! -d "python" ] || [ ! -d "java" ] || [ ! -d "dotnet" ] || [ ! -d "go" ] ; then
-  echo "ERROR: unable to find the subdirectories 'js', 'python', 'java', 'dotnet' and 'go' which should be in the 'dist' directory"
-  echo "Did you run 'yarn run package' to create the 'dist' directory?"
+# The JS dist is always required — this script publishes cdktn-cli from
+# dist/js and the CLI drives every language's tests. Per-language dists are
+# only consumed by the jest tests passed in via $@, so missing ones surface
+# as clear test failures rather than blocking the whole run.
+if [ ! -d "js" ]; then
+  echo "ERROR: unable to find the 'js' subdirectory in the 'dist' directory"
+  echo "Did you run 'yarn run package' (or 'yarn run package:js') to create the 'dist' directory?"
   exit 1
 fi
+
+for lang in python java dotnet go; do
+  if [ ! -d "$lang" ]; then
+    echo "WARNING: dist/$lang is missing — tests for that language will fail. Run 'yarn run package:$lang' if you need it."
+  fi
+done
 
 echo "Publishing CLI from 'dist'..."
 for pkg in ${CDKTF_DIST}/js/*.tgz


### PR DESCRIPTION
Allow running Typescript integration tests without having to build Java, Python, Go, and .NET packages.

Fixes #200

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #200

### Description

Don't be so strict about checking `dist`. Log warnings instead.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
