### PR TITLE
chore: Add gradle cache to the examples and integration CI workflows

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -109,6 +109,8 @@ jobs:
           echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
           mkdir -p /usr/local/share/.cache/go
           echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/gradle
+          echo "gradle=/usr/local/share/.cache/gradle" >> $GITHUB_OUTPUT
       - name: Restore yarn cache
         # restore-only on the matrix side; only the prepare job saves to avoid parallel writes
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -135,6 +137,13 @@ jobs:
           restore-keys: |
             go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
+      - name: Cache gradle
+        if: endsWith(matrix.target, '-gradle')
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.gradle }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('examples/java/*-gradle/gradle/wrapper/gradle-wrapper.properties') }}-examples
+          restore-keys: gradle-${{ runner.os }}-
       - name: Install dependencies
         run: yarn install --frozen-lockfile --prefer-offline
       - name: Download dist
@@ -159,4 +168,5 @@ jobs:
           MAVEN_OPTS: "-Xmx3G"
           TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
           GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
+          GRADLE_USER_HOME: ${{ steps.global-cache-dir-path.outputs.gradle }}
           SYNTH_HCL_OUTPUT: ${{ matrix.hclOutput }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -141,7 +141,10 @@ jobs:
         if: endsWith(matrix.target, '-gradle')
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.gradle }}
+          # Skip daemon/, notifications/, native/ — only the distribution + module jars are worth keeping
+          path: |
+            ${{ steps.global-cache-dir-path.outputs.gradle }}/caches/modules-2
+            ${{ steps.global-cache-dir-path.outputs.gradle }}/wrapper/dists
           key: gradle-${{ runner.os }}-${{ hashFiles('examples/java/*-gradle/gradle/wrapper/gradle-wrapper.properties') }}-examples
           restore-keys: gradle-${{ runner.os }}-
       - name: Install dependencies

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: ensure correct user
         run: chown -R root /__w/cdk-terrain
-      # Setup caches for yarn, terraform, and go
+      # Setup caches for yarn, terraform, go, and gradle
       - name: Get cache directory paths
         id: global-cache-dir-path
         run: |
@@ -126,6 +126,8 @@ jobs:
           echo "terraform=/usr/local/share/.cache/terraform" >> $GITHUB_OUTPUT
           mkdir -p /usr/local/share/.cache/go
           echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
+          mkdir -p /usr/local/share/.cache/gradle
+          echo "gradle=/usr/local/share/.cache/gradle" >> $GITHUB_OUTPUT
       # restore-only on the matrix side; only the prepare job saves to avoid parallel writes
       - name: Restore yarn cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -150,6 +152,12 @@ jobs:
           restore-keys: |
             go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
+      - name: Cache gradle
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.global-cache-dir-path.outputs.gradle }}
+          key: gradle-${{ runner.os }}-integration
+          restore-keys: gradle-${{ runner.os }}-
       - name: Download dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -171,6 +179,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=7168"
           TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
           GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
+          GRADLE_USER_HOME: ${{ steps.global-cache-dir-path.outputs.gradle }}
 
   windows_integration:
     needs: prepare-integration-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -155,7 +155,10 @@ jobs:
       - name: Cache gradle
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          path: ${{ steps.global-cache-dir-path.outputs.gradle }}
+          # Skip daemon/, notifications/, native/ — only the distribution + module jars are worth keeping
+          path: |
+            ${{ steps.global-cache-dir-path.outputs.gradle }}/caches/modules-2
+            ${{ steps.global-cache-dir-path.outputs.gradle }}/wrapper/dists
           key: gradle-${{ runner.os }}-integration
           restore-keys: gradle-${{ runner.os }}-
       - name: Download dist


### PR DESCRIPTION
### Description

The CI is intermittently failing with 502 errors downloading Gradle for the Java tests. Example: https://github.com/open-constructs/cdk-terrain/actions/runs/26368817116/job/77619233680#step:12:1157.

To reduce the occurrences of this, this PR adds gradle caching to the examples and integration CI workflows, following the same pattern as the Go cache.

The cache paths include:
- `wrapper/dists/` - unpacked Gradle distributions
- `caches/modules-2/` - downloaded Maven/JCenter artifact jars and metadata

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
