### PR TITLE
feat(lib): add useLockfile to S3BackendConfig

### DIFF
--- a/packages/cdktn/src/backends/s3-backend.ts
+++ b/packages/cdktn/src/backends/s3-backend.ts
@@ -319,6 +319,20 @@ export interface S3BackendConfig {
    * This behavior does not align with the authentication flow of the AWS CLI or SDK's, and will be removed in the future.
    */
   readonly useLegacyWorkflow?: boolean;
+
+  /**
+   * Whether the backend should use S3-native state locking (Terraform 1.10+).
+   *
+   * When `true`, Terraform acquires a `<key>.tflock` object in the state bucket
+   * for the duration of state-modifying operations. This is the modern
+   * replacement for `dynamodbTable`, which is deprecated in Terraform 1.10+.
+   *
+   * When using this option, ensure your Terraform CLI is at least version 1.10.
+   *
+   * @default false
+   */
+  readonly useLockfile?: boolean;
+
   /**
    * (Optional) The endpoint configuration block.
    */

--- a/packages/cdktn/test/__snapshots__/backend.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/backend.test.ts.snap
@@ -275,3 +275,18 @@ exports[`s3 backend 1`] = `
   }
 }"
 `;
+
+exports[`s3 backend with use_lockfile 1`] = `
+"{
+  "terraform": {
+    "backend": {
+      "s3": {
+        "bucket": "mybucket",
+        "key": "path/to/my/key",
+        "region": "us-east-1",
+        "use_lockfile": true
+      }
+    }
+  }
+}"
+`;

--- a/packages/cdktn/test/backend.test.ts
+++ b/packages/cdktn/test/backend.test.ts
@@ -265,3 +265,17 @@ test("s3 backend", () => {
 
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
+
+test("s3 backend with use_lockfile", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new b.S3Backend(stack, {
+    bucket: "mybucket",
+    key: "path/to/my/key",
+    region: "us-east-1",
+    useLockfile: true,
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});


### PR DESCRIPTION


### Description

Terraform 1.10 (Dec 2024) deprecated the S3 backend's `dynamodb_table` argument
in favor of `use_lockfile = true`, which enables S3-native state locking via a
`<key>.tflock` object in the state bucket. `S3BackendConfig` was forked from
CDKTF before this feature existed, so the typed prop was missing — users had to
fall back to escape hatches to set it.

This PR adds an optional `useLockfile?: boolean` field to `S3BackendConfig`.
It's a pure pass-through to the rendered backend JSON (no validation,
no interaction with `dynamodbTable`), so users can combine or migrate at their
own pace. Defaults to `false` to preserve existing behavior.

Requires Terraform CLI ≥ 1.10 at apply time; documented in the JSDoc.

### Checklist

- [x] I have updated the PR title to match CDKTN's style guide
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
