### PR TITLE
feat(cli)!: rename `--cdktf-version` in `init`

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/init.ts
+++ b/packages/@cdktn/cli-core/src/lib/init.ts
@@ -34,7 +34,7 @@ export interface RemoteProject extends LocalProject {
 export type Project = LocalProject | RemoteProject;
 
 export type InitArgs = {
-  cdktfVersion?: string;
+  cdktnVersion?: string;
   destination: string;
   dist?: string;
   providers?: string[];
@@ -57,7 +57,7 @@ for (const template of availableTemplates) {
 }
 
 export async function init({
-  cdktfVersion,
+  cdktnVersion,
   destination,
   dist,
   projectId,
@@ -68,8 +68,8 @@ export async function init({
   providersForceLocal,
   silent,
 }: InitArgs) {
-  const deps: any = await determineDeps(
-    cdktfVersion,
+  const deps = await determineDeps(
+    cdktnVersion,
     dist,
     path.basename(templatePath),
   );
@@ -83,8 +83,8 @@ export async function init({
     ...projectInfo,
     futureFlags,
     projectId,
-    sendCrashReports,
-    silent,
+    sendCrashReports: String(!!sendCrashReports),
+    silent: String(!!silent),
   });
   const cdktfConfig = CdktfConfig.read(destination);
 
@@ -187,7 +187,7 @@ export async function determineDeps(
 
   if (version === "0.0.0") {
     throw Errors.Usage(
-      `cannot use version 0.0.0, use --cdktf-version, --dist or CDKTF_DIST to install from a "dist" directory`,
+      `cannot use version 0.0.0, use --cdktn-version, --dist or CDKTF_DIST to install from a "dist" directory`,
     );
   }
 

--- a/packages/cdktn-cli/src/bin/cmds/handlers.ts
+++ b/packages/cdktn-cli/src/bin/cmds/handlers.ts
@@ -24,7 +24,11 @@ import {
   ConstructsMakerProviderTarget,
 } from "@cdktn/commons";
 
-import { checkForEmptyDirectory, runInit } from "./helper/init";
+import {
+  checkForEmptyDirectory,
+  runInit,
+  type RunInitOptions,
+} from "./helper/init";
 import { renderInk } from "./helper/render-ink";
 import { terraformCheck } from "./helper/terraform-check";
 import * as terraformCloudClient from "./helper/terraform-cloud-client";
@@ -150,14 +154,14 @@ export async function convert({
       enableCrashReporting: false,
       fromTerraformProject: "no",
       dist: pkg.version === "0.0.0" ? dist : undefined,
-      cdktfVersion: pkg.version,
+      cdktnVersion: pkg.version,
       silent: true,
       nonInteractive: true,
     });
     logger.useDefaultLevel();
   }
 
-  let output;
+  let output: string | undefined;
   try {
     const { all, stats } = await hcl2cdkConvert(input, {
       language,
@@ -359,12 +363,15 @@ export async function get(argv: {
   }
 }
 
-export async function init(argv: any) {
+export async function init(argv: RunInitOptions) {
   await terraformCheck();
   await displayVersionMessage();
   await checkEnvironment();
 
-  if (["", ".", process.cwd()].includes(argv.fromTerraformProject)) {
+  if (
+    argv.fromTerraformProject &&
+    [".", process.cwd()].includes(argv.fromTerraformProject)
+  ) {
     throw Errors.Usage(
       "--from-terraform-project requires a path to an existing Terraform project to be set, e.g. --from-terraform-project=../my-tf-codebase This folder can not be the same as the current working directory since cdktn init will initialize the new project in that folder.",
     );

--- a/packages/cdktn-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/init.ts
@@ -66,16 +66,16 @@ type GatheredInfo = {
   projectInfo: Project;
   useTerraformCloud: boolean | undefined;
 };
-type Options = {
+export type RunInitOptions = {
   local?: boolean;
   template?: string;
   projectName?: string;
   projectDescription?: string;
-  cdktfVersion?: string;
+  cdktnVersion?: string;
   dist?: string;
   providers?: string[];
   providersForceLocal?: boolean;
-  destination: string;
+  destination?: string;
   fromTerraformProject?: string;
   enableCrashReporting?: boolean;
   tfeHostname?: string;
@@ -83,7 +83,7 @@ type Options = {
   nonInteractive?: boolean;
 };
 
-export async function runInit(argv: Options) {
+export async function runInit(argv: RunInitOptions) {
   const telemetryData: Record<string, unknown> = {};
   const destination = argv.destination || ".";
   const terraformRemoteHostname = argv.tfeHostname || tfcHostname;
@@ -101,7 +101,7 @@ export async function runInit(argv: Options) {
 This means that your Terraform state file will be stored locally on disk in a file 'terraform.<STACK NAME>.tfstate' in the root of your project.}`);
     }
   }
-  const isRemote = token != "";
+  const isRemote = token !== "";
 
   // Check if template was specified by the user
   let template = "";
@@ -219,7 +219,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
   }
 
   const needsGet = await init({
-    cdktfVersion: argv.cdktfVersion,
+    cdktnVersion: argv.cdktnVersion,
     destination,
     dist: argv.dist,
     projectId,

--- a/packages/cdktn-cli/src/bin/cmds/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/init.ts
@@ -35,8 +35,7 @@ class Command extends BaseCommand {
         desc: "Use local state storage for generated Terraform.",
         default: false,
       })
-      .option("cdktf-version", {
-        // TODO: requires update to runInit cdktfVersion field
+      .option("cdktn-version", {
         type: "string",
         desc: "The cdktn version to use while creating a new project.",
         default: pkg.version,


### PR DESCRIPTION
The `init` CLI command currently accepts a `--cdktf-version` option. This change renames it to `--cdktn-version`.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

`cdktn init --cdktf-version` -> `cdktn init --cdktn-version`

This is a breaking change, but should hopefully not be too disruptive.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
