### PR TITLE
chore: rename cdktfVersion context field

### DIFF
--- a/packages/cdktn/src/app.ts
+++ b/packages/cdktn/src/app.ts
@@ -117,7 +117,7 @@ export class App extends Construct {
       node.setContext(DISABLE_STACK_TRACE_IN_METADATA, true);
     }
 
-    node.setContext("cdktfVersion", version);
+    node.setContext("cdktnVersion", version);
 
     if (!fs.existsSync(this.outdir)) {
       fs.mkdirSync(this.outdir);

--- a/packages/cdktn/src/terraform-stack.ts
+++ b/packages/cdktn/src/terraform-stack.ts
@@ -85,7 +85,7 @@ export class TerraformStack extends Construct {
 
     throwIfIdIsGlobCharacter(id);
     throwIfIdContainsWhitespace(id);
-    this.cdktfVersion = this.node.tryGetContext("cdktfVersion");
+    this.cdktfVersion = this.node.tryGetContext("cdktnVersion");
     this.synthesizer = new StackSynthesizer(
       this,
       process.env.CDKTF_CONTINUE_SYNTH_ON_ERROR_ANNOTATIONS !== undefined,

--- a/packages/cdktn/src/testing/index.ts
+++ b/packages/cdktn/src/testing/index.ts
@@ -75,7 +75,7 @@ export class Testing {
   }
 
   public static stubVersion(app: App): App {
-    app.node.setContext("cdktfVersion", "stubbed");
+    app.node.setContext("cdktnVersion", "stubbed");
     (app.manifest.version as string) = "stubbed";
     return app;
   }

--- a/packages/cdktn/test/app.test.ts
+++ b/packages/cdktn/test/app.test.ts
@@ -57,13 +57,13 @@ test("context can be passed through CDKTF_CONTEXT", () => {
   expect(node.tryGetContext("key2")).toEqual("val2");
 });
 
-test("cdktfVersion is accessible in context", () => {
+test("cdktnVersion is accessible in context", () => {
   const prog = Testing.app({ stubVersion: false, enableFutureFlags: false });
   const node = prog.node;
-  expect(node.tryGetContext("cdktfVersion")).toEqual(version);
+  expect(node.tryGetContext("cdktnVersion")).toEqual(version);
 });
 
-test("app synth does not throw error when validatons are disabled", () => {
+test("app synth does not throw error when validations are disabled", () => {
   const outdir = tmp("cdktf.outdir.");
   const app = Testing.stubVersion(
     new App({ stackTraces: false, outdir, skipValidation: true }),


### PR DESCRIPTION
Christen it `cdktnVersion`.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

Rename the `cdktfVersion` field we save on node context.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
