### PR TITLE
chore: Update npm version to support OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           name: ${{ inputs.dist_artifact_name }}
           path: dist
+      - name: Upgrade npm for OIDC trusted publisher support
+        # OIDC publishing requires npm >= 11.5.0 — https://github.com/npm/cli/pull/8336
+        # TODO 
+        run: npm install --global npm@11.15.0
       - name: Release
         run: npx --no publib-npm
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,7 +56,7 @@ jobs:
           path: dist
       - name: Upgrade npm for OIDC trusted publisher support
         # OIDC publishing requires npm >= 11.5.0 — https://github.com/npm/cli/pull/8336
-        # TODO 
+        # TODO: Remove when Node is updated to version 24+
         run: npm install --global npm@11.15.0
       - name: Release
         run: npx --no publib-npm


### PR DESCRIPTION
### Description

The current version of npm that is bundled with Node version 22.22.0 that is included in the `terraconstructs/jsii-terraform`  image does not support OIDC trusted publishing. We need to update the npm version in the `release-npm` workflow job to version 11.5.0+.

### References

- https://github.com/npm/cli/releases/tag/v11.5.0

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
