### PR TITLE
feat(cli): validate Terraform CLI feature versions

### DIFF
--- a/packages/cdktn/src/validations/index.ts
+++ b/packages/cdktn/src/validations/index.ts
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: MPL-2.0
 export * from "./validate-binary-version";
 export * from "./validate-provider-presence";
+export * from "./validate-terraform-feature-version";

--- a/packages/cdktn/src/validations/validate-terraform-feature-version.ts
+++ b/packages/cdktn/src/validations/validate-terraform-feature-version.ts
@@ -1,0 +1,106 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { IValidation } from "constructs";
+import { execSync } from "child_process";
+import * as semver from "semver";
+import { terraformBinaryName } from "../util";
+
+export type TerraformCliName = "terraform" | "opentofu" | "unknown";
+
+export interface TerraformCliVersion {
+  readonly name: TerraformCliName;
+  readonly version?: string;
+}
+
+export interface TerraformFeatureVersionConstraints {
+  readonly terraform?: string;
+  readonly opentofu?: string;
+}
+
+/**
+ * Parses the output of `terraform version` or `tofu version`.
+ *
+ * Plain text version output is used because both Terraform and OpenTofu expose
+ * a Terraform-compatible `terraform_version` key in `version -json` output.
+ */
+export function parseTerraformCliVersion(
+  versionOutput: string,
+): TerraformCliVersion {
+  const firstLine = versionOutput.trim().split(/\r?\n/)[0] || "";
+  const firstLineMatch = firstLine.match(
+    /^(Terraform|OpenTofu) v(\d+\.\d+\.\d+(?:[-+][^\s]+)?)/,
+  );
+
+  if (firstLineMatch) {
+    return {
+      name: firstLineMatch[1] === "OpenTofu" ? "opentofu" : "terraform",
+      version: firstLineMatch[2],
+    };
+  }
+
+  return {
+    name: "unknown",
+    version: versionOutput.match(/\d+\.\d+\.\d+(?:[-+][^\s]+)?/)?.[0],
+  };
+}
+
+/**
+ * Validates whether the selected Terraform-compatible CLI supports a feature.
+ *
+ * A feature can become available in Terraform and OpenTofu at different
+ * versions, so the validation matrix is feature -> CLI product -> semver range.
+ */
+export class ValidateTerraformFeatureVersion implements IValidation {
+  constructor(
+    protected featureName: string,
+    protected constraints: TerraformFeatureVersionConstraints,
+    protected versionCommand: string = `${terraformBinaryName} version`,
+    protected binary: string = terraformBinaryName,
+    protected hint?: string,
+  ) {}
+
+  public validate() {
+    try {
+      const versionOutput = execSync(this.versionCommand, {
+        stdio: "pipe",
+      }).toString();
+      const firstLine = versionOutput.trim().split(/\r?\n/)[0] || "";
+      const cliVersion = parseTerraformCliVersion(versionOutput);
+
+      if (cliVersion.name === "unknown") {
+        return [
+          `Could not determine whether ${this.binary} is Terraform or OpenTofu from the first line of ${this.binary} version output: ${firstLine}`,
+        ];
+      }
+
+      if (!cliVersion.version) {
+        return [
+          `Could not determine version of ${this.binary} (running ${this.versionCommand})`,
+        ];
+      }
+
+      const constraint = this.constraints[cliVersion.name];
+      if (!constraint) {
+        return [
+          `${this.featureName} is not supported by ${cliVersion.name}. ${
+            this.hint || ""
+          }`,
+        ];
+      }
+
+      if (!semver.satisfies(cliVersion.version, constraint)) {
+        return [
+          `${this.featureName} requires ${cliVersion.name} ${constraint}, but ${cliVersion.name} version ${cliVersion.version} was found. ${
+            this.hint || ""
+          }`.trimEnd(),
+        ];
+      }
+
+      return [];
+    } catch (e) {
+      return [
+        `Could not determine version of ${this.binary}, ${this.versionCommand} failed: ${e}`,
+      ];
+    }
+  }
+}

--- a/packages/cdktn/test/validations.test.ts
+++ b/packages/cdktn/test/validations.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src/validations";
 import { TestProvider } from "./helper/provider";
 import { createTmpHelper } from "./helper/tmp";
+import { terraformBinaryName } from "../src/util";
 
 const tmp = createTmpHelper();
 
@@ -268,9 +269,11 @@ describe("ValidateTerraformFeatureVersion", () => {
       ),
     );
 
+    const binaryName = terraformBinaryName;
+
     expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
       "Validation failed with the following errors:
-        [MyStack/testResource] Could not determine whether terraform is Terraform or OpenTofu from the first line of terraform version output: {\"terraform_version\":\"1.10.10\"}
+        [MyStack/testResource] Could not determine whether ${binaryName} is Terraform or OpenTofu from the first line of ${binaryName} version output: {\"terraform_version\":\"1.10.10\"}
 
       If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
       "

--- a/packages/cdktn/test/validations.test.ts
+++ b/packages/cdktn/test/validations.test.ts
@@ -4,7 +4,11 @@ import { App, TerraformStack, Testing } from "../src";
 
 import { Construct, IValidation } from "constructs";
 import { TestResource } from "./helper/resource";
-import { ValidateBinaryVersion } from "../src/validations";
+import {
+  parseTerraformCliVersion,
+  ValidateBinaryVersion,
+  ValidateTerraformFeatureVersion,
+} from "../src/validations";
 import { TestProvider } from "./helper/provider";
 import { createTmpHelper } from "./helper/tmp";
 
@@ -140,6 +144,133 @@ describe("ValidateBinaryVersion", () => {
     expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
       "Validation failed with the following errors:
         [MyStack/testResource] Could not determine version of terraform (running echo "foo")
+
+      If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
+      "
+    `);
+  });
+});
+
+describe("parseTerraformCliVersion", () => {
+  test("detects Terraform from the first version output line", () => {
+    expect(
+      parseTerraformCliVersion("Terraform v1.10.5\non linux_arm64"),
+    ).toEqual({ name: "terraform", version: "1.10.5" });
+  });
+
+  test("detects OpenTofu from the first version output line", () => {
+    expect(
+      parseTerraformCliVersion("OpenTofu v1.10.10\non linux_arm64"),
+    ).toEqual({ name: "opentofu", version: "1.10.10" });
+  });
+
+  test("does not infer the product from a matching JSON version key", () => {
+    expect(
+      parseTerraformCliVersion(
+        JSON.stringify({
+          terraform_version: "1.10.10",
+          platform: "linux_arm64",
+        }),
+      ),
+    ).toEqual({ name: "unknown", version: "1.10.10" });
+  });
+});
+
+describe("ValidateTerraformFeatureVersion", () => {
+  test("passes when the detected Terraform version satisfies the feature matrix", () => {
+    const outdir = tmp("cdktf.outdir.");
+    const app = Testing.stubVersion(new App({ stackTraces: false, outdir }));
+    const stack = new TerraformStack(app, "MyStack");
+    new TestProvider(stack, "foo", {});
+    const testResource = new TestResource(stack, "testResource", {
+      name: "foo",
+    });
+    testResource.node.addValidation(
+      new ValidateTerraformFeatureVersion(
+        "S3 native state locking",
+        {
+          terraform: ">=1.10.0",
+          opentofu: ">=1.10.0",
+        },
+        `echo "Terraform v1.10.5\non linux_arm64"`,
+      ),
+    );
+
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  test("fails with the product-specific constraint when Terraform is too old", () => {
+    const outdir = tmp("cdktf.outdir.");
+    const app = Testing.stubVersion(new App({ stackTraces: false, outdir }));
+    const stack = new TerraformStack(app, "MyStack");
+    new TestProvider(stack, "foo", {});
+    const testResource = new TestResource(stack, "testResource", {
+      name: "foo",
+    });
+    testResource.node.addValidation(
+      new ValidateTerraformFeatureVersion(
+        "S3 native state locking",
+        {
+          terraform: ">=1.10.0",
+          opentofu: ">=1.9.0",
+        },
+        `echo "Terraform v1.7.5\non linux_arm64"`,
+      ),
+    );
+
+    expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
+      "Validation failed with the following errors:
+        [MyStack/testResource] S3 native state locking requires terraform >=1.10.0, but terraform version 1.7.5 was found.
+
+      If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
+      "
+    `);
+  });
+
+  test("uses the OpenTofu constraint when OpenTofu is detected", () => {
+    const outdir = tmp("cdktf.outdir.");
+    const app = Testing.stubVersion(new App({ stackTraces: false, outdir }));
+    const stack = new TerraformStack(app, "MyStack");
+    new TestProvider(stack, "foo", {});
+    const testResource = new TestResource(stack, "testResource", {
+      name: "foo",
+    });
+    testResource.node.addValidation(
+      new ValidateTerraformFeatureVersion(
+        "S3 native state locking",
+        {
+          terraform: ">=1.12.0",
+          opentofu: ">=1.10.0",
+        },
+        `echo "OpenTofu v1.10.10\non linux_arm64"`,
+      ),
+    );
+
+    expect(() => app.synth()).not.toThrow();
+  });
+
+  test("fails when the CLI product cannot be detected from the first line", () => {
+    const outdir = tmp("cdktf.outdir.");
+    const app = Testing.stubVersion(new App({ stackTraces: false, outdir }));
+    const stack = new TerraformStack(app, "MyStack");
+    new TestProvider(stack, "foo", {});
+    const testResource = new TestResource(stack, "testResource", {
+      name: "foo",
+    });
+    testResource.node.addValidation(
+      new ValidateTerraformFeatureVersion(
+        "S3 native state locking",
+        {
+          terraform: ">=1.10.0",
+          opentofu: ">=1.10.0",
+        },
+        `echo '{"terraform_version":"1.10.10"}'`,
+      ),
+    );
+
+    expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
+      "Validation failed with the following errors:
+        [MyStack/testResource] Could not determine whether terraform is Terraform or OpenTofu from the first line of terraform version output: {\"terraform_version\":\"1.10.10\"}
 
       If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
       "


### PR DESCRIPTION
## Summary

Introduce a Terraform-compatible CLI feature/version validator that can be reused by feature PRs whose support depends on both the selected CLI product and its version.

This adds:

- `parseTerraformCliVersion()` to detect Terraform vs OpenTofu from the first line of plain `version` output:
  - `Terraform vX.Y.Z` -> `terraform`
  - `OpenTofu vX.Y.Z` -> `opentofu`
- `ValidateTerraformFeatureVersion`, a single validation class for the matrix:
  - feature -> CLI product (`terraform` / `opentofu`) -> semver constraint
- tests proving that `version -json`-style output is not used to infer the product, because OpenTofu keeps the Terraform-compatible `terraform_version` key.

## Intended downstream use

This is meant to unblock/reduce duplication for the S3 `useLockfile` work in:

- References #217
- References #234

A follow-up PR can add the backend-specific validation with:

```ts
new ValidateTerraformFeatureVersion("S3 native state locking", {
  terraform: ">=1.10.0",
  opentofu: ">=1.10.0",
});
```

If future features land at different times, the same class can encode different product constraints, for example:

```ts
new ValidateTerraformFeatureVersion("some future feature", {
  terraform: ">=1.12.0",
  opentofu: ">=1.10.0",
});
```

## Test plan

- [x] `yarn jest packages/cdktn/test/validations.test.ts --runInBand`
- [x] `yarn lerna run --scope cdktn build`
- [x] `yarn nx test cdktn --runInBand`
