### PR TITLE
chore: prepare v0.23.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## 0.23.2
+
+### chore
+- chore: Update npm version to support OIDC trusted publishing [\#205](https://github.com/open-constructs/cdk-terrain/pull/205)
+- chore: Fix publib running to use npx rather than yarn [\#203](https://github.com/open-constructs/cdk-terrain/pull/203)
+- chore(tests): Add test for Node type stripping [\#198](https://github.com/open-constructs/cdk-terrain/pull/198)
+- chore(gha): Enable NPM OIDC Publishing [\#195](https://github.com/open-constructs/cdk-terrain/pull/195)
+- chore: remove mention of Hashicorp support [\#193](https://github.com/open-constructs/cdk-terrain/pull/193)
+- chore: consolidate release workflows for npm OIDC [\#192](https://github.com/open-constructs/cdk-terrain/pull/192)
+- chore: tell users to search for cdktn on npm [\#185](https://github.com/open-constructs/cdk-terrain/pull/185)
+- chore: replace cdk.tf/modules-and-providers links [\#184](https://github.com/open-constructs/cdk-terrain/pull/184)
+- chore: fix references to cdktf in TS examples [\#183](https://github.com/open-constructs/cdk-terrain/pull/183)
+- chore: point to correct docs repo [\#181](https://github.com/open-constructs/cdk-terrain/pull/181)
+- chore: delete Vercel config for cdk.tf site [\#180](https://github.com/open-constructs/cdk-terrain/pull/180)
+- chore(gha): optimise integration & provider-integration CI pipelines [\#178](https://github.com/open-constructs/cdk-terrain/pull/178)
+- chore(gha): optimise examples CI pipeline [\#175](https://github.com/open-constructs/cdk-terrain/pull/175)
+- chore: migrate jest to @nx/jest plugin with swc-jest [\#160](https://github.com/open-constructs/cdk-terrain/pull/160)
+- chore: replace yazl with fflate [\#148](https://github.com/open-constructs/cdk-terrain/pull/148)
+- chore(lib): Move cdktn package to src/ and lib/ layout [\#145](https://github.com/open-constructs/cdk-terrain/pull/145)
+- chore: Consolidate PR CI into tiered orchestrator workflow [\#143](https://github.com/open-constructs/cdk-terrain/pull/143)
+
+### fix
+
+- fix(gha): Need to grant permission on workflow call job [\#196](https://github.com/open-constructs/cdk-terrain/pull/196)
+- fix(cli): Fix input getting split between cdktn and Terraform [\#191](https://github.com/open-constructs/cdk-terrain/pull/191)
+- fix(cli): restore non-bundled dependencies [\#190](https://github.com/open-constructs/cdk-terrain/pull/190)
+- fix: Configurable dist artifact name to fix release workflows [\#189](https://github.com/open-constructs/cdk-terrain/pull/189)
+- fix(tests): pass --no-compile to pip in python integration tests [\#188](https://github.com/open-constructs/cdk-terrain/pull/188)
+- fix(cli): pass languageOptions to `get` [\#179](https://github.com/open-constructs/cdk-terrain/pull/179)
+- fix(provider-generator): add missing semicolons [\#177](https://github.com/open-constructs/cdk-terrain/pull/177)
+
+### feat
+
+- feat(provider-generator): configurable import extensions [\#151](https://github.com/open-constructs/cdk-terrain/pull/151)
+
 ## 0.23.1
 
 ### fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.23.2
 
 ### chore
+
 - chore: Update npm version to support OIDC trusted publishing [\#205](https://github.com/open-constructs/cdk-terrain/pull/205)
 - chore: Fix publib running to use npx rather than yarn [\#203](https://github.com/open-constructs/cdk-terrain/pull/203)
 - chore(tests): Add test for Node type stripping [\#198](https://github.com/open-constructs/cdk-terrain/pull/198)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "0.23.1",
+    "version": "0.23.2",
     "private": true,
     "scripts": {
         "build-and-package": "lerna run --scope 'cdktn*' --scope @cdktn/* build,package && tools/collect-dist.sh",


### PR DESCRIPTION
## 0.23.2

### chore
- chore: Update npm version to support OIDC trusted publishing [\#205](https://github.com/open-constructs/cdk-terrain/pull/205)
- chore: Fix publib running to use npx rather than yarn [\#203](https://github.com/open-constructs/cdk-terrain/pull/203)
- chore(tests): Add test for Node type stripping [\#198](https://github.com/open-constructs/cdk-terrain/pull/198)
- chore(gha): Enable NPM OIDC Publishing [\#195](https://github.com/open-constructs/cdk-terrain/pull/195)
- chore: remove mention of Hashicorp support [\#193](https://github.com/open-constructs/cdk-terrain/pull/193)
- chore: consolidate release workflows for npm OIDC [\#192](https://github.com/open-constructs/cdk-terrain/pull/192)
- chore: tell users to search for cdktn on npm [\#185](https://github.com/open-constructs/cdk-terrain/pull/185)
- chore: replace cdk.tf/modules-and-providers links [\#184](https://github.com/open-constructs/cdk-terrain/pull/184)
- chore: fix references to cdktf in TS examples [\#183](https://github.com/open-constructs/cdk-terrain/pull/183)
- chore: point to correct docs repo [\#181](https://github.com/open-constructs/cdk-terrain/pull/181)
- chore: delete Vercel config for cdk.tf site [\#180](https://github.com/open-constructs/cdk-terrain/pull/180)
- chore(gha): optimise integration & provider-integration CI pipelines [\#178](https://github.com/open-constructs/cdk-terrain/pull/178)
- chore(gha): optimise examples CI pipeline [\#175](https://github.com/open-constructs/cdk-terrain/pull/175)
- chore: migrate jest to @nx/jest plugin with swc-jest [\#160](https://github.com/open-constructs/cdk-terrain/pull/160)
- chore: replace yazl with fflate [\#148](https://github.com/open-constructs/cdk-terrain/pull/148)
- chore(lib): Move cdktn package to src/ and lib/ layout [\#145](https://github.com/open-constructs/cdk-terrain/pull/145)
- chore: Consolidate PR CI into tiered orchestrator workflow [\#143](https://github.com/open-constructs/cdk-terrain/pull/143)

### fix

- fix(gha): Need to grant permission on workflow call job [\#196](https://github.com/open-constructs/cdk-terrain/pull/196)
- fix(cli): Fix input getting split between cdktn and Terraform [\#191](https://github.com/open-constructs/cdk-terrain/pull/191)
- fix(cli): restore non-bundled dependencies [\#190](https://github.com/open-constructs/cdk-terrain/pull/190)
- fix: Configurable dist artifact name to fix release workflows [\#189](https://github.com/open-constructs/cdk-terrain/pull/189)
- fix(tests): pass --no-compile to pip in python integration tests [\#188](https://github.com/open-constructs/cdk-terrain/pull/188)
- fix(cli): pass languageOptions to `get` [\#179](https://github.com/open-constructs/cdk-terrain/pull/179)
- fix(provider-generator): add missing semicolons [\#177](https://github.com/open-constructs/cdk-terrain/pull/177)

### feat

- feat(provider-generator): configurable import extensions [\#151](https://github.com/open-constructs/cdk-terrain/pull/151)
