### PR TITLE
feat(lib): S3-backend - Add `useLockfile` field and update `dynamodbTable` deprecated JSDoc

### DIFF
--- a/packages/cdktn/src/backends/s3-backend.ts
+++ b/packages/cdktn/src/backends/s3-backend.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: MPL-2.0
 import { Construct } from "constructs";
 import { TerraformBackend } from "../terraform-backend";
-import { keysToSnakeCase } from "../util";
 import {
-  TerraformRemoteState,
   DataTerraformRemoteStateConfig,
+  TerraformRemoteState,
 } from "../terraform-remote-state";
+import { keysToSnakeCase } from "../util";
+import { ValidateTerraformFeatureVersion } from "../validations";
 
 // eslint-disable-next-line jsdoc/require-jsdoc
 export class S3Backend extends TerraformBackend {
@@ -15,6 +16,15 @@ export class S3Backend extends TerraformBackend {
     private readonly props: S3BackendConfig,
   ) {
     super(scope, "backend", "s3");
+
+    if (props.useLockfile) {
+      this.node.addValidation(
+        new ValidateTerraformFeatureVersion("S3 native state locking", {
+          terraform: ">=1.10.0",
+          opentofu: ">=1.10.0",
+        }),
+      );
+    }
   }
 
   protected synthesizeAttributes(): { [name: string]: any } {
@@ -184,9 +194,19 @@ export interface S3BackendConfig {
    */
   readonly kmsKeyId?: string;
   /**
+   * (Optional) Whether to use a lockfile for locking the state file. Defaults to false.
+   * State locking is an opt-in feature of the S3 backend.
+   * Locking can be enabled via S3 or DynamoDB (see dynamodbTable). However, DynamoDB-based locking
+   *   is deprecated and will be removed in a future minor version. To support migration from older
+   *   versions of Terraform that only support DynamoDB-based locking, the S3 (useLockfile) and DynamoDB
+   *   (dynamodbTable) arguments can be configured simultaneously.
+   */
+  readonly useLockfile?: boolean;
+  /**
    * (Optional) Name of DynamoDB Table to use for state locking and consistency.
    * The table must have a partition key named LockID with type of String.
    * If not configured, state locking will be disabled.
+   * @deprecated Use useLockfile instead, which uses S3 for locking
    */
   readonly dynamodbTable?: string;
   /**

--- a/packages/cdktn/test/__snapshots__/backend.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/backend.test.ts.snap
@@ -239,7 +239,7 @@ exports[`remote backend single ws 1`] = `
 }"
 `;
 
-exports[`s3 backend 1`] = `
+exports[`s3 backend (useLockfile: false) 1`] = `
 "{
   "terraform": {
     "backend": {
@@ -269,6 +269,45 @@ exports[`s3 backend 1`] = `
         "sse_customer_key": "AWS_SSE_CUSTOMER_KEY",
         "sts_endpoint": "AWS_STS_ENDPOINT",
         "token": "AWS_SESSION_TOKEN",
+        "use_lockfile": false,
+        "workspace_key_prefix": "env:"
+      }
+    }
+  }
+}"
+`;
+
+exports[`s3 backend (useLockfile: true) 1`] = `
+"{
+  "terraform": {
+    "backend": {
+      "s3": {
+        "access_key": "AWS_ACCESS_KEY_ID",
+        "acl": "Canned ACL",
+        "assume_role_policy": "permissions for assuming role",
+        "bucket": "mybucket",
+        "dynamodb_endpoint": "AWS_DYNAMODB_ENDPOINT",
+        "dynamodb_table": "DynamoDB table",
+        "encrypt": true,
+        "endpoint": "AWS_S3_ENDPOINT",
+        "external_id": "external ID",
+        "force_path_style": false,
+        "iam_endpoint": "AWS_IAM_ENDPOINT",
+        "key": "path/to/my/key",
+        "kms_key_id": "ARN of a KMS Key",
+        "max_retries": 5,
+        "profile": "AWS_PROFILE",
+        "region": "us-east-1",
+        "role_arn": "role to be assumed",
+        "secret_key": "AWS_SECRET_ACCESS_KEY",
+        "session_name": "role session name",
+        "shared_credentials_file": "~/.aws/credentials",
+        "skip_credentials_validation": false,
+        "skip_metadata_api_check": true,
+        "sse_customer_key": "AWS_SSE_CUSTOMER_KEY",
+        "sts_endpoint": "AWS_STS_ENDPOINT",
+        "token": "AWS_SESSION_TOKEN",
+        "use_lockfile": true,
         "workspace_key_prefix": "env:"
       }
     }

--- a/packages/cdktn/test/__snapshots__/remote-state.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/remote-state.test.ts.snap
@@ -201,7 +201,82 @@ exports[`remote 1`] = `
 }"
 `;
 
-exports[`s3 1`] = `
+exports[`s3 reference 1`] = `
+"{
+  "data": {
+    "terraform_remote_state": {
+      "remote": {
+        "backend": "s3",
+        "config": {
+          "bucket": "mybucket",
+          "key": "path/to/my/key"
+        }
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test_resource": {
+        "name": "\${data.terraform_remote_state.remote.outputs.name}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`s3 with \`useLockfile: false\` & \`dynamodbTable\` NOT set 1`] = `
+"{
+  "data": {
+    "terraform_remote_state": {
+      "remote": {
+        "backend": "s3",
+        "config": {
+          "access_key": "AWS_ACCESS_KEY_ID",
+          "acl": "Canned ACL",
+          "assume_role_policy": "permissions for assuming role",
+          "bucket": "mybucket",
+          "dynamodb_endpoint": "AWS_DYNAMODB_ENDPOINT",
+          "encrypt": true,
+          "endpoint": "AWS_S3_ENDPOINT",
+          "external_id": "external ID",
+          "force_path_style": false,
+          "iam_endpoint": "AWS_IAM_ENDPOINT",
+          "key": "path/to/my/key",
+          "kms_key_id": "ARN of a KMS Key",
+          "max_retries": 5,
+          "profile": "AWS_PROFILE",
+          "region": "us-east-1",
+          "role_arn": "role to be assumed",
+          "secret_key": "AWS_SECRET_ACCESS_KEY",
+          "session_name": "role session name",
+          "shared_credentials_file": "~/.aws/credentials",
+          "skip_credentials_validation": false,
+          "skip_metadata_api_check": true,
+          "sse_customer_key": "AWS_SSE_CUSTOMER_KEY",
+          "sts_endpoint": "AWS_STS_ENDPOINT",
+          "token": "AWS_SESSION_TOKEN",
+          "use_lockfile": false,
+          "workspace_key_prefix": "env:"
+        }
+      }
+    }
+  }
+}"
+`;
+
+exports[`s3 with \`useLockfile: false\` & \`dynamodbTable\` set 1`] = `
 "{
   "data": {
     "terraform_remote_state": {
@@ -233,6 +308,7 @@ exports[`s3 1`] = `
           "sse_customer_key": "AWS_SSE_CUSTOMER_KEY",
           "sts_endpoint": "AWS_STS_ENDPOINT",
           "token": "AWS_SESSION_TOKEN",
+          "use_lockfile": false,
           "workspace_key_prefix": "env:"
         }
       }
@@ -241,35 +317,81 @@ exports[`s3 1`] = `
 }"
 `;
 
-exports[`s3 reference 1`] = `
+exports[`s3 with \`useLockfile: true\` & \`dynamodbTable\` NOT set 1`] = `
 "{
   "data": {
     "terraform_remote_state": {
       "remote": {
         "backend": "s3",
         "config": {
+          "access_key": "AWS_ACCESS_KEY_ID",
+          "acl": "Canned ACL",
+          "assume_role_policy": "permissions for assuming role",
           "bucket": "mybucket",
-          "key": "path/to/my/key"
+          "dynamodb_endpoint": "AWS_DYNAMODB_ENDPOINT",
+          "encrypt": true,
+          "endpoint": "AWS_S3_ENDPOINT",
+          "external_id": "external ID",
+          "force_path_style": false,
+          "iam_endpoint": "AWS_IAM_ENDPOINT",
+          "key": "path/to/my/key",
+          "kms_key_id": "ARN of a KMS Key",
+          "max_retries": 5,
+          "profile": "AWS_PROFILE",
+          "region": "us-east-1",
+          "role_arn": "role to be assumed",
+          "secret_key": "AWS_SECRET_ACCESS_KEY",
+          "session_name": "role session name",
+          "shared_credentials_file": "~/.aws/credentials",
+          "skip_credentials_validation": false,
+          "skip_metadata_api_check": true,
+          "sse_customer_key": "AWS_SSE_CUSTOMER_KEY",
+          "sts_endpoint": "AWS_STS_ENDPOINT",
+          "token": "AWS_SESSION_TOKEN",
+          "use_lockfile": true,
+          "workspace_key_prefix": "env:"
         }
       }
     }
-  },
-  "provider": {
-    "test": [
-      {}
-    ]
-  },
-  "resource": {
-    "test_resource": {
-      "test_resource": {
-        "name": "\${data.terraform_remote_state.remote.outputs.name}"
-      }
-    }
-  },
-  "terraform": {
-    "required_providers": {
-      "test": {
-        "version": "~> 2.0"
+  }
+}"
+`;
+
+exports[`s3 with \`useLockfile: true\` & \`dynamodbTable\` set 1`] = `
+"{
+  "data": {
+    "terraform_remote_state": {
+      "remote": {
+        "backend": "s3",
+        "config": {
+          "access_key": "AWS_ACCESS_KEY_ID",
+          "acl": "Canned ACL",
+          "assume_role_policy": "permissions for assuming role",
+          "bucket": "mybucket",
+          "dynamodb_endpoint": "AWS_DYNAMODB_ENDPOINT",
+          "dynamodb_table": "DynamoDB table",
+          "encrypt": true,
+          "endpoint": "AWS_S3_ENDPOINT",
+          "external_id": "external ID",
+          "force_path_style": false,
+          "iam_endpoint": "AWS_IAM_ENDPOINT",
+          "key": "path/to/my/key",
+          "kms_key_id": "ARN of a KMS Key",
+          "max_retries": 5,
+          "profile": "AWS_PROFILE",
+          "region": "us-east-1",
+          "role_arn": "role to be assumed",
+          "secret_key": "AWS_SECRET_ACCESS_KEY",
+          "session_name": "role session name",
+          "shared_credentials_file": "~/.aws/credentials",
+          "skip_credentials_validation": false,
+          "skip_metadata_api_check": true,
+          "sse_customer_key": "AWS_SSE_CUSTOMER_KEY",
+          "sts_endpoint": "AWS_STS_ENDPOINT",
+          "token": "AWS_SESSION_TOKEN",
+          "use_lockfile": true,
+          "workspace_key_prefix": "env:"
+        }
       }
     }
   }

--- a/packages/cdktn/test/backend.test.ts
+++ b/packages/cdktn/test/backend.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Testing, TerraformStack } from "../src";
+import { TerraformStack, Testing } from "../src";
 import * as b from "../src/backends";
 
 test("local backend", () => {
@@ -230,7 +230,7 @@ test("pg backend", () => {
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
 
-test("s3 backend", () => {
+test("s3 backend (useLockfile: false)", () => {
   const app = Testing.app();
   const stack = new TerraformStack(app, "test");
 
@@ -244,6 +244,44 @@ test("s3 backend", () => {
     accessKey: "AWS_ACCESS_KEY_ID",
     secretKey: "AWS_SECRET_ACCESS_KEY",
     kmsKeyId: "ARN of a KMS Key",
+    useLockfile: false,
+    dynamodbTable: "DynamoDB table",
+    profile: "AWS_PROFILE",
+    sharedCredentialsFile: "~/.aws/credentials",
+    token: "AWS_SESSION_TOKEN",
+    roleArn: "role to be assumed",
+    assumeRolePolicy: "permissions for assuming role",
+    externalId: "external ID",
+    sessionName: "role session name",
+    workspaceKeyPrefix: "env:",
+    dynamodbEndpoint: "AWS_DYNAMODB_ENDPOINT",
+    iamEndpoint: "AWS_IAM_ENDPOINT",
+    stsEndpoint: "AWS_STS_ENDPOINT",
+    forcePathStyle: false,
+    skipCredentialsValidation: false,
+    skipMetadataApiCheck: true,
+    sseCustomerKey: "AWS_SSE_CUSTOMER_KEY",
+    maxRetries: 5,
+  });
+
+  expect(Testing.synth(stack)).toMatchSnapshot();
+});
+
+test("s3 backend (useLockfile: true)", () => {
+  const app = Testing.app();
+  const stack = new TerraformStack(app, "test");
+
+  new b.S3Backend(stack, {
+    bucket: "mybucket",
+    key: "path/to/my/key",
+    region: "us-east-1",
+    endpoint: "AWS_S3_ENDPOINT",
+    encrypt: true,
+    acl: "Canned ACL",
+    accessKey: "AWS_ACCESS_KEY_ID",
+    secretKey: "AWS_SECRET_ACCESS_KEY",
+    kmsKeyId: "ARN of a KMS Key",
+    useLockfile: true,
     dynamodbTable: "DynamoDB table",
     profile: "AWS_PROFILE",
     sharedCredentialsFile: "~/.aws/credentials",

--- a/packages/cdktn/test/remote-state.test.ts
+++ b/packages/cdktn/test/remote-state.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Testing, TerraformStack } from "../src";
+import { TerraformStack, Testing } from "../src";
 import * as b from "../src/backends";
 import { TestResource } from "./helper";
 import { TestProvider } from "./helper/provider";
@@ -171,72 +171,108 @@ test("pg", () => {
   expect(Testing.synth(stack)).toMatchSnapshot();
 });
 
-test("s3", () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, "test");
+describe("s3", () => {
+  const createStack = (
+    override: Partial<b.DataTerraformRemoteStateS3Config>,
+  ) => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, "test");
 
-  new b.DataTerraformRemoteStateS3(stack, "remote", {
-    bucket: "mybucket",
-    key: "path/to/my/key",
-    region: "us-east-1",
-    endpoint: "AWS_S3_ENDPOINT",
-    encrypt: true,
-    acl: "Canned ACL",
-    accessKey: "AWS_ACCESS_KEY_ID",
-    secretKey: "AWS_SECRET_ACCESS_KEY",
-    kmsKeyId: "ARN of a KMS Key",
-    dynamodbTable: "DynamoDB table",
-    profile: "AWS_PROFILE",
-    sharedCredentialsFile: "~/.aws/credentials",
-    token: "AWS_SESSION_TOKEN",
-    roleArn: "role to be assumed",
-    assumeRolePolicy: "permissions for assuming role",
-    externalId: "external ID",
-    sessionName: "role session name",
-    workspaceKeyPrefix: "env:",
-    dynamodbEndpoint: "AWS_DYNAMODB_ENDPOINT",
-    iamEndpoint: "AWS_IAM_ENDPOINT",
-    stsEndpoint: "AWS_STS_ENDPOINT",
-    forcePathStyle: false,
-    skipCredentialsValidation: false,
-    skipMetadataApiCheck: true,
-    sseCustomerKey: "AWS_SSE_CUSTOMER_KEY",
-    maxRetries: 5,
+    const remoteState = new b.DataTerraformRemoteStateS3(stack, "remote", {
+      bucket: "mybucket",
+      key: "path/to/my/key",
+      region: "us-east-1",
+      endpoint: "AWS_S3_ENDPOINT",
+      encrypt: true,
+      acl: "Canned ACL",
+      accessKey: "AWS_ACCESS_KEY_ID",
+      secretKey: "AWS_SECRET_ACCESS_KEY",
+      kmsKeyId: "ARN of a KMS Key",
+      useLockfile: false,
+      dynamodbTable: "DynamoDB table",
+      profile: "AWS_PROFILE",
+      sharedCredentialsFile: "~/.aws/credentials",
+      token: "AWS_SESSION_TOKEN",
+      roleArn: "role to be assumed",
+      assumeRolePolicy: "permissions for assuming role",
+      externalId: "external ID",
+      sessionName: "role session name",
+      workspaceKeyPrefix: "env:",
+      dynamodbEndpoint: "AWS_DYNAMODB_ENDPOINT",
+      iamEndpoint: "AWS_IAM_ENDPOINT",
+      stsEndpoint: "AWS_STS_ENDPOINT",
+      forcePathStyle: false,
+      skipCredentialsValidation: false,
+      skipMetadataApiCheck: true,
+      sseCustomerKey: "AWS_SSE_CUSTOMER_KEY",
+      maxRetries: 5,
+      ...override,
+    });
+
+    return {
+      app,
+      stack,
+      remoteState,
+    };
+  };
+
+  test("with `useLockfile: false` & `dynamodbTable` set", () => {
+    const { stack } = createStack({ useLockfile: false });
+    expect(Testing.synth(stack)).toMatchSnapshot();
   });
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test("s3 with options", () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, "test");
-
-  new b.DataTerraformRemoteStateS3(stack, "remote", {
-    bucket: "mybucket",
-    key: "path/to/my/key",
-    workspace: "my_workspace",
-    defaults: {
-      someProp: "some_value",
-    },
+  test("with `useLockfile: true` & `dynamodbTable` set", () => {
+    const { stack } = createStack({ useLockfile: true });
+    expect(Testing.synth(stack)).toMatchSnapshot();
   });
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
-});
-
-test("s3 reference", () => {
-  const app = Testing.app();
-  const stack = new TerraformStack(app, "test");
-
-  new TestProvider(stack, "provider", {});
-
-  const remoteState = new b.DataTerraformRemoteStateS3(stack, "remote", {
-    bucket: "mybucket",
-    key: "path/to/my/key",
+  test("with `useLockfile: false` & `dynamodbTable` NOT set", () => {
+    const { stack } = createStack({
+      useLockfile: false,
+      dynamodbTable: undefined,
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
   });
 
-  new TestResource(stack, "test_resource", {
-    name: remoteState.getString("name"),
+  test("with `useLockfile: true` & `dynamodbTable` NOT set", () => {
+    const { stack } = createStack({
+      useLockfile: true,
+      dynamodbTable: undefined,
+    });
+    expect(Testing.synth(stack)).toMatchSnapshot();
   });
 
-  expect(Testing.synth(stack)).toMatchSnapshot();
+  test("with options", () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, "test");
+
+    new b.DataTerraformRemoteStateS3(stack, "remote", {
+      bucket: "mybucket",
+      key: "path/to/my/key",
+      workspace: "my_workspace",
+      defaults: {
+        someProp: "some_value",
+      },
+    });
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+
+  test("reference", () => {
+    const app = Testing.app();
+    const stack = new TerraformStack(app, "test");
+
+    new TestProvider(stack, "provider", {});
+
+    const remoteState = new b.DataTerraformRemoteStateS3(stack, "remote", {
+      bucket: "mybucket",
+      key: "path/to/my/key",
+    });
+
+    new TestResource(stack, "test_resource", {
+      name: remoteState.getString("name"),
+    });
+
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
**☝️ Could I get some help with this please ☝️**
Hi, I couldn't get all the tests to pass locally, but I think it's a setup issue, not due to my changes. 
Could someone help me out by either running it locally themselves or running it through GH Actions?

---

Updated documentation for state locking and deprecated features.

### Related issue

Fixes https://github.com/open-constructs/cdk-terrain/issues/233

Terraform **State Locking** reference: https://developer.hashicorp.com/terraform/language/backend/s3#state-locking

### Description

Changes made in the s3-backend file:
1. Add new field `useLockfile` and assoc JSDocs
2. Add deprecated JSDoc for the `dynamodbTable` field
3. Update deprecated JSDoc for the `dynamodbEndpoint` field

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
  -  > Successfully ran target lint for 34 projects (11s)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
