### PR TITLE
fix(gha): pull jsii-terraform CI image from GHCR instead of Docker Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build-and-package:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,15 +20,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Cache Docker layers
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ hashFiles('/Dockerfile', '.terraform.versions.json') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Login to DockerHub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -66,8 +61,12 @@ jobs:
             ghcr.io/open-constructs/jsii-terraform:latest
             ghcr.io/open-constructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}
             ghcr.io/open-constructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}-${{ steps.git-sha.outputs.git-sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # Registry-backed layer cache instead of the GitHub Actions cache:
+          # writing to it requires packages:write, which only this workflow's
+          # token has, so it cannot be poisoned from less-privileged contexts
+          # (zizmor cache-poisoning).
+          cache-from: type=registry,ref=ghcr.io/open-constructs/jsii-terraform:buildcache
+          cache-to: type=registry,ref=ghcr.io/open-constructs/jsii-terraform:buildcache,mode=max
           build-args: |
             DEFAULT_TERRAFORM_VERSION=${{ steps.tf-versions.outputs.default }}
             AVAILABLE_TERRAFORM_VERSIONS=${{ steps.tf-versions.outputs.available }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,9 @@ jobs:
   build-docker-image:
     if: github.repository == 'open-constructs/cdk-terrain'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Docker Buildx
@@ -31,6 +34,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - id: tf-versions
         run: |
           DEFAULT_TERRAFORM_VERSION=$(cat .terraform.versions.json | jq -r '.default')
@@ -50,7 +59,13 @@ jobs:
         with:
           pull: true
           push: true
-          tags: terraconstructs/jsii-terraform:latest,terraconstructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }},terraconstructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}-${{ steps.git-sha.outputs.git-sha }}
+          tags: |
+            terraconstructs/jsii-terraform:latest
+            terraconstructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}
+            terraconstructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}-${{ steps.git-sha.outputs.git-sha }}
+            ghcr.io/open-constructs/jsii-terraform:latest
+            ghcr.io/open-constructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}
+            ghcr.io/open-constructs/jsii-terraform:${{ steps.cdktn-version.outputs.cdktn }}-${{ steps.git-sha.outputs.git-sha }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,7 +35,7 @@ jobs:
   prepare-examples:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60
@@ -93,7 +93,7 @@ jobs:
       matrix: ${{fromJSON(needs.build-example-matrix.outputs.examples)}}
       max-parallel: 20
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60
@@ -103,7 +103,7 @@ jobs:
       matrix: ${{fromJSON(needs.prepare-integration-tests.outputs.tests)}}
       max-parallel: 30 # too many in parallel will give HTTP 429 errors from GH when checking out the source for example
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
       TERRAFORM_VERSION: ${{ matrix.terraform }}

--- a/.github/workflows/pnpm-upgrade.yml
+++ b/.github/workflows/pnpm-upgrade.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Check Out
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -113,7 +113,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     strategy:
       fail-fast: false
       matrix:
@@ -213,7 +213,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Check Out
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/pr-unit.yml
+++ b/.github/workflows/pr-unit.yml
@@ -19,7 +19,7 @@ jobs:
     name: "Affected Unit Tests (no terraform)"
     runs-on: depot-ubuntu-24.04-16
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
     name: "Affected Unit Tests (terraform)"
     runs-on: depot-ubuntu-24.04-16
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/.github/workflows/provider-integration.yml
+++ b/.github/workflows/provider-integration.yml
@@ -35,7 +35,7 @@ jobs:
     outputs:
       tests: ${{ steps.build-provider-test-matrix.outputs.tests }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 60
@@ -95,7 +95,7 @@ jobs:
       matrix: ${{fromJSON(needs.prepare-provider-tests.outputs.tests)}}
       max-parallel: 10
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
       TERRAFORM_VERSION: ${{ inputs.terraform_version }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,7 +20,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -38,7 +38,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/registry-docs-pr-based.yml
+++ b/.github/workflows/registry-docs-pr-based.yml
@@ -105,7 +105,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 120
@@ -145,7 +145,7 @@ jobs:
       matrix:
         files: ${{fromJSON(needs.cdktnDocsMatrix.outputs.matrix)}}
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     timeout-minutes: 360

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -38,7 +38,7 @@ jobs:
     name: Release to NPM (${{ inputs.channel }})
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     permissions:
       contents: read
       id-token: write
@@ -74,7 +74,7 @@ jobs:
     name: Release to PyPi (${{ inputs.channel }})
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -114,7 +114,7 @@ jobs:
     name: Release to Maven Central (${{ inputs.channel }})
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -147,7 +147,7 @@ jobs:
     name: Release to NuGet (${{ inputs.channel }})
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -175,7 +175,7 @@ jobs:
     name: Release Go to Github Repo (${{ inputs.channel }})
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       version: ${{ steps.get_version.outputs.version }}
       release_status: ${{ steps.get_release_status.outputs.release }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
@@ -106,7 +106,7 @@ jobs:
       tests: ${{ steps.build-test-matrix.outputs.tests }}
       version: ${{ steps.get_version.outputs.version }}
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     env:
       CHECKPOINT_DISABLE: "1"
     steps:
@@ -327,7 +327,7 @@ jobs:
       - unit_test
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -375,7 +375,7 @@ jobs:
       - publish_release
     if: needs.prepare-release.outputs.release_status == 'unreleased'
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -431,7 +431,7 @@ jobs:
       - publish_next
     runs-on: ubuntu-latest
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -24,7 +24,7 @@ jobs:
   unit-test:
     runs-on: depot-ubuntu-24.04-16
     container:
-      image: terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
+      image: ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
     timeout-minutes: 60
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@
 
 FROM public.ecr.aws/jsii/superchain:1-bookworm-slim-node22-nightly@sha256:06598e70ca71c3b8ebf3a8d6836449c682da10610026211c2d1b475974bb9d7b
 
+# Links the GHCR package to this repository so it shows up under the repo's
+# Packages and inherits repo-based access settings.
+LABEL org.opencontainers.image.source="https://github.com/open-constructs/cdk-terrain" \
+      org.opencontainers.image.description="jsii/superchain with Terraform toolchain for CDK Terrain CI and development" \
+      org.opencontainers.image.licenses="MPL-2.0"
+
 USER root
 
 ARG DEFAULT_TERRAFORM_VERSION


### PR DESCRIPTION
Refs #206 (GHCR-for-CI half; OCF Public ECR for the devcontainer is a follow-up).

## Why

Docker Hub's anonymous pull throttling on GitHub's shared runner IP pool is causing intermittent container-init failures across CI (see the audit in #206). All ~27 `container:` references across 12 workflows pull `terraconstructs/jsii-terraform` anonymously; GHCR public-package pulls from Actions runners are free, unmetered, and unauthenticated.

## What

- **`docker.yml`**: also pushes to `ghcr.io/open-constructs/jsii-terraform` (`packages: write` + `docker/login-action` against `ghcr.io` with `GITHUB_TOKEN`). Docker Hub publishing stays until consumers have moved.
- **`Dockerfile`**: adds `org.opencontainers.image.source` label so future pushes auto-link the GHCR package to this repo (plus description/licenses labels).
- **12 consumer workflows**: `container.image` repointed to `ghcr.io/open-constructs/jsii-terraform@sha256:c46ac91…` — the **same digest** as today, because the image is mirrored registry-to-registry (digest-preserving). No rebuild needed for this PR's CI to pass.

## Prerequisites before marking ready (one-time, maintainer)

- [x] Mirror the current image to GHCR (digest-preserving copy):
  ```sh
  echo $GHCR_TOKEN | docker login ghcr.io -u <user> --password-stdin   # PAT with write:packages
  docker buildx imagetools create \
    --tag ghcr.io/open-constructs/jsii-terraform:latest \
    docker.io/terraconstructs/jsii-terraform@sha256:c46ac91c8be20947a2b0e27a517eb4a5bfc015c16a27341876ed0b04d734ddf5
  ```
- [x] Set the new package **public** (org → Packages → jsii-terraform → settings → Change visibility). New GHCR packages default to private; anonymous CI pulls get 403 until this is done.
- [x] Manually link the package to this repo in package settings (the mirrored manifest predates the source label; the label takes over on the next `docker.yml` push to main).
- [x] Re-run CI on this PR to confirm GHCR pulls resolve, then mark ready.

## Follow-ups (tracked in #206)

- Mirror to OCF Public ECR for devcontainer/contributor distribution; update `.devcontainer.json` + `CONTRIBUTING.md`.
- Retire Docker Hub publishing and the `DOCKERHUB_*` secrets once consumers have moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)