### PR TITLE
fix(cli): don't mistake terraform error output for a missing-variable prompt

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts
@@ -84,16 +84,43 @@ export type DeployState =
       context: DeployContext;
     };
 
+/**
+ * Terraform's interactive prompt for a missing variable looks like:
+ *
+ *   var.<name>
+ *     Enter a value:
+ *
+ * The variable name appears on its own line, prefixed with "var." (optionally
+ * indented). We match this precisely so we don't mistake terraform error output
+ * that merely references a variable (e.g. "92:   mirror = var.mirror" from an
+ * "Unsupported argument" error) for an actual prompt. Terraform variable names
+ * start with a letter or underscore and may contain letters, digits,
+ * underscores and dashes. (#265)
+ */
+const VARIABLE_PROMPT_REGEX = /^\s*var\.([A-Za-z_][A-Za-z0-9_-]*)\s*$/;
+
+/**
+ * Returns true if any line in the given (ANSI-stripped) output is terraform's
+ * interactive prompt for a missing variable.
+ */
+export function isMissingVariablePrompt(noColorLine: string): boolean {
+  return noColorLine
+    .split("\n")
+    .some((line) => VARIABLE_PROMPT_REGEX.test(line));
+}
+
 export function extractVariableNameFromPrompt(line: string) {
   const noColorLine = stripAnsi(line);
   const lines = noColorLine.split("\n");
-  const lineWithVar = lines.find((line) => line.includes("var."));
-  if (!lineWithVar) {
+  const match = lines
+    .map((l) => l.match(VARIABLE_PROMPT_REGEX))
+    .find((m): m is RegExpMatchArray => m !== null);
+  if (!match) {
     throw Errors.Internal(
       `Could not find variable name in prompt: ${line}. This is most likely a bug in cdktn. Please report it at http://cdktn.io/issues`,
     );
   }
-  return lineWithVar.split("var.")[1].trim();
+  return match[1];
 }
 
 interface BufferedReceiverFunction {
@@ -146,7 +173,7 @@ export function handleLineReceived(send: (event: DeployEvent) => void) {
       hideOutput = true;
       send({ type: "OUTPUT_RECEIVED", output });
       send({ type: "REQUEST_APPROVAL" });
-    } else if (noColorLine.includes("var.")) {
+    } else if (isMissingVariablePrompt(noColorLine)) {
       hideOutput = true;
 
       const variableName = extractVariableNameFromPrompt(output);

--- a/packages/@cdktn/cli-core/src/test/models/deploy-machine.test.ts
+++ b/packages/@cdktn/cli-core/src/test/models/deploy-machine.test.ts
@@ -303,6 +303,27 @@ describe("handleLineReceived", () => {
     });
   });
 
+  it("should not treat terraform error output referencing var. as a missing variable (#265)", () => {
+    const send = jest.fn();
+    const input = `
+│ Error: Unsupported argument
+│
+│   on .terraform/modules/project/main.tf line 92, in resource "gitlab_project" "project":
+│   92:   mirror                              = var.mirror
+│
+│ An argument named "mirror" is not expected here.
+`;
+    handleLineReceived(send)(input);
+    expect(send).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "VARIABLE_MISSING" }),
+    );
+    // the real error output must still be forwarded to the user
+    expect(send).toHaveBeenCalledWith({
+      type: "OUTPUT_RECEIVED",
+      output: input,
+    });
+  });
+
   it("should detect destroy all resources in workspace message on windows", () => {
     const send = jest.fn();
     const input = `\u001b[25


### PR DESCRIPTION
Fixes #265

## Problem

`cdktn deploy` (and `destroy`) transformed real terraform errors into a misleading `Missing variable` error, swallowing the actual failure.

In `packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts`, `handleLineReceived` detected terraform's interactive variable prompt with:

```ts
} else if (noColorLine.includes("var.")) {
```

That substring check fires on **any** terraform output that references a module variable — including `Unsupported argument` error lines such as `92:   mirror = var.mirror`. As a result, the real error was hidden behind:

```
Missing variable: 'mirror'. You can provide it using the 'TF_VAR_mirror' environment variable.
```

(see #265 — this was a regression vs. `0.22.0`).

## Fix

Scope the detection to terraform's actual interactive prompt, which puts the variable name on its own line:

```
var.<name>
  Enter a value:
```

- New `isMissingVariablePrompt()` helper backed by `/^\s*var\.([A-Za-z_][A-Za-z0-9_-]*)\s*$/` replaces the loose `includes("var.")` check.
- `extractVariableNameFromPrompt` reuses the same regex and returns the captured group instead of `split("var.")`.

Now genuine missing-variable prompts are still detected, but error output that merely references a variable is forwarded to the user unchanged.

## Before / After

**Before** (`0.23.3`):
```
Missing variable: 'mirror'. You can provide it using the 'TF_VAR_mirror' environment variable.
```

**After**:
```
╷
│ Error: Unsupported argument
│   on assets/.../main.tf line 92, in resource "gitlab_project" "project":
│   92:   mirror = var.mirror
│ An argument named "mirror" is not expected here.
╵
```

## Tests

- Added regression test `should not treat terraform error output referencing var. as a missing variable (#265)` feeding the exact `Unsupported argument` block from the issue, asserting no `VARIABLE_MISSING` event fires and the real error is still forwarded.
- Existing `extractVariableNameFromPrompt` cases (`var.content`, `var.SCREAM_CASE`, `var.nested_content_578CD0EA`, `var.with-dashes`) and the `var.my_var` prompt test still pass under the new regex.

## Note

As the issue diagnosis points out, there is a second, **separate** problem: the reporter's module references `mirror`, which doesn't exist on `gitlabhq/gitlab ~> 19.0.0`. That's a module/provider version mismatch, not a cdktn bug — this PR simply makes cdktn surface that real terraform error instead of masking it.

https://claude.ai/code/session_01HYP7w7BmQM9F8xZTc9qoHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYP7w7BmQM9F8xZTc9qoHD)_