### PR TITLE
chore(gha): run integration tests on Depot runners

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   prepare-integration-tests:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-4
     outputs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
     container:
@@ -102,7 +102,7 @@ jobs:
 
   linux_integration:
     needs: prepare-integration-tests
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-integration-tests.outputs.tests)}}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   prepare-integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     outputs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
     container:
@@ -102,7 +102,7 @@ jobs:
 
   linux_integration:
     needs: prepare-integration-tests
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-integration-tests.outputs.tests)}}

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   prepare-provider-tests:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     outputs:
       tests: ${{ steps.build-provider-test-matrix.outputs.tests }}
     container:
@@ -94,7 +94,7 @@ jobs:
 
   linux_provider:
     needs: prepare-provider-tests
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-16
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-provider-tests.outputs.tests)}}

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   prepare-provider-tests:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-4
     outputs:
       tests: ${{ steps.build-provider-test-matrix.outputs.tests }}
     container:
@@ -94,7 +94,7 @@ jobs:
 
   linux_provider:
     needs: prepare-provider-tests
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       fail-fast: false
       matrix: ${{fromJSON(needs.prepare-provider-tests.outputs.tests)}}


### PR DESCRIPTION
## Summary
- Move Linux integration test jobs to Depot's `depot-ubuntu-24.04-16` runner.
- Move provider integration preparation and Linux provider matrix jobs to Depot runners.
- Keep Windows integration/provider jobs on their existing Windows runners.

## Test Plan
- `python3 -c 'import yaml; [yaml.safe_load(open(f)) for f in [".github/workflows/integration.yml", ".github/workflows/provider-integration.yml"]]'`
- `/home/ubuntu/.cache/go-tools/actionlint -ignore 'label "depot-ubuntu-24.04-16" is unknown' -ignore 'constant expression "false" in condition' .github/workflows/integration.yml .github/workflows/provider-integration.yml`
- `git diff --check`
