### PR TITLE
feat: faster JSON stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,9 @@
             "fflate",
             "**/fflate",
             "**/fflate/**",
-            "json-stable-stringify",
-            "**/json-stable-stringify",
-            "**/json-stable-stringify/**",
+            "safe-stable-stringify",
+            "**/safe-stable-stringify",
+            "**/safe-stable-stringify/**",
             "semver",
             "**/semver",
             "**/semver/**"

--- a/packages/@cdktn/provider-schema/package.json
+++ b/packages/@cdktn/provider-schema/package.json
@@ -43,8 +43,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/json-stable-stringify": "1.2.0",
-    "json-stable-stringify": "1.3.0",
+    "safe-stable-stringify": "2.5.0",
     "tsc-files": "1.1.4",
     "typescript": "5.4.5"
   },

--- a/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
+++ b/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
@@ -42,8 +42,7 @@ exports[`readSchema generates a local module 1`] = `
         "type": "string"
       },
       {
-        "default": {
-        },
+        "default": {},
         "description": "Tags to set on the bucket.",
         "name": "tags",
         "required": false,
@@ -139,8 +138,7 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "string"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "A list of the desired control plane logging to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)",
         "name": "cluster_enabled_log_types",
         "required": false,
@@ -216,8 +214,7 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "string"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "Any additional arguments to pass to the authenticator such as the role to assume. e.g. [\\"-r\\", \\"MyEksRole\\"].",
         "name": "kubeconfig_aws_authenticator_additional_args",
         "required": false,
@@ -231,16 +228,14 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "string"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "Default arguments passed to the authenticator command. Defaults to [token -i $cluster_name].",
         "name": "kubeconfig_aws_authenticator_command_args",
         "required": false,
         "type": "list(string)"
       },
       {
-        "default": {
-        },
+        "default": {},
         "description": "Environment variables that should be used when executing the authenticator. e.g. { AWS_PROFILE = \\"eks\\"}.",
         "name": "kubeconfig_aws_authenticator_env_variables",
         "required": false,
@@ -292,24 +287,21 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "bool"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "Additional AWS account numbers to add to the aws-auth configmap. See examples/basic/variables.tf for example format.",
         "name": "map_accounts",
         "required": false,
         "type": "list(string)"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format.",
         "name": "map_roles",
         "required": false,
         "type": "any"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "Additional IAM users to add to the aws-auth configmap. See examples/basic/variables.tf for example format.",
         "name": "map_users",
         "required": false,
@@ -329,8 +321,7 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "list(string)"
       },
       {
-        "default": {
-        },
+        "default": {},
         "description": "A map of tags to add to all resources.",
         "name": "tags",
         "required": false,
@@ -343,8 +334,7 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "string"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "A list of additional security group ids to attach to worker instances",
         "name": "worker_additional_security_group_ids",
         "required": false,
@@ -393,16 +383,14 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "bool"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys.",
         "name": "worker_groups",
         "required": false,
         "type": "any"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "A list of maps defining worker group configurations to be defined using AWS Launch Templates. See workers_group_defaults for valid keys.",
         "name": "worker_groups_launch_template",
         "required": false,
@@ -423,16 +411,14 @@ exports[`readSchema generates a more complex schema 1`] = `
         "type": "number"
       },
       {
-        "default": [
-        ],
+        "default": [],
         "description": "Additional policies to be added to workers",
         "name": "workers_additional_policies",
         "required": false,
         "type": "list(string)"
       },
       {
-        "default": {
-        },
+        "default": {},
         "description": "Override default values for target groups. See workers_group_defaults_defaults in local.tf for valid keys.",
         "name": "workers_group_defaults",
         "required": false,

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 import * as path from "path";
-import stableStringify from "json-stable-stringify";
+import stableStringify from "safe-stable-stringify";
 import {
   TerraformModuleConstraint,
   TerraformProviderConstraint,
@@ -19,9 +19,7 @@ import {
 
 function sanitizeJson(value: any) {
   value["format_version"] = "STUBBED VERSION";
-  return stableStringify(value, {
-    space: 2,
-  });
+  return stableStringify(value, null, 2);
 }
 
 describe("readSchema", () => {

--- a/packages/cdktn/package.json
+++ b/packages/cdktn/package.json
@@ -77,7 +77,6 @@
     },
     "license": "MPL-2.0",
     "devDependencies": {
-        "@types/json-stable-stringify": "1.2.0",
         "@types/node": "18.19.130",
         "@types/semver": "7.7.1",
         "constructs": "10.6.0",
@@ -87,12 +86,12 @@
     },
     "dependencies": {
         "fflate": "0.8.2",
-        "json-stable-stringify": "1.3.0",
+        "safe-stable-stringify": "2.5.0",
         "semver": "7.7.4"
     },
     "bundledDependencies": [
         "fflate",
-        "json-stable-stringify",
+        "safe-stable-stringify",
         "semver"
     ],
     "stability": "experimental",

--- a/packages/cdktn/src/manifest.ts
+++ b/packages/cdktn/src/manifest.ts
@@ -4,8 +4,7 @@ import * as path from "path";
 import * as fs from "fs";
 import { TerraformStack } from "./terraform-stack";
 import { AnnotationMetadataEntryType } from "./annotations";
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import stringify = require("json-stable-stringify");
+import stringify from "safe-stable-stringify";
 
 export interface StackAnnotation {
   readonly constructPath: string;
@@ -89,7 +88,7 @@ export class Manifest implements IManifest {
   public writeToFile() {
     fs.writeFileSync(
       path.join(this.outdir, Manifest.fileName),
-      stringify(this.buildManifest(), { space: 2 }) as string,
+      stringify(this.buildManifest(), null, 2) as string,
     );
   }
 }

--- a/packages/cdktn/src/synthesize/synthesizer.ts
+++ b/packages/cdktn/src/synthesize/synthesizer.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import * as path from "path";
 import * as fs from "fs";
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-import stringify = require("json-stable-stringify");
+import stringify from "safe-stable-stringify";
 import { TerraformStack } from "../terraform-stack";
 import { IStackSynthesizer, ISynthesisSession } from "./types";
 import { AnnotationMetadataEntryType, Annotations } from "../annotations";
@@ -99,7 +98,7 @@ export class StackSynthesizer implements IStackSynthesizer {
 
       fs.writeFileSync(
         path.join(session.outdir, stackManifest.stackMetadataPath!),
-        stringify(hcl.metadata, { space: 2 }) as string,
+        stringify(hcl.metadata, null, 2) as string,
       );
 
       return;
@@ -109,7 +108,7 @@ export class StackSynthesizer implements IStackSynthesizer {
 
     fs.writeFileSync(
       path.join(session.outdir, stackManifest.synthesizedStackPath),
-      stringify(jsonTfConfig, { space: 2 }) as string,
+      stringify(jsonTfConfig, null, 2) as string,
     );
   }
 }

--- a/packages/cdktn/src/testing/index.ts
+++ b/packages/cdktn/src/testing/index.ts
@@ -1,11 +1,11 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 
-/* eslint-disable @typescript-eslint/no-require-imports */
-import fs = require("fs");
-import path = require("path");
-import os = require("os");
-import stringify = require("json-stable-stringify");
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+import stringify from "safe-stable-stringify";
 import { App, TerraformStack } from "..";
 import { Manifest } from "../manifest";
 import { FUTURE_FLAGS } from "../features";
@@ -135,7 +135,7 @@ export class Testing {
     }
     const cleaned = removeMetadata(tfConfig);
 
-    return stringify(cleaned, { space: 2 }) as string;
+    return stringify(cleaned, null, 2) as string;
   }
 
   /**

--- a/packages/cdktn/test/__snapshots__/data-source.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/data-source.test.ts.snap
@@ -14,8 +14,7 @@ exports[`dependent data source 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -46,8 +45,7 @@ exports[`minimal configuration 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
@@ -71,8 +69,7 @@ exports[`with any map 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -103,8 +100,7 @@ exports[`with boolean map 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -135,8 +131,7 @@ exports[`with complex computed list 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -167,8 +162,7 @@ exports[`with number map 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -199,8 +193,7 @@ exports[`with string map 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -231,8 +224,7 @@ exports[`with string map map - lookup returns StringMap reference 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -263,8 +255,7 @@ exports[`with string map map - nested lookup produces correct reference 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {

--- a/packages/cdktn/test/__snapshots__/local.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/local.test.ts.snap
@@ -15,8 +15,7 @@ exports[`local reference 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {

--- a/packages/cdktn/test/__snapshots__/output.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/output.test.ts.snap
@@ -22,8 +22,7 @@ exports[`dependent output 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -63,8 +62,7 @@ exports[`expression output 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -93,8 +91,7 @@ exports[`full resource output 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -161,8 +158,7 @@ exports[`resource map output 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -194,8 +190,7 @@ exports[`resource[] output 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -257,8 +252,7 @@ exports[`variable output 1`] = `
     }
   },
   "variable": {
-    "test-variable": {
-    }
+    "test-variable": {}
   }
 }"
 `;

--- a/packages/cdktn/test/__snapshots__/provider.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/provider.test.ts.snap
@@ -71,8 +71,7 @@ exports[`with generator metadata 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {

--- a/packages/cdktn/test/__snapshots__/remote-state.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/remote-state.test.ts.snap
@@ -256,8 +256,7 @@ exports[`s3 reference 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {

--- a/packages/cdktn/test/__snapshots__/resource.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/resource.test.ts.snap
@@ -11,8 +11,7 @@ exports[`dependent resource 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -39,8 +38,7 @@ exports[`do not change capitalization of arbritary nested types 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -67,8 +65,7 @@ exports[`do not change capitalization of tags 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -101,8 +98,7 @@ exports[`includes import block when import is present 1`] = `
   ],
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -159,8 +155,7 @@ exports[`maintains the same order of provisioner 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -201,8 +196,7 @@ exports[`minimal configuration 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -231,8 +225,7 @@ exports[`number[] attributes 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -261,8 +254,7 @@ exports[`numeric attributes 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -313,18 +305,15 @@ exports[`serialize list interpolation 1`] = `
 "{
   "provider": {
     "other": [
-      {
-      }
+      {}
     ],
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
     "other_test_resource": {
-      "othertest": {
-      }
+      "othertest": {}
     },
     "test_resource": {
       "test": {
@@ -350,8 +339,7 @@ exports[`supports file provisioner 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -394,8 +382,7 @@ exports[`supports local-exec provisioner 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -444,8 +431,7 @@ exports[`supports resource and attribute references in lifecycle.replaceTriggere
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -478,18 +464,15 @@ exports[`with complex computed list 1`] = `
 "{
   "provider": {
     "other": [
-      {
-      }
+      {}
     ],
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
     "other_test_resource": {
-      "othertest": {
-      }
+      "othertest": {}
     },
     "test_resource": {
       "test": {

--- a/packages/cdktn/test/__snapshots__/terraform-hcl-module.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/terraform-hcl-module.test.ts.snap
@@ -76,8 +76,7 @@ exports[`depend on module 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -187,8 +186,7 @@ exports[`reference module 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -217,8 +215,7 @@ exports[`reference module list 1`] = `
   },
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {

--- a/packages/cdktn/test/__snapshots__/terraform-provisioner.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/terraform-provisioner.test.ts.snap
@@ -4,8 +4,7 @@ exports[`self with nested keys 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {

--- a/packages/cdktn/test/__snapshots__/variable.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/variable.test.ts.snap
@@ -99,8 +99,7 @@ exports[`reference 1`] = `
 "{
   "provider": {
     "test": [
-      {
-      }
+      {}
     ]
   },
   "resource": {

--- a/packages/cdktn/test/manifest.test.ts
+++ b/packages/cdktn/test/manifest.test.ts
@@ -54,22 +54,20 @@ test("write manifest", () => {
 
   expect(fs.readFileSync(path.join(outdir, Manifest.fileName)).toString())
     .toMatchInlineSnapshot(`
-    "{
-      "stacks": {
-        "this-is-a-stack": {
-          "annotations": [
-          ],
-          "constructPath": "this-is-a-stack",
-          "dependencies": [
-          ],
-          "name": "this-is-a-stack",
-          "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
-          "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
-          "workingDirectory": "stacks/this-is-a-stack"
-        }
-      },
-      "version": "0.0.0"
-    }"
+   "{
+     "stacks": {
+       "this-is-a-stack": {
+         "annotations": [],
+         "constructPath": "this-is-a-stack",
+         "dependencies": [],
+         "name": "this-is-a-stack",
+         "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
+         "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
+         "workingDirectory": "stacks/this-is-a-stack"
+       }
+     },
+     "version": "0.0.0"
+   }"
   `);
 });
 
@@ -91,37 +89,36 @@ describe("manifest annotations", () => {
 
     expect(fs.readFileSync(path.join(outdir, Manifest.fileName)).toString())
       .toMatchInlineSnapshot(`
-      "{
-        "stacks": {
-          "this-is-a-stack": {
-            "annotations": [
-              {
-                "constructPath": "this-is-a-stack",
-                "level": "@cdktf/info",
-                "message": "an info"
-              },
-              {
-                "constructPath": "this-is-a-stack",
-                "level": "@cdktf/warn",
-                "message": "a warning"
-              },
-              {
-                "constructPath": "this-is-a-stack",
-                "level": "@cdktf/error",
-                "message": "an error"
-              }
-            ],
-            "constructPath": "this-is-a-stack",
-            "dependencies": [
-            ],
-            "name": "this-is-a-stack",
-            "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
-            "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
-            "workingDirectory": "stacks/this-is-a-stack"
-          }
-        },
-        "version": "stubbed"
-      }"
+     "{
+       "stacks": {
+         "this-is-a-stack": {
+           "annotations": [
+             {
+               "constructPath": "this-is-a-stack",
+               "level": "@cdktf/info",
+               "message": "an info"
+             },
+             {
+               "constructPath": "this-is-a-stack",
+               "level": "@cdktf/warn",
+               "message": "a warning"
+             },
+             {
+               "constructPath": "this-is-a-stack",
+               "level": "@cdktf/error",
+               "message": "an error"
+             }
+           ],
+           "constructPath": "this-is-a-stack",
+           "dependencies": [],
+           "name": "this-is-a-stack",
+           "stackMetadataPath": "stacks/this-is-a-stack/metadata.json",
+           "synthesizedStackPath": "stacks/this-is-a-stack/cdk.tf.json",
+           "workingDirectory": "stacks/this-is-a-stack"
+         }
+       },
+       "version": "stubbed"
+     }"
     `);
   });
 });

--- a/test/python/cross-stack-references/test.ts
+++ b/test/python/cross-stack-references/test.ts
@@ -22,8 +22,7 @@ describe("python cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "source"
@@ -34,8 +33,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "source"
@@ -46,8 +44,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/functionOutput"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "source"
@@ -58,8 +55,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/passthrough"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "source"
@@ -70,11 +66,9 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/sink"
           },
           "source": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "source",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "source",
             "stackMetadataPath": "stacks/source/metadata.json",
             "synthesizedStackPath": "stacks/source/cdk.tf.json",
@@ -91,8 +85,7 @@ describe("python cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "source"
@@ -103,8 +96,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "source"
@@ -115,8 +107,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/functionOutput"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "source"
@@ -127,8 +118,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/passthrough"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "source"
@@ -139,11 +129,9 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks/sink"
           },
           "source": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "source",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "source",
             "stackMetadataPath": "stacks/source/metadata.json",
             "synthesizedStackPath": "stacks/source/cdk.tf",
@@ -160,8 +148,7 @@ describe("python cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "source"
@@ -172,8 +159,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "source"
@@ -184,8 +170,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\functionOutput"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "source"
@@ -196,8 +181,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\passthrough"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "source"
@@ -208,11 +192,9 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\sink"
           },
           "source": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "source",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "source",
             "stackMetadataPath": "stacks\\\\source\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\source\\\\cdk.tf.json",
@@ -229,8 +211,7 @@ describe("python cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "source"
@@ -241,8 +222,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "source"
@@ -253,8 +233,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\functionOutput"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "source"
@@ -265,8 +244,7 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\passthrough"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "source"
@@ -277,11 +255,9 @@ describe("python cross stack references", () => {
             "workingDirectory": "stacks\\\\sink"
           },
           "source": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "source",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "source",
             "stackMetadataPath": "stacks\\\\source\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\source\\\\cdk.tf",

--- a/test/typescript/cross-stack-references/test.ts
+++ b/test/typescript/cross-stack-references/test.ts
@@ -22,8 +22,7 @@ describe("cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "origin"
@@ -34,8 +33,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "origin"
@@ -46,8 +44,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/functionOutput"
           },
           "functionOutputPinned": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutputPinned",
             "dependencies": [
               "pinnedFns"
@@ -58,19 +55,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/functionOutputPinned"
           },
           "origin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "origin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "origin",
             "stackMetadataPath": "stacks/origin/metadata.json",
             "synthesizedStackPath": "stacks/origin/cdk.tf.json",
             "workingDirectory": "stacks/origin"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "origin"
@@ -81,8 +75,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/passthrough"
           },
           "pinnedFns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "pinnedFns",
             "dependencies": [
               "origin"
@@ -93,19 +86,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/pinnedFns"
           },
           "secondOrigin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "secondOrigin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "secondOrigin",
             "stackMetadataPath": "stacks/secondOrigin/metadata.json",
             "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
             "workingDirectory": "stacks/secondOrigin"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "origin"
@@ -116,11 +106,9 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/sink"
           },
           "switchedStack": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "switchedStack",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "switchedStack",
             "stackMetadataPath": "stacks/switchedStack/metadata.json",
             "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
@@ -137,8 +125,7 @@ describe("cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "origin"
@@ -149,8 +136,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "origin"
@@ -161,8 +147,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/functionOutput"
           },
           "functionOutputPinned": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutputPinned",
             "dependencies": [
               "pinnedFns"
@@ -173,19 +158,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/functionOutputPinned"
           },
           "origin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "origin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "origin",
             "stackMetadataPath": "stacks/origin/metadata.json",
             "synthesizedStackPath": "stacks/origin/cdk.tf",
             "workingDirectory": "stacks/origin"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "origin"
@@ -196,8 +178,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/passthrough"
           },
           "pinnedFns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "pinnedFns",
             "dependencies": [
               "origin"
@@ -208,19 +189,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/pinnedFns"
           },
           "secondOrigin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "secondOrigin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "secondOrigin",
             "stackMetadataPath": "stacks/secondOrigin/metadata.json",
             "synthesizedStackPath": "stacks/secondOrigin/cdk.tf",
             "workingDirectory": "stacks/secondOrigin"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "origin"
@@ -231,11 +209,9 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks/sink"
           },
           "switchedStack": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "switchedStack",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "switchedStack",
             "stackMetadataPath": "stacks/switchedStack/metadata.json",
             "synthesizedStackPath": "stacks/switchedStack/cdk.tf",
@@ -252,8 +228,7 @@ describe("cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "origin"
@@ -264,8 +239,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "origin"
@@ -276,8 +250,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\functionOutput"
           },
           "functionOutputPinned": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutputPinned",
             "dependencies": [
               "pinnedFns"
@@ -288,19 +261,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\functionOutputPinned"
           },
           "origin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "origin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "origin",
             "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
             "workingDirectory": "stacks\\\\origin"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "origin"
@@ -311,8 +281,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\passthrough"
           },
           "pinnedFns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "pinnedFns",
             "dependencies": [
               "origin"
@@ -323,19 +292,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\pinnedFns"
           },
           "secondOrigin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "secondOrigin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "secondOrigin",
             "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf.json",
             "workingDirectory": "stacks\\\\secondOrigin"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "origin"
@@ -346,11 +312,9 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\sink"
           },
           "switchedStack": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "switchedStack",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "switchedStack",
             "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf.json",
@@ -367,8 +331,7 @@ describe("cross stack references", () => {
       "{
         "stacks": {
           "fns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "fns",
             "dependencies": [
               "origin"
@@ -379,8 +342,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\fns"
           },
           "functionOutput": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutput",
             "dependencies": [
               "origin"
@@ -391,8 +353,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\functionOutput"
           },
           "functionOutputPinned": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "functionOutputPinned",
             "dependencies": [
               "pinnedFns"
@@ -403,19 +364,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\functionOutputPinned"
           },
           "origin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "origin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "origin",
             "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf",
             "workingDirectory": "stacks\\\\origin"
           },
           "passthrough": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "passthrough",
             "dependencies": [
               "origin"
@@ -426,8 +384,7 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\passthrough"
           },
           "pinnedFns": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "pinnedFns",
             "dependencies": [
               "origin"
@@ -438,19 +395,16 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\pinnedFns"
           },
           "secondOrigin": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "secondOrigin",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "secondOrigin",
             "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf",
             "workingDirectory": "stacks\\\\secondOrigin"
           },
           "sink": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "sink",
             "dependencies": [
               "origin"
@@ -461,11 +415,9 @@ describe("cross stack references", () => {
             "workingDirectory": "stacks\\\\sink"
           },
           "switchedStack": {
-            "annotations": [
-            ],
+            "annotations": [],
             "constructPath": "switchedStack",
-            "dependencies": [
-            ],
+            "dependencies": [],
             "name": "switchedStack",
             "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
             "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf",
@@ -554,8 +506,7 @@ describe("cross stack references", () => {
           "{
             "stacks": {
               "fns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "fns",
                 "dependencies": [
                   "origin"
@@ -566,8 +517,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/fns"
               },
               "functionOutput": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutput",
                 "dependencies": [
                   "origin"
@@ -578,8 +528,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/functionOutput"
               },
               "functionOutputPinned": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutputPinned",
                 "dependencies": [
                   "pinnedFns"
@@ -590,19 +539,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/functionOutputPinned"
               },
               "origin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "origin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "origin",
                 "stackMetadataPath": "stacks/origin/metadata.json",
                 "synthesizedStackPath": "stacks/origin/cdk.tf.json",
                 "workingDirectory": "stacks/origin"
               },
               "passthrough": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "passthrough",
                 "dependencies": [
                   "origin"
@@ -613,8 +559,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/passthrough"
               },
               "pinnedFns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "pinnedFns",
                 "dependencies": [
                   "origin"
@@ -625,19 +570,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/pinnedFns"
               },
               "secondOrigin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "secondOrigin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "secondOrigin",
                 "stackMetadataPath": "stacks/secondOrigin/metadata.json",
                 "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
                 "workingDirectory": "stacks/secondOrigin"
               },
               "sink": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "sink",
                 "dependencies": [
                   "origin"
@@ -648,8 +590,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/sink"
               },
               "switchedStack": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "switchedStack",
                 "dependencies": [
                   "secondOrigin"
@@ -670,8 +611,7 @@ describe("cross stack references", () => {
           "{
             "stacks": {
               "fns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "fns",
                 "dependencies": [
                   "origin"
@@ -682,8 +622,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/fns"
               },
               "functionOutput": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutput",
                 "dependencies": [
                   "origin"
@@ -694,8 +633,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/functionOutput"
               },
               "functionOutputPinned": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutputPinned",
                 "dependencies": [
                   "pinnedFns"
@@ -706,19 +644,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/functionOutputPinned"
               },
               "origin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "origin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "origin",
                 "stackMetadataPath": "stacks/origin/metadata.json",
                 "synthesizedStackPath": "stacks/origin/cdk.tf.json",
                 "workingDirectory": "stacks/origin"
               },
               "passthrough": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "passthrough",
                 "dependencies": [
                   "origin"
@@ -729,8 +664,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/passthrough"
               },
               "pinnedFns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "pinnedFns",
                 "dependencies": [
                   "origin"
@@ -741,19 +675,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/pinnedFns"
               },
               "secondOrigin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "secondOrigin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "secondOrigin",
                 "stackMetadataPath": "stacks/secondOrigin/metadata.json",
                 "synthesizedStackPath": "stacks/secondOrigin/cdk.tf.json",
                 "workingDirectory": "stacks/secondOrigin"
               },
               "sink": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "sink",
                 "dependencies": [
                   "origin"
@@ -764,11 +695,9 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks/sink"
               },
               "switchedStack": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "switchedStack",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "switchedStack",
                 "stackMetadataPath": "stacks/switchedStack/metadata.json",
                 "synthesizedStackPath": "stacks/switchedStack/cdk.tf.json",
@@ -792,8 +721,7 @@ describe("cross stack references", () => {
           "{
             "stacks": {
               "fns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "fns",
                 "dependencies": [
                   "origin"
@@ -804,8 +732,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\fns"
               },
               "functionOutput": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutput",
                 "dependencies": [
                   "origin"
@@ -816,8 +743,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\functionOutput"
               },
               "functionOutputPinned": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutputPinned",
                 "dependencies": [
                   "pinnedFns"
@@ -828,19 +754,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\functionOutputPinned"
               },
               "origin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "origin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "origin",
                 "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
                 "workingDirectory": "stacks\\\\origin"
               },
               "passthrough": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "passthrough",
                 "dependencies": [
                   "origin"
@@ -851,8 +774,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\passthrough"
               },
               "pinnedFns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "pinnedFns",
                 "dependencies": [
                   "origin"
@@ -863,19 +785,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\pinnedFns"
               },
               "secondOrigin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "secondOrigin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "secondOrigin",
                 "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf.json",
                 "workingDirectory": "stacks\\\\secondOrigin"
               },
               "sink": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "sink",
                 "dependencies": [
                   "origin"
@@ -886,8 +805,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\sink"
               },
               "switchedStack": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "switchedStack",
                 "dependencies": [
                   "secondOrigin"
@@ -908,8 +826,7 @@ describe("cross stack references", () => {
           "{
             "stacks": {
               "fns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "fns",
                 "dependencies": [
                   "origin"
@@ -920,8 +837,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\fns"
               },
               "functionOutput": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutput",
                 "dependencies": [
                   "origin"
@@ -932,8 +848,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\functionOutput"
               },
               "functionOutputPinned": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "functionOutputPinned",
                 "dependencies": [
                   "pinnedFns"
@@ -944,19 +859,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\functionOutputPinned"
               },
               "origin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "origin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "origin",
                 "stackMetadataPath": "stacks\\\\origin\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\origin\\\\cdk.tf.json",
                 "workingDirectory": "stacks\\\\origin"
               },
               "passthrough": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "passthrough",
                 "dependencies": [
                   "origin"
@@ -967,8 +879,7 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\passthrough"
               },
               "pinnedFns": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "pinnedFns",
                 "dependencies": [
                   "origin"
@@ -979,19 +890,16 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\pinnedFns"
               },
               "secondOrigin": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "secondOrigin",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "secondOrigin",
                 "stackMetadataPath": "stacks\\\\secondOrigin\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\secondOrigin\\\\cdk.tf.json",
                 "workingDirectory": "stacks\\\\secondOrigin"
               },
               "sink": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "sink",
                 "dependencies": [
                   "origin"
@@ -1002,11 +910,9 @@ describe("cross stack references", () => {
                 "workingDirectory": "stacks\\\\sink"
               },
               "switchedStack": {
-                "annotations": [
-                ],
+                "annotations": [],
                 "constructPath": "switchedStack",
-                "dependencies": [
-                ],
+                "dependencies": [],
                 "name": "switchedStack",
                 "stackMetadataPath": "stacks\\\\switchedStack\\\\metadata.json",
                 "synthesizedStackPath": "stacks\\\\switchedStack\\\\cdk.tf.json",

--- a/test/typescript/renamed-providers/test.ts
+++ b/test/typescript/renamed-providers/test.ts
@@ -21,8 +21,7 @@ describe("renamed providers", () => {
             "stackName": "renamed-providers",
             "version": "stubbed"
           },
-          "outputs": {
-          }
+          "outputs": {}
         },
         "provider": {
           "abitbucket": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3821,13 +3821,6 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/json-stable-stringify@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.2.0.tgz#fda9291c45a8ec79ed195883fb2bb09f0aa95854"
-  integrity sha512-PEHY3ohqolHqAzDyB1+31tFaAMnoLN7x/JgdcGmNZ2uvtEJ6rlFCUYNQc0Xe754xxCYLNGZbLUGydSE6tS4S9A==
-  dependencies:
-    json-stable-stringify "*"
-
 "@types/jsonfile@*":
   version "6.1.4"
   resolved "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz#614afec1a1164e7d670b4a7ad64df3e7beb7b702"
@@ -8817,7 +8810,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stable-stringify@*, json-stable-stringify@1.3.0:
+json-stable-stringify@1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
   integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
@@ -11018,6 +11011,11 @@ safe-regex-test@^1.1.0:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-regex "^1.2.1"
+
+safe-stable-stringify@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz#4ca2f8e385f2831c432a719b108a3bf7af42a1dd"
+  integrity sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"


### PR DESCRIPTION
Replace `json-stable-stringify` with `safe-stable-stringify`. The latter is ~2x faster in benchmarks.

Benchmark (Node 20, realistic TF-JSON payloads):
| payload                | json-stable | safe-stable | speedup |
|------------------------|-------------|-------------|---------|
| 100 resources (101 KB) | 1.91 ms/op  | 0.79 ms/op  | 2.43×   |
| 500 resources (512 KB) | 9.24 ms/op  | 3.92 ms/op  | 2.36×   |
| 2000 resources (2.1 MB)| 38.1 ms/op  | 19.8 ms/op  | 1.93×   |

This is inline with the benchmarks published at https://github.com/BridgeAR/safe-stable-stringify#performance--benchmarks.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue
Fixes #220

### Description

Switch from https://www.npmjs.com/package/json-stable-stringify to https://www.npmjs.com/package/safe-stable-stringify.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
