### PR TITLE
feat(lib): allow disabling creation stacks

### DIFF
--- a/packages/cdktn/src/complex-computed-list.ts
+++ b/packages/cdktn/src/complex-computed-list.ts
@@ -11,7 +11,7 @@ import {
   TerraformIterator,
   DynamicListTerraformIterator,
 } from ".";
-import { captureStackTrace } from "./tokens/private/stack-trace";
+import { captureCreationStack } from "./tokens/private/stack-trace";
 import { providerVersionMismatch } from "./errors";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
@@ -27,7 +27,7 @@ abstract class ComplexResolvable implements IResolvable, ITerraformAddressable {
     protected terraformResource: IInterpolatingParent,
     protected terraformAttribute: string,
   ) {
-    this.creationStack = captureStackTrace();
+    this.creationStack = captureCreationStack();
   }
 
   abstract computeFqn(): string;

--- a/packages/cdktn/src/errors.ts
+++ b/packages/cdktn/src/errors.ts
@@ -446,16 +446,15 @@ export const indexTooLargeToEncode = (index: number) =>
 
 export const argToIntrinsicMustBePlainValue = (
   value: any,
-  creationStack: string[],
-) =>
-  new Error(
-    `You can only use a plain value (not a function) while creating an Intrinsic token. We received the value '${value}' created at:\n${creationStack.join(
-      "\n",
-    )}. If you want to use a function, please use the Lazy class. For example:  Lazy.anyValue({ produce: () => "Hello World" }).`,
+  creationStack: string[] | undefined,
+) => {
+  const createdAt = creationStack?.length
+    ? ` created at:\n${creationStack.join("\n")}`
+    : "";
+  return new Error(
+    `You can only use a plain value (not a function) while creating an Intrinsic token. We received the value '${value}'${createdAt}. If you want to use a function, please use the Lazy class. For example:  Lazy.anyValue({ produce: () => "Hello World" }).`,
   );
-
-export const intrinsicNewError = (message: string, createdAt: string) =>
-  new Error(`${message}\nToken created:\n    at ${createdAt}\nError thrown:`);
+};
 
 export const unableToResolveCircularReference = (pathName: string) =>
   new Error(`Unable to resolve object tree with circular reference at '${pathName}'.

--- a/packages/cdktn/src/terraform-dynamic-block.ts
+++ b/packages/cdktn/src/terraform-dynamic-block.ts
@@ -4,7 +4,7 @@ import { dynamicBlockNotSupported } from "./errors";
 import { TerraformDynamicExpression } from "./terraform-dynamic-expression";
 import { ITerraformIterator } from "./terraform-iterator";
 import { IResolvable, IResolveContext, Lazy, Token } from "./tokens";
-import { captureStackTrace } from "./tokens/private/stack-trace";
+import { captureCreationStack } from "./tokens/private/stack-trace";
 
 const DYNAMIC_BLOCK_SYMBOL = Symbol.for("cdktf/TerraformDynamicBlock");
 
@@ -21,7 +21,7 @@ export class TerraformDynamicBlock implements IResolvable {
     content: { [key: string]: any };
   }) {
     Object.defineProperty(this, DYNAMIC_BLOCK_SYMBOL, { value: true });
-    this.creationStack = captureStackTrace();
+    this.creationStack = captureCreationStack();
     this.forEach = args.forEach;
     this.content = args.content;
   }

--- a/packages/cdktn/src/terraform-dynamic-expression.ts
+++ b/packages/cdktn/src/terraform-dynamic-expression.ts
@@ -3,7 +3,7 @@
 import { ITerraformIterator } from "./terraform-iterator";
 import { forExpression } from ".";
 import { IResolvable, Lazy, Token } from "./tokens";
-import { captureStackTrace } from "./tokens/private/stack-trace";
+import { captureCreationStack } from "./tokens/private/stack-trace";
 
 const DYNAMIC_EXPRESSION_SYMBOL = Symbol.for(
   "cdktf/TerraformDynamicExpression",
@@ -29,7 +29,7 @@ export class TerraformDynamicExpression implements IResolvable {
     content: { [key: string]: any };
   }) {
     Object.defineProperty(this, DYNAMIC_EXPRESSION_SYMBOL, { value: true });
-    this.creationStack = captureStackTrace();
+    this.creationStack = captureCreationStack();
     this.iterator = args.iterator;
     this.content = args.content;
   }

--- a/packages/cdktn/src/tokens/lazy.ts
+++ b/packages/cdktn/src/tokens/lazy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 // Copied from https://github.com/aws/constructs/blob/e01e47f78ef1e9b600efcd23ff7705aa8d384017/lib/lazy.ts
-import { captureStackTrace } from "./private/stack-trace";
+import { captureCreationStack } from "./private/stack-trace";
 import { IPostProcessor, IResolvable, IResolveContext } from "./resolvable";
 import { Token } from "./token";
 
@@ -153,7 +153,7 @@ export abstract class LazyBase implements IResolvable {
   private postProcessors: IPostProcessor[] = [];
 
   constructor() {
-    this.creationStack = captureStackTrace();
+    this.creationStack = captureCreationStack();
   }
 
   public resolve(context: IResolveContext): any {

--- a/packages/cdktn/src/tokens/private/intrinsic.ts
+++ b/packages/cdktn/src/tokens/private/intrinsic.ts
@@ -1,13 +1,10 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 // copied from https://github.com/aws/constructs/blob/e01e47f78ef1e9b600efcd23ff7705aa8d384017/lib/private/intrinsic.ts
-import {
-  argToIntrinsicMustBePlainValue,
-  intrinsicNewError,
-} from "../../errors";
+import { argToIntrinsicMustBePlainValue } from "../../errors";
 import { IResolvable, IResolveContext } from "../resolvable";
 import { Token } from "../token";
-import { captureStackTrace } from "./stack-trace";
+import { captureCreationStack } from "./stack-trace";
 
 /**
  * Token subclass that represents values intrinsic to the target document language
@@ -29,7 +26,7 @@ export class Intrinsic implements IResolvable {
   private readonly value: any;
 
   constructor(value: any) {
-    this.creationStack = captureStackTrace();
+    this.creationStack = captureCreationStack();
     if (isFunction(value)) {
       throw argToIntrinsicMustBePlainValue(value, this.creationStack);
     }
@@ -69,14 +66,6 @@ export class Intrinsic implements IResolvable {
     // So return a string representation that indicates this thing is a token
     // and needs resolving.
     return `<unresolved-token>`;
-  }
-
-  /**
-   * Creates a throwable Error object that contains the token creation stack trace.
-   * @param message Error message
-   */
-  protected newError(message: string): any {
-    return intrinsicNewError(message, this.creationStack.join("\n    at "));
   }
 }
 

--- a/packages/cdktn/src/tokens/private/stack-trace.ts
+++ b/packages/cdktn/src/tokens/private/stack-trace.ts
@@ -24,3 +24,16 @@ export function captureStackTrace(below?: Function): string[] {
     .slice(1)
     .map((s) => s.replace(/^\s*at\s+/, ""));
 }
+
+/**
+ * Captures a stack trace for a resolvable's `creationStack`, unless disabled
+ * via the `CDKTN_DISABLE_CREATION_STACK` env var. When disabled, returns `[]`
+ * to skip the (expensive) `Error.captureStackTrace` call.
+ */
+export function captureCreationStack(): string[] {
+  const flag = process.env.CDKTN_DISABLE_CREATION_STACK;
+  if (flag === "true" || flag === "1") {
+    return [];
+  }
+  return captureStackTrace(captureCreationStack);
+}

--- a/packages/cdktn/src/tokens/resolvable.ts
+++ b/packages/cdktn/src/tokens/resolvable.ts
@@ -200,7 +200,7 @@ export class DefaultTokenResolver implements ITokenResolver {
     } catch (e) {
       const err = e as any;
       let message = `Resolution error: ${err.message}.`;
-      if (t.creationStack && t.creationStack.length > 0) {
+      if (t.creationStack?.length) {
         message += `\nObject creation stack:\n  at ${t.creationStack.join(
           "\n  at ",
         )}`;

--- a/packages/cdktn/test/stack-trace.test.ts
+++ b/packages/cdktn/test/stack-trace.test.ts
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { Lazy } from "../src";
+import {
+  captureCreationStack,
+  captureStackTrace,
+} from "../src/tokens/private/stack-trace";
+
+const ENV_VAR = "CDKTN_DISABLE_CREATION_STACK";
+
+describe("captureCreationStack", () => {
+  let previous: string | undefined;
+
+  beforeEach(() => {
+    previous = process.env[ENV_VAR];
+    delete process.env[ENV_VAR];
+  });
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env[ENV_VAR];
+    } else {
+      process.env[ENV_VAR] = previous;
+    }
+  });
+
+  test("returns a non-empty stack when env var is unset", () => {
+    const stack = captureCreationStack();
+    expect(stack.length).toBeGreaterThan(0);
+  });
+
+  test("returns [] when env var is 'true'", () => {
+    process.env[ENV_VAR] = "true";
+    expect(captureCreationStack()).toEqual([]);
+  });
+
+  test("returns [] when env var is '1'", () => {
+    process.env[ENV_VAR] = "1";
+    expect(captureCreationStack()).toEqual([]);
+  });
+
+  test("returns a non-empty stack for other values like 'false' or '0'", () => {
+    process.env[ENV_VAR] = "false";
+    expect(captureCreationStack().length).toBeGreaterThan(0);
+
+    process.env[ENV_VAR] = "0";
+    expect(captureCreationStack().length).toBeGreaterThan(0);
+  });
+
+  test("does not affect captureStackTrace, which is general-purpose", () => {
+    process.env[ENV_VAR] = "true";
+    expect(captureStackTrace().length).toBeGreaterThan(0);
+  });
+
+  test("Lazy.anyValue.creationStack is [] when env var is set", () => {
+    process.env[ENV_VAR] = "true";
+    const lazy = Lazy.anyValue({ produce: () => 1 });
+    expect(lazy.creationStack).toEqual([]);
+  });
+
+  test("Lazy.anyValue.creationStack is populated when env var is unset", () => {
+    const lazy = Lazy.anyValue({ produce: () => 1 });
+    expect(lazy.creationStack.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Allow setting `CDKTN_DISABLE_CREATION_STACK` environment variable to disable capturing stack traces when constructing IResolvables.

Capturing stack traces is fairly slow in Node, so disabling them saves a lot of time when synthing large stacks.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #209

### Description

Don't capture stack traces if the `CDKTN_DISABLE_CREATION_STACK` env var is set.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
