### PR TITLE
chore: rename CdktfProject to CdktnProject

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/cdktn-project-io-handler.ts
+++ b/packages/@cdktn/cli-core/src/lib/cdktn-project-io-handler.ts
@@ -8,13 +8,13 @@ import {
   isWaitingForUserInputUpdate,
   MultiStackUpdate,
   LogMessage,
-} from "./cdktf-project";
+} from "./cdktn-project";
 
 /**
- * This class is used to buffer events while the user is being asked for input. It is solely consumed by the CdktfProject class,
- * and is mostly created as a separation of concerns to keep the CdktfProject class as clean as possible.
+ * This class is used to buffer events while the user is being asked for input. It is solely consumed by the CdktnProject class,
+ * and is mostly created as a separation of concerns to keep the CdktnProject class as clean as possible.
  */
-export class CdktfProjectIOHandler {
+export class CdktnProjectIOHandler {
   // Pauses all progress / status events from being forwarded to the user
   // If set from true to false, the events will be sent through the channels they came in
   // (until a waiting for approval event is sent)

--- a/packages/@cdktn/cli-core/src/lib/cdktn-project.ts
+++ b/packages/@cdktn/cli-core/src/lib/cdktn-project.ts
@@ -29,7 +29,7 @@ import {
   getStackWithNoUnmetDependants,
   getStackWithNoUnmetDependencies,
 } from "./helpers/stack-helpers";
-import { CdktfProjectIOHandler } from "./cdktf-project-io-handler";
+import { CdktnProjectIOHandler } from "./cdktn-project-io-handler";
 
 type MultiStackApprovalUpdate = {
   type: "waiting for approval";
@@ -135,7 +135,7 @@ export function isWaitingForUserInputUpdate(
 export type ProjectEvent =
   | Buffered<ProjectUpdate, "projectUpdate">
   | Buffered<LogMessage, "logMessage">;
-export type CdktfProjectOptions = {
+export type CdktnProjectOptions = {
   synthCommand: string;
   outDir: string;
   onUpdate: (update: ProjectUpdate) => void;
@@ -144,7 +144,7 @@ export type CdktfProjectOptions = {
   synthOrigin?: SynthOrigin;
   hcl?: boolean;
 };
-export class CdktfProject {
+export class CdktnProject {
   public stacks?: SynthesizedStack[];
   public hardAbort: () => void;
 
@@ -163,7 +163,7 @@ export class CdktfProject {
   private stopAllStacksThatCanNotRunWithout: (stackName: string) => void =
     () => {};
 
-  private ioHandler: CdktfProjectIOHandler;
+  private ioHandler: CdktnProjectIOHandler;
 
   constructor({
     synthCommand,
@@ -173,7 +173,7 @@ export class CdktfProject {
     workingDirectory = process.cwd(),
     synthOrigin,
     hcl = false,
-  }: CdktfProjectOptions) {
+  }: CdktnProjectOptions) {
     this.synthCommand = synthCommand;
     this.outDir = outDir;
     this.workingDirectory = workingDirectory;
@@ -188,7 +188,7 @@ export class CdktfProject {
       hcl;
 
     this.hardAbort = ac.abort.bind(ac);
-    this.ioHandler = new CdktfProjectIOHandler();
+    this.ioHandler = new CdktnProjectIOHandler();
   }
 
   private stopAllStacks() {

--- a/packages/@cdktn/cli-core/src/lib/index.ts
+++ b/packages/@cdktn/cli-core/src/lib/index.ts
@@ -17,7 +17,7 @@ export { CdktfStack } from "./cdktf-stack";
 export { init, Project, InitArgs, templates, templatesDir } from "./init";
 export { get, GetStatus, runGetInDir } from "./get";
 export { SynthesizedStack } from "./synth-stack";
-export { CdktfProject, ProjectUpdate } from "./cdktf-project";
+export { CdktnProject, ProjectUpdate } from "./cdktn-project";
 export { watch, State as WatchState } from "./watch";
 export {
   NestedTerraformOutputs,

--- a/packages/@cdktn/cli-core/src/lib/watch.ts
+++ b/packages/@cdktn/cli-core/src/lib/watch.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MPL-2.0
 import path from "path";
 import {
-  CdktfProject,
-  CdktfProjectOptions,
+  CdktnProject,
+  CdktnProjectOptions,
   MutationOptions,
-} from "./cdktf-project";
+} from "./cdktn-project";
 import * as fs from "fs";
 import * as chokidar from "chokidar";
 import { logger, Errors, sendTelemetry } from "@cdktn/commons";
@@ -68,7 +68,7 @@ function getOrWriteDefaultWatchConfig(projectPath = process.cwd()) {
   return defaultWatchPattern;
 }
 
-const projectStatus = (project?: CdktfProject) => {
+const projectStatus = (project?: CdktnProject) => {
   if (!project?.stacksToRun.length) {
     return {
       inProgress: [],
@@ -98,7 +98,7 @@ export type State =
   | { type: "stopped" };
 
 export async function watch(
-  projectOptions: CdktfProjectOptions,
+  projectOptions: CdktnProjectOptions,
   mutationOptions: MutationOptions,
   abortSignal: AbortSignal,
   onStateChange: (newState: State) => void,
@@ -115,7 +115,7 @@ export async function watch(
 
   async function run() {
     logger.debug("Running cdktn deploy");
-    const project = new CdktfProject({
+    const project = new CdktnProject({
       synthOrigin: "watch",
       ...projectOptions,
       onLog: (log) => {

--- a/packages/@cdktn/cli-core/src/test/lib/cdktn-project.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/cdktn-project.test.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MPL-2.0
 import * as fs from "fs-extra";
 import * as path from "path";
-import { CdktfProject, get, init } from "../../lib/index";
+import { CdktnProject, get, init } from "../../lib/index";
 import { Language } from "@cdktn/commons";
 import { SynthesizedStack } from "../../lib/synth-stack";
 import { getMultipleStacks } from "../../lib/helpers/stack-helpers";
-import { LogMessage } from "../../lib/cdktf-project";
+import { LogMessage } from "../../lib/cdktn-project";
 import { createTmpHelper, describeIfDistExists } from "../test-helpers";
 
 const tmp = createTmpHelper();
@@ -26,17 +26,17 @@ function installFixturesInWorkingDirectory(
     workingDirectory: string;
   },
 
-  fixtureName: string
+  fixtureName: string,
 ) {
   fs.copyFileSync(
     path.resolve(__dirname, `fixtures/${fixtureName}/main.ts.fixture`),
-    path.resolve(workingDirectory, "main.ts")
+    path.resolve(workingDirectory, "main.ts"),
   );
   return { outDir, workingDirectory };
 }
 
 jest.setTimeout(300_000);
-describeIfDistExists(__dirname)("CdktfProject", () => {
+describeIfDistExists(__dirname)("CdktnProject", () => {
   let inNewWorkingDirectory: () => {
     workingDirectory: string;
     outDir: string;
@@ -57,11 +57,11 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     fs.copyFileSync(
       path.resolve(__dirname, "fixtures/default/main.ts.fixture"),
-      path.resolve(workingDirectory, "main.ts")
+      path.resolve(workingDirectory, "main.ts"),
     );
     fs.copyFileSync(
       path.resolve(__dirname, "fixtures/default/cdktf.json"),
-      path.resolve(workingDirectory, "cdktf.json")
+      path.resolve(workingDirectory, "cdktf.json"),
     );
 
     await get({
@@ -94,19 +94,19 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
     };
   }, 200_000);
 
-  it("should be able to create a CdktfProject", () => {
-    const cdktfProject = new CdktfProject({
+  it("should be able to create a CdktnProject", () => {
+    const cdktnProject = new CdktnProject({
       synthCommand: "npx ts-node main.ts",
       ...inNewWorkingDirectory(),
       onUpdate: () => {},
     });
-    expect(cdktfProject).toBeTruthy();
+    expect(cdktnProject).toBeTruthy();
   });
 
   describe("synth", () => {
     it("runs synth command in the target dir and is done", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -114,7 +114,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      await cdktfProject.synth();
+      await cdktnProject.synth();
 
       expect(eventNames(events)).toEqual(["synthesizing", "synthesized"]);
     });
@@ -125,7 +125,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect.assertions(2);
       const events: any[] = [];
       const logs: LogMessage[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -134,7 +134,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         onLog: (msg) => logs.push(msg),
       });
 
-      await cdktfProject.diff({ stackName: "first" });
+      await cdktnProject.diff({ stackName: "first" });
 
       expect(eventNames(events)).toEqual([
         "synthesizing",
@@ -146,15 +146,15 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect(logs).toContainEqual(
         expect.objectContaining({
           message: expect.stringContaining(
-            "1 to add, 0 to change, 0 to destroy"
+            "1 to add, 0 to change, 0 to destroy",
           ),
-        })
+        }),
       );
     });
 
     it("fails if no stack specified", () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -162,8 +162,8 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      return expect(cdktfProject.diff()).rejects.toMatchInlineSnapshot(
-        `[Error: Usage Error: Found more than one stack, please specify a target stack. Run cdktn diff <stack> with one of these stacks: fifth, first, fourth, second, third ]`
+      return expect(cdktnProject.diff()).rejects.toMatchInlineSnapshot(
+        `[Error: Usage Error: Found more than one stack, please specify a target stack. Run cdktn diff <stack> with one of these stacks: fifth, first, fourth, second, third ]`,
       );
     });
   });
@@ -171,7 +171,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
   describe("deploy", () => {
     it("runs synth once and waits for approval", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -183,7 +183,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      await cdktfProject.deploy({ stackNames: ["first"], parallelism: 1 });
+      await cdktnProject.deploy({ stackNames: ["first"], parallelism: 1 });
 
       return expect(eventNames(events)).toEqual([
         "synthesizing",
@@ -198,7 +198,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("runs synth once and deploys on autoApprove", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -209,7 +209,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["first"],
         autoApprove: true,
         parallelism: 1,
@@ -230,7 +230,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
   describe("destroy", () => {
     it("runs synth once and waits for approval", async () => {
       let events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -244,7 +244,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
       // we need to deploy first to have something to destroy
       // (else TF CLI wouldn't ask us to confirm as there's nothing)
-      await cdktfProject.deploy({ stackNames: ["second"] });
+      await cdktnProject.deploy({ stackNames: ["second"] });
       const lastEvent = events.pop();
       expect(lastEvent).toHaveProperty("type", "deployed");
       expect(lastEvent).toHaveProperty("stackName", "second");
@@ -252,7 +252,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       // clear events before next invocation
       events = [];
 
-      await cdktfProject.destroy({ stackNames: ["second"], parallelism: 1 });
+      await cdktnProject.destroy({ stackNames: ["second"], parallelism: 1 });
 
       return expect(eventNames(events)).toEqual([
         "synthesizing",
@@ -267,7 +267,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("runs synth once and destroys on autoApprove", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -275,7 +275,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      await cdktfProject.destroy({
+      await cdktnProject.destroy({
         stackNames: ["second"],
         autoApprove: true,
         parallelism: 1,
@@ -296,7 +296,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
   describe("multi-stack", () => {
     it("Errors if a stack can not be found", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -305,15 +305,15 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       await expect(
-        cdktfProject.deploy({ stackNames: ["not-found"], parallelism: 1 })
+        cdktnProject.deploy({ stackNames: ["not-found"], parallelism: 1 }),
       ).rejects.toMatchInlineSnapshot(
-        `[Error: Usage Error: Could not find stack for pattern 'not-found']`
+        `[Error: Usage Error: Could not find stack for pattern 'not-found']`,
       );
     });
 
     it("Errors if a dependent stack can not be found", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -322,15 +322,15 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       await expect(
-        cdktfProject.deploy({ stackNames: ["third"], parallelism: 1 })
+        cdktnProject.deploy({ stackNames: ["third"], parallelism: 1 }),
       ).rejects.toMatchInlineSnapshot(
-        `[Error: Usage Error: The following dependencies are not included in the stacks to run: first. Either add them or add the --ignore-missing-stack-dependencies flag.]`
+        `[Error: Usage Error: The following dependencies are not included in the stacks to run: first. Either add them or add the --ignore-missing-stack-dependencies flag.]`,
       );
     });
 
     it("Does not error if a dependent stack can not be found but the ignore option is passed", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -338,7 +338,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["third"],
         autoApprove: true,
         ignoreMissingStackDependencies: true,
@@ -350,7 +350,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("deploys stacks in the right order", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -363,7 +363,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       // Random order to implicitly test out sorting
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["third", "first", "second"],
         parallelism: 1,
       });
@@ -371,7 +371,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect(
         events
           .filter((e) => !e.type.includes("update"))
-          .map((e) => `${e.stackName || "global"}: ${e.type}`)
+          .map((e) => `${e.stackName || "global"}: ${e.type}`),
       ).toEqual([
         "global: synthesizing",
         "global: synthesized",
@@ -395,11 +395,11 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("error in an deploying stack does not abort already running stacks", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...installFixturesInWorkingDirectory(
           inNewWorkingDirectory(),
-          "parallel-error"
+          "parallel-error",
         ),
         onUpdate: (event) => {
           events.push(event);
@@ -407,7 +407,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       try {
-        await cdktfProject
+        await cdktnProject
           .deploy({
             stackNames: ["stack1", "stack2", "stack3"],
             parallelism: 100,
@@ -421,7 +421,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         throw new Error("This error should not be thrown");
       } catch (e) {
         expect(e).toMatchInlineSnapshot(
-          `"Invoking Terraform CLI failed with exit code 1"`
+          `"Invoking Terraform CLI failed with exit code 1"`,
         );
       }
 
@@ -448,13 +448,17 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       // the middle events can occur in any order as the duration
       // they take to plan is not guaranteed
       expect(new Set(relevantEvents.slice(5, -3))).toEqual(
-        new Set(["stack1: deploying", "stack2: deploying", "stack3: deploying"])
+        new Set([
+          "stack1: deploying",
+          "stack2: deploying",
+          "stack3: deploying",
+        ]),
       );
     }, 120_000);
 
     it("deploys stacks in the right order with auto approve", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -463,7 +467,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       // Random order to implicitly test out sorting
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["third", "first", "second"],
         autoApprove: true,
         parallelism: 1,
@@ -472,7 +476,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect(
         events
           .filter((e) => !e.type.includes("update"))
-          .map((e) => `${e.stackName || "global"}: ${e.type}`)
+          .map((e) => `${e.stackName || "global"}: ${e.type}`),
       ).toEqual([
         "global: synthesizing",
         "global: synthesized",
@@ -490,7 +494,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("only aborts dependant stacks when deploying", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -507,7 +511,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       // Random order to implicitly test out sorting
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["third", "first", "second", "fourth", "fifth"],
         parallelism: 1,
       });
@@ -515,7 +519,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect(
         events
           .filter((e) => !e.type.includes("update"))
-          .map((e) => `${e.stackName || "global"}: ${e.type}`)
+          .map((e) => `${e.stackName || "global"}: ${e.type}`),
       ).toEqual([
         "global: synthesizing",
         "global: synthesized",
@@ -543,7 +547,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("destroys stacks in the right order", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -552,7 +556,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       // To destroy sth we need to deploy first, with a different project to not polute the event list
-      new CdktfProject({
+      new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: () => {},
@@ -563,7 +567,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       // Random order to implicitly test out sorting
-      await cdktfProject.destroy({
+      await cdktnProject.destroy({
         stackNames: ["third", "first", "second", "fourth", "fifth"],
         autoApprove: true,
         parallelism: 1,
@@ -572,7 +576,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect(
         events
           .filter((e) => !e.type.includes("update"))
-          .map((e) => `${e.stackName || "global"}: ${e.type}`)
+          .map((e) => `${e.stackName || "global"}: ${e.type}`),
       ).toEqual([
         "global: synthesizing",
         "global: synthesized",
@@ -596,7 +600,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
 
     it("only aborts dependant when destroying", async () => {
       let events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -613,7 +617,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       });
 
       // To destroy sth we need to deploy first, using the same project (= same working directory)
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["third", "first", "second", "fourth", "fifth"],
         autoApprove: true,
         parallelism: 1,
@@ -625,7 +629,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       events = []; // clear events
 
       // Random order to implicitly test out sorting
-      await cdktfProject.destroy({
+      await cdktnProject.destroy({
         stackNames: ["third", "first", "second", "fourth", "fifth"],
         parallelism: 1,
       });
@@ -633,7 +637,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
       expect(
         events
           .filter((e) => !e.type.includes("update"))
-          .map((e) => `${e.stackName || "global"}: ${e.type}`)
+          .map((e) => `${e.stackName || "global"}: ${e.type}`),
       ).toEqual([
         "global: synthesizing",
         "global: synthesized",
@@ -664,11 +668,11 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
     it("stalls logs and updates while waiting for approval", async () => {
       let events: any[] = [];
       let eventsDuringWaitForApprove: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...installFixturesInWorkingDirectory(
           inNewWorkingDirectory(),
-          "parallel"
+          "parallel",
         ),
         onUpdate: (event) => {
           events.push(event);
@@ -689,7 +693,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         },
       });
 
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: new Array(5).fill(0).map((_, i) => `stack-${i}`),
         parallelism: 100,
       });
@@ -725,7 +729,7 @@ describe("getMultipleStacks", () => {
       ] as SynthesizedStack[];
 
       expect(
-        getMultipleStacks(synthesizedStacks, ["StackB", "StackC"])
+        getMultipleStacks(synthesizedStacks, ["StackB", "StackC"]),
       ).toEqual([{ name: "StackB" }, { name: "StackC" }]);
     });
 
@@ -737,7 +741,7 @@ describe("getMultipleStacks", () => {
       ] as SynthesizedStack[];
 
       expect(() =>
-        getMultipleStacks(synthesizedStacks, ["StackD", "StackC"])
+        getMultipleStacks(synthesizedStacks, ["StackD", "StackC"]),
       ).toThrow();
     });
   });

--- a/packages/@cdktn/cli-core/src/test/lib/terraform-parallelism.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/terraform-parallelism.test.ts
@@ -6,7 +6,7 @@
 import path from "path";
 import * as fs from "fs-extra";
 import { EventEmitter } from "events";
-import { CdktfProject, init } from "../../lib/index";
+import { CdktnProject, init } from "../../lib/index";
 import { spawn } from "cross-spawn";
 import { exec } from "@cdktn/commons";
 import { createTmpHelper, describeIfDistExists } from "../test-helpers";
@@ -147,7 +147,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
   describe("terraform parallelism flag in deploy", () => {
     it("passes the terraform parallelism flag to terraform", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -158,7 +158,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         },
       });
 
-      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+      cdktnProject.synth = jest.fn().mockImplementation(async () => {
         return [
           stackWithName("first"),
           stackWithName("second"),
@@ -167,7 +167,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         ];
       });
 
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["first"],
         autoApprove: true,
         parallelism: 1,
@@ -181,7 +181,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
 
     it("ignores the terraform parallelism flag if negative", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -192,7 +192,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         },
       });
 
-      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+      cdktnProject.synth = jest.fn().mockImplementation(async () => {
         return [
           stackWithName("first"),
           stackWithName("second"),
@@ -201,7 +201,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         ];
       });
 
-      await cdktfProject.deploy({
+      await cdktnProject.deploy({
         stackNames: ["first"],
         autoApprove: true,
         parallelism: 1,
@@ -217,7 +217,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
   describe("terraform parallelism flag in destroy", () => {
     it("passes the terraform parallelism flag to terraform", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -225,7 +225,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         },
       });
 
-      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+      cdktnProject.synth = jest.fn().mockImplementation(async () => {
         return [
           stackWithName("first"),
           stackWithName("second"),
@@ -234,7 +234,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         ];
       });
 
-      await cdktfProject.destroy({
+      await cdktnProject.destroy({
         stackNames: ["second"],
         autoApprove: true,
         parallelism: 1,
@@ -248,7 +248,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
 
     it("doesn't pass the terraform parallelism flag if negative", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -256,7 +256,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         },
       });
 
-      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+      cdktnProject.synth = jest.fn().mockImplementation(async () => {
         return [
           stackWithName("first"),
           stackWithName("second"),
@@ -265,7 +265,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         ];
       });
 
-      await cdktfProject.destroy({
+      await cdktnProject.destroy({
         stackNames: ["second"],
         autoApprove: true,
         parallelism: 1,
@@ -281,7 +281,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
   describe("terraform parallelism flag in diff", () => {
     it("passes the terraform parallelism flag to terraform", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -292,7 +292,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         },
       });
 
-      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+      cdktnProject.synth = jest.fn().mockImplementation(async () => {
         return [
           stackWithName("first"),
           stackWithName("second"),
@@ -301,7 +301,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         ];
       });
 
-      await cdktfProject.diff({
+      await cdktnProject.diff({
         stackName: "first",
         terraformParallelism: 1,
       });
@@ -313,7 +313,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
 
     it("ignores the terraform parallelism flag if negative", async () => {
       const events: any[] = [];
-      const cdktfProject = new CdktfProject({
+      const cdktnProject = new CdktnProject({
         synthCommand: "npx ts-node ./main.ts",
         ...inNewWorkingDirectory(),
         onUpdate: (event) => {
@@ -324,7 +324,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         },
       });
 
-      cdktfProject.synth = jest.fn().mockImplementation(async () => {
+      cdktnProject.synth = jest.fn().mockImplementation(async () => {
         return [
           stackWithName("first"),
           stackWithName("second"),
@@ -333,7 +333,7 @@ describeIfDistExists(__dirname)("terraform parallelism", () => {
         ];
       });
 
-      await cdktfProject.diff({
+      await cdktnProject.diff({
         stackName: "first",
         terraformParallelism: -1,
       });

--- a/packages/cdktn-cli/src/bin/cmds/helper/check-directory.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/check-directory.ts
@@ -3,7 +3,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Errors } from "@cdktn/commons";
-export function isCdktfProjectDirectory(directory: string): boolean {
+export function isCdktnProjectDirectory(directory: string): boolean {
   try {
     const cdktfPath = path.join(directory, "cdktf.json");
     const cdktf = JSON.parse(fs.readFileSync(cdktfPath, "utf-8"));
@@ -14,7 +14,7 @@ export function isCdktfProjectDirectory(directory: string): boolean {
 }
 
 export function throwIfNotProjectDirectory(directory = process.cwd()): void {
-  if (!isCdktfProjectDirectory(directory)) {
+  if (!isCdktnProjectDirectory(directory)) {
     throw Errors.Usage(
       `${directory} is not a cdktf/cdktn project directory, no cdktf.json found or cdktf.json is missing language / app keys`,
     );

--- a/packages/cdktn-cli/src/bin/cmds/ui/components/bottom-bars/status.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/components/bottom-bars/status.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import { Text, Box } from "ink";
 import Spinner from "ink-spinner";
-import { Status } from "../../hooks/cdktf-project";
+import { Status } from "../../hooks/cdktn-project";
 import { WatchState, CdktfStack } from "@cdktn/cli-core";
 
 type Props = {

--- a/packages/cdktn-cli/src/bin/cmds/ui/components/stream-view.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/components/stream-view.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { Box, Static, Text } from "ink";
-import { LogEntry } from "../hooks/cdktf-project";
+import { LogEntry } from "../hooks/cdktn-project";
 
 const possibleColors = [
   "yellow",

--- a/packages/cdktn-cli/src/bin/cmds/ui/deploy.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/deploy.tsx
@@ -6,7 +6,7 @@
 import React, { useState } from "react";
 import { Text, Box } from "ink";
 import { DeployingResource, NestedTerraformOutputs } from "@cdktn/cli-core";
-import { useCdktfProject } from "./hooks/cdktf-project";
+import { useCdktnProject } from "./hooks/cdktn-project";
 import {
   StreamView,
   OutputsBottomBar,
@@ -88,7 +88,7 @@ export const Deploy = ({
   skipProviderLock,
 }: DeployConfig): React.ReactElement => {
   const [outputs, setOutputs] = useState<NestedTerraformOutputs>();
-  const { status, logEntries } = useCdktfProject(
+  const { status, logEntries } = useCdktnProject(
     { outDir, synthCommand },
     async (project) => {
       await project.deploy({

--- a/packages/cdktn-cli/src/bin/cmds/ui/destroy.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/destroy.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 
-import { useCdktfProject } from "./hooks/cdktf-project";
+import { useCdktnProject } from "./hooks/cdktn-project";
 import {
   StreamView,
   ExecutionStatusBottomBar,
@@ -44,7 +44,7 @@ export const Destroy = ({
   skipSynth,
   skipProviderLock,
 }: DestroyConfig): React.ReactElement => {
-  const { status, logEntries } = useCdktfProject(
+  const { status, logEntries } = useCdktnProject(
     { outDir, synthCommand },
     (project) =>
       project.destroy({

--- a/packages/cdktn-cli/src/bin/cmds/ui/diff.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/diff.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 
-import { useCdktfProject } from "./hooks/cdktf-project";
+import { useCdktnProject } from "./hooks/cdktn-project";
 import { StreamView, StatusBottomBar } from "./components";
 
 interface DiffConfig {
@@ -35,7 +35,7 @@ export const Diff = ({
   skipSynth,
   skipProviderLock,
 }: DiffConfig): React.ReactElement => {
-  const { status, logEntries } = useCdktfProject(
+  const { status, logEntries } = useCdktnProject(
     { outDir, synthCommand },
     (project) =>
       project.diff({

--- a/packages/cdktn-cli/src/bin/cmds/ui/hooks/cdktn-project.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/hooks/cdktn-project.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { useApp } from "ink";
 import { useEffect, useState } from "react";
-import { CdktfProject, ProjectUpdate, CdktfStack } from "@cdktn/cli-core";
+import { CdktnProject, ProjectUpdate, CdktfStack } from "@cdktn/cli-core";
 
 export type LogEntry = {
   content: string;
@@ -10,7 +10,7 @@ export type LogEntry = {
   stackName: string;
 };
 
-type CdktfProjectOpts = {
+type CdktnProjectOps = {
   outDir: string;
   synthCommand: string;
   hcl?: boolean;
@@ -46,9 +46,9 @@ export type Status =
       type: "done";
     };
 
-export function useCdktfProject<T>(
-  opts: CdktfProjectOpts,
-  projectCallback: (project: CdktfProject) => Promise<T>,
+export function useCdktnProject<T>(
+  opts: CdktnProjectOps,
+  projectCallback: (project: CdktnProject) => Promise<T>,
 ) {
   const { exit } = useApp();
   const [id, setID] = useState<number>(0);
@@ -57,7 +57,7 @@ export function useCdktfProject<T>(
   const [returnValue, setReturnValue] = useState<T>();
   const [status, setStatus] = useState<Status>({ type: "starting" });
 
-  const updateRunningStatus = (project: CdktfProject) => {
+  const updateRunningStatus = (project: CdktnProject) => {
     const inProgress = project.stacksToRun.filter((s) => s.isRunning);
     const finished = project.stacksToRun.filter((s) => s.isDone);
     const pending = project.stacksToRun.filter((s) => s.isPending);
@@ -65,7 +65,7 @@ export function useCdktfProject<T>(
   };
 
   useEffect(() => {
-    const project = new CdktfProject({
+    const project = new CdktnProject({
       outDir: opts.outDir,
       hcl: opts.hcl,
       synthCommand: opts.synthCommand,

--- a/packages/cdktn-cli/src/bin/cmds/ui/list.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/list.tsx
@@ -5,7 +5,7 @@
 
 import React, { Fragment } from "react";
 import { Text, Box } from "ink";
-import { useCdktfProject } from "./hooks/cdktf-project";
+import { useCdktnProject } from "./hooks/cdktn-project";
 import { StreamView, StatusBottomBar } from "./components";
 
 interface ListConfig {
@@ -17,7 +17,7 @@ export const List = ({
   outDir,
   synthCommand,
 }: ListConfig): React.ReactElement => {
-  const { status, logEntries, returnValue } = useCdktfProject(
+  const { status, logEntries, returnValue } = useCdktnProject(
     { outDir, synthCommand },
     (project) => project.synth(),
   );

--- a/packages/cdktn-cli/src/bin/cmds/ui/output.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/output.tsx
@@ -5,7 +5,7 @@
 
 import React from "react";
 import { NestedTerraformOutputs } from "@cdktn/cli-core";
-import { useCdktfProject } from "./hooks/cdktf-project";
+import { useCdktnProject } from "./hooks/cdktn-project";
 import { StreamView, OutputsBottomBar, StatusBottomBar } from "./components";
 
 type OutputConfig = {
@@ -27,7 +27,7 @@ export const Output = ({
   skipSynth,
   skipProviderLock,
 }: OutputConfig): React.ReactElement => {
-  const { status, logEntries, returnValue } = useCdktfProject(
+  const { status, logEntries, returnValue } = useCdktnProject(
     { outDir, synthCommand },
     async (project) => {
       const outputs = await project.fetchOutputs({

--- a/packages/cdktn-cli/src/bin/cmds/ui/synth.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/synth.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import { Text } from "ink";
 
-import { useCdktfProject } from "./hooks/cdktf-project";
+import { useCdktnProject } from "./hooks/cdktn-project";
 import { StreamView } from "./components";
 import { SynthesizedStack } from "@cdktn/cli-core";
 import { StatusBottomBar } from "./components/bottom-bars/status";
@@ -36,7 +36,7 @@ export const Synth = ({
   synthCommand,
   hcl,
 }: SynthConfig): React.ReactElement => {
-  const { returnValue, logEntries, status } = useCdktfProject(
+  const { returnValue, logEntries, status } = useCdktnProject(
     { outDir, synthCommand, hcl },
     (project) => project.synth(),
   );

--- a/packages/cdktn-cli/src/bin/cmds/ui/watch.tsx
+++ b/packages/cdktn-cli/src/bin/cmds/ui/watch.tsx
@@ -6,7 +6,7 @@
 import React, { useEffect, useState } from "react";
 import { watch, WatchState } from "@cdktn/cli-core";
 import { StreamView, WatchStatusBottomBar } from "./components";
-import { LogEntry } from "./hooks/cdktf-project";
+import { LogEntry } from "./hooks/cdktn-project";
 
 interface WatchConfig {
   targetDir: string;


### PR DESCRIPTION
Rename internal "project" symbols from cdktf to cdktn.

This should *not* affect external consumers. This is an internal refactoring only.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

`CdktfProject` -> `CdktnProject`

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
