### PR TITLE
chore: Add PR workflow concurrency group and CI Label Filter job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,10 @@ on:
       - unlabeled
       - reopened
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: "Quality"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,12 +11,24 @@ on:
       - reopened
 
 concurrency:
-  group: pr-${{ github.event.pull_request.number || github.run_id }}
+  group: >-
+    ${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled')
+        && !startsWith(github.event.label.name, 'ci/')
+        && format('pr-noop-{0}', github.run_id)
+        || format('pr-{0}', github.event.pull_request.number || github.run_id) }}
   cancel-in-progress: true
 
 jobs:
+  ci_label_filter:
+    name: "CI Label Filter"
+    if: ${{ !((github.event.action == 'labeled' || github.event.action == 'unlabeled') && !startsWith(github.event.label.name, 'ci/')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: "true"
+
   quality:
     name: "Quality"
+    needs: [ci_label_filter]
     uses: ./.github/workflows/quality.yml
     with:
       concurrency_group_prefix: pr
@@ -24,6 +36,7 @@ jobs:
 
   build:
     name: "Build"
+    needs: [ci_label_filter]
     uses: ./.github/workflows/build.yml
     with:
       concurrency_group_prefix: pr
@@ -71,6 +84,7 @@ jobs:
     name: "PR - Result"
     needs:
       [
+        ci_label_filter,
         quality,
         build,
         all_unit_tests,


### PR DESCRIPTION
### Description

Currently, if a label is added to a PR, i.e. `ci/skip-unit`, `ci/skip-examples` etc, the GitHub Actions check run will re-trigger, but the current run will not be cancelled.

### Fix

- Adds a top-level `concurrency` block to `pr.yml` so adding or removing a `ci/*` label on a PR cancels the in-flight run and lets the re-evaluated `if:` gates skip the now-disabled jobs (e.g. `ci/unit-only` actually stops the integration suites).
- Scopes that cancellation to `ci/*` label changes only. Non-CI label edits get a unique concurrency group and a no-op run, so they no longer abort and restart the whole pipeline.
- Introduces a single `ci_label_filter` gate job that `quality` and `build` depend on, so the skip cascades through `all_unit_tests` and the integration jobs without duplicating the condition on every job.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
