### PR TITLE
chore(cli): rename cdktf deps to cdktn

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/init.ts
+++ b/packages/@cdktn/cli-core/src/lib/init.ts
@@ -102,27 +102,27 @@ export async function init({
 }
 
 export interface Deps {
-  npm_cdktf: string;
-  npm_cdktf_cli: string;
-  pypi_cdktf: string;
-  mvn_cdktf: string;
-  nuget_cdktf: string;
-  go_cdktf: string;
-  cdktf_version: string;
+  npm_cdktn: string;
+  npm_cdktn_cli: string;
+  pypi_cdktn: string;
+  mvn_cdktn: string;
+  nuget_cdktn: string;
+  go_cdktn: string;
+  cdktn_version: string;
   constructs_version: string;
 }
-type DistKey = Exclude<keyof Deps, "cdktf_version" | "constructs_version">;
+type DistKey = Exclude<keyof Deps, "cdktn_version" | "constructs_version">;
 
 // Each built-in template only consumes the dist artifact for its own
 // language. Skipping the others lets `cdktn init --dist` work when only
 // some language dists are present (e.g. CI ran `yarn package:js` only).
 const distKeysByTemplate: Record<string, DistKey[]> = {
-  typescript: ["npm_cdktf"],
-  python: ["pypi_cdktf"],
-  "python-pip": ["pypi_cdktf"],
-  java: ["mvn_cdktf"],
-  csharp: ["nuget_cdktf"],
-  go: ["go_cdktf"],
+  typescript: ["npm_cdktn"],
+  python: ["pypi_cdktn"],
+  "python-pip": ["pypi_cdktn"],
+  java: ["mvn_cdktn"],
+  csharp: ["nuget_cdktn"],
+  go: ["go_cdktn"],
 };
 
 export async function determineDeps(
@@ -139,20 +139,20 @@ export async function determineDeps(
   if (dist) {
     // TODO: What about existing cdktf TS/PY dependencies?
     const ret = {
-      npm_cdktf: path.resolve(dist, "js", `cdktn@${version}.jsii.tgz`),
-      npm_cdktf_cli: path.resolve(dist, "js", `cdktn-cli-${version}.tgz`),
-      pypi_cdktf: path.resolve(
+      npm_cdktn: path.resolve(dist, "js", `cdktn@${version}.jsii.tgz`),
+      npm_cdktn_cli: path.resolve(dist, "js", `cdktn-cli-${version}.tgz`),
+      pypi_cdktn: path.resolve(
         dist,
         "python",
         `cdktn-${pythonVersion}-py3-none-any.whl`,
       ),
-      mvn_cdktf: path.resolve(
+      mvn_cdktn: path.resolve(
         dist,
         "java",
         `io/cdktn/cdktn/${version}/cdktn-${version}.jar`,
       ),
-      nuget_cdktf: path.resolve(dist, "dotnet", `Io.Cdktn.${version}.nupkg`),
-      go_cdktf: path.resolve(dist, "go", `cdktn`),
+      nuget_cdktn: path.resolve(dist, "dotnet", `Io.Cdktn.${version}.nupkg`),
+      go_cdktn: path.resolve(dist, "go", `cdktn`),
     };
 
     // If we know the template, only validate its artifact; otherwise fall
@@ -175,7 +175,7 @@ export async function determineDeps(
     }
 
     const versions = {
-      cdktf_version: version,
+      cdktn_version: version,
       constructs_version: constructsVersion,
     };
 
@@ -198,13 +198,13 @@ export async function determineDeps(
   const ver = version.includes("-") ? version : `^${version}`;
 
   return {
-    cdktf_version: version,
+    cdktn_version: version,
     constructs_version: constructsVersion,
-    npm_cdktf: `cdktn@${ver}`,
-    npm_cdktf_cli: `cdktn-cli@${ver}`,
-    pypi_cdktf: `cdktn~=${pythonVersion}`,
-    mvn_cdktf: version,
-    nuget_cdktf: version,
-    go_cdktf: `v${version}`,
+    npm_cdktn: `cdktn@${ver}`,
+    npm_cdktn_cli: `cdktn-cli@${ver}`,
+    pypi_cdktn: `cdktn~=${pythonVersion}`,
+    mvn_cdktn: version,
+    nuget_cdktn: version,
+    go_cdktn: `v${version}`,
   };
 }

--- a/packages/@cdktn/cli-core/src/lib/provider-add.ts
+++ b/packages/@cdktn/cli-core/src/lib/provider-add.ts
@@ -28,7 +28,7 @@ export async function providerAdd({
   forceLocal,
 }: ProviderAddArgs): Promise<boolean> {
   const version =
-    cdktfVersion || (await determineDeps(cdktfVersion, dist)).cdktf_version;
+    cdktfVersion || (await determineDeps(cdktfVersion, dist)).cdktn_version;
 
   const manager = new DependencyManager(language, version, projectDirectory);
 

--- a/packages/@cdktn/cli-core/templates/csharp/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/csharp/.hooks.sscaff.js
@@ -23,9 +23,9 @@ exports.pre = (variables) => {
 };
 
 exports.post = options => {
-  const { nuget_cdktf, cdktf_version } = options;
-  if (!nuget_cdktf) {
-    throw new Error(`missing context "nuget_cdktf"`);
+  const { nuget_cdktn, cdktn_version } = options;
+  if (!nuget_cdktn) {
+    throw new Error(`missing context "nuget_cdktn"`);
   }
 
   // Terraform Cloud configuration settings if the organization name and workspace is set.
@@ -35,8 +35,8 @@ exports.post = options => {
   }
 
   // dist package
-  if (nuget_cdktf.endsWith('.nupkg')) {
-    srcFolder = path.dirname(nuget_cdktf);
+  if (nuget_cdktn.endsWith('.nupkg')) {
+    srcFolder = path.dirname(nuget_cdktn);
 
     writeFileSync('./NuGet.Config', `<?xml version="1.0" encoding="utf-8"?>
     <configuration>

--- a/packages/@cdktn/cli-core/templates/csharp/MyTerraformStack.csproj
+++ b/packages/@cdktn/cli-core/templates/csharp/MyTerraformStack.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Io.Cdktn" Version="{{ cdktf_version }}" />
+    <PackageReference Include="Io.Cdktn" Version="{{ cdktn_version }}" />
   </ItemGroup>
 
 </Project>

--- a/packages/@cdktn/cli-core/templates/go/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/go/.hooks.sscaff.js
@@ -24,9 +24,9 @@ exports.pre = (variables) => {
 };
 
 exports.post = options => {
-  const { go_cdktf, cdktf_version } = options;
-  if (!go_cdktf) {
-    throw new Error(`missing context "go_cdktf"`);
+  const { go_cdktn, cdktn_version } = options;
+  if (!go_cdktn) {
+    throw new Error(`missing context "go_cdktn"`);
   }
 
   // Terraform Cloud configuration settings if the organization name and workspace is set.
@@ -36,13 +36,13 @@ exports.post = options => {
   }
 
   // dist package
-  if (go_cdktf.endsWith('cdktn')) {
+  if (go_cdktn.endsWith('cdktn')) {
     const gomod = readFileSync('./go.mod', 'utf-8');
 
     // set the version of the package to the version of the CDKTN CLI as the package itself
     // will be replaced and have no version on its own
-    let result = gomod.replace(go_cdktf, `v${cdktf_version}`);
-    result += `\n\nreplace github.com/open-constructs/cdk-terrain-go/cdktn => ${go_cdktf}\n`;
+    let result = gomod.replace(go_cdktn, `v${cdktn_version}`);
+    result += `\n\nreplace github.com/open-constructs/cdk-terrain-go/cdktn => ${go_cdktn}\n`;
 
     writeFileSync('./go.mod', result, 'utf-8');
   }

--- a/packages/@cdktn/cli-core/templates/go/go.mod
+++ b/packages/@cdktn/cli-core/templates/go/go.mod
@@ -4,5 +4,5 @@ go 1.25.0
 
 require github.com/aws/constructs-go/constructs/v10 v{{ constructs_version }}
 
-require github.com/open-constructs/cdk-terrain-go/cdktn {{ go_cdktf }}
+require github.com/open-constructs/cdk-terrain-go/cdktn {{ go_cdktn }}
 require github.com/aws/jsii-runtime-go v1.67.0

--- a/packages/@cdktn/cli-core/templates/java/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/java/.hooks.sscaff.js
@@ -23,9 +23,9 @@ exports.pre = (variables) => {
 };
 
 exports.post = options => {
-  const { mvn_cdktf, cdktf_version } = options;
-  if (!mvn_cdktf) {
-    throw new Error(`missing context "mvn_cdktf"`);
+  const { mvn_cdktn, cdktn_version } = options;
+  if (!mvn_cdktn) {
+    throw new Error(`missing context "mvn_cdktn"`);
   }
 
   // Terraform Cloud configuration settings if the organization name and workspace is set.
@@ -36,11 +36,11 @@ exports.post = options => {
 
   // This is used for installing artifacts that are local (not from Maven)
   // https://maven.apache.org/plugins/maven-install-plugin/usage.html
-  if (mvn_cdktf.endsWith('.jar')) {
+  if (mvn_cdktn.endsWith('.jar')) {
     writeFileSync('./build.gradle',
       readFileSync('./build.gradle', 'utf-8').replace(
-        `implementation "io.cdktn:cdktn:${cdktf_version}"`,
-        `implementation files("${mvn_cdktf.replaceAll('\\', '/')}")`
+        `implementation "io.cdktn:cdktn:${cdktn_version}"`,
+        `implementation files("${mvn_cdktn.replaceAll('\\', '/')}")`
       )
     );
   }

--- a/packages/@cdktn/cli-core/templates/java/build.gradle
+++ b/packages/@cdktn/cli-core/templates/java/build.gradle
@@ -20,7 +20,7 @@ repositories {
 }
 
 dependencies {
-    implementation "io.cdktn:cdktn:{{ cdktf_version }}"
+    implementation "io.cdktn:cdktn:{{ cdktn_version }}"
     implementation "software.constructs:constructs:{{ constructs_version }}"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.0"

--- a/packages/@cdktn/cli-core/templates/python-pip/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/python-pip/.hooks.sscaff.js
@@ -29,12 +29,12 @@ exports.post = options => {
     terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname);
   }
 
-  const pypi_cdktf = options.pypi_cdktf;
-  if (!pypi_cdktf) {
-    throw new Error(`missing context "pypi_cdktf"`);
+  const pypi_cdktn = options.pypi_cdktn;
+  if (!pypi_cdktn) {
+    throw new Error(`missing context "pypi_cdktn"`);
   }
 
-  writeFileSync('requirements.txt', pypi_cdktf + '\r\npytest\r\n', 'utf-8');
+  writeFileSync('requirements.txt', pypi_cdktn + '\r\npytest\r\n', 'utf-8');
 
   let installArgs = '';
   if (!process.env.VIRTUAL_ENV) {

--- a/packages/@cdktn/cli-core/templates/python/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/python/.hooks.sscaff.js
@@ -29,13 +29,13 @@ exports.post = options => {
     terraformCloudConfig(options.$base, options.OrganizationName, options.WorkspaceName, options.TerraformRemoteHostname)
   }
 
-  const pypi_cdktf = options.pypi_cdktf;
-  if (!pypi_cdktf) {
-    throw new Error(`missing context "pypi_cdktf"`);
+  const pypi_cdktn = options.pypi_cdktn;
+  if (!pypi_cdktn) {
+    throw new Error(`missing context "pypi_cdktn"`);
   }
 
   execSync('pipenv install', { stdio: 'inherit' });
-  execSync(`pipenv install ${pypi_cdktf}`, { stdio: 'inherit' });
+  execSync(`pipenv install ${pypi_cdktn}`, { stdio: 'inherit' });
   execSync(`pipenv install pytest`, { stdio: 'inherit' });
   chmodSync('main.py', '700');
 

--- a/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
@@ -23,12 +23,12 @@ exports.post = (ctx) => {
     );
   }
 
-  const npm_cdktf = ctx.npm_cdktf;
-  if (!npm_cdktf) {
-    throw new Error(`missing context "npm_cdktf"`);
+  const npm_cdktn = ctx.npm_cdktn;
+  if (!npm_cdktn) {
+    throw new Error(`missing context "npm_cdktn"`);
   }
 
-  installDeps([npm_cdktf, `constructs@10`], false, silent);
+  installDeps([npm_cdktn, `constructs@10`], false, silent);
   installDeps(
     ["@types/node", "typescript@5.x", "jest", "@types/jest", "ts-jest", "ts-node"],
     true,


### PR DESCRIPTION
Rename fields on the `Deps` interface from `npm_cdktf` to `npm_cdktn`, `pypi_cdktf` to `pypi_cdktn`, etc.

This change should be totally internal.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

Rename some internal fields from "_cdktf" to "_cdktn".

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
