### PR TITLE
chore: add uv to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,3 @@
-# SpecLedger mise configuration
-# Issue tracking is now built into sl CLI (sl issue commands)
-
 [settings]
 idiomatic_version_file_enable_tools = ["node"]
 
@@ -9,6 +6,7 @@ python = '3.11'
 go = '1.25'
 java = "prefix:corretto-20"
 dotnet = "6.0"  # Match jsii-superchain DOTNET_CHANNEL
+uv = "0.11.19" # Used by the pipx backend
 "pipx:pipenv" = "latest"
 
 terraform = "1.7.5"


### PR DESCRIPTION
We currently have `pipx:pipenv` in our mise tools. But that fails to install unless uv or pipx are already installed. The solution is to add uv to our mise tools so that dev environments without any existing python tooling can be bootstrapped.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes # <!-- INSERT ISSUE NUMBER -->

### Description

The `pipx:pipenv tool` relies on mise's `pipx` backend, which shells out to either pipx or uv. So one of those tools should be in mise.toml.

See https://mise.jdx.dev/dev-tools/backends/pipx.html

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
