### PR TITLE
fix(release): add Changelog title for correct release-please insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 0.23.3
 
 ### chore


### PR DESCRIPTION
### Description

Fixes the changelog insertion position in release-please's standing release PR (observed in #254, where `## [0.23.4]` was injected **below** `## 0.23.3` instead of at the top).

#### Root cause

release-please's changelog updater finds where to insert a new entry with this regex (`src/updaters/changelog.ts`):

```js
DEFAULT_VERSION_HEADER_REGEX = '\n###? v?[0-9[]'
```

The leading `\n` means it only matches a version header that has a **newline before it**, and it inserts immediately before the first match. Our `CHANGELOG.md` began at byte 0 with:

```
## 0.23.3      ← no preceding newline → not matched
...
## 0.23.2      ← preceded by \n → first match
```

So the top `## 0.23.3` was skipped and the new entry was inserted before `## 0.23.2` — i.e. below 0.23.3.

#### Fix

Prepend a `# Changelog` H1 so the first version header has a preceding newline:

```diff
+# Changelog
+
 ## 0.23.3
```

release-please now inserts new entries at the top. The plain (`## 0.23.3`) vs. linked (`## [0.23.4](…)`) header format is irrelevant to the matcher, so existing entries are left untouched — minimal 2-line diff.

#### After merge

On the next push to `main`, release-please rebases its standing release PR (#254) and will regenerate the `CHANGELOG.md` diff with the entry inserted at the top.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable

https://claude.ai/code/session_0168ykjbd1W96iSBoQUEkSLE

---
_Generated by [Claude Code](https://claude.ai/code/session_0168ykjbd1W96iSBoQUEkSLE)_