### PR TITLE
chore: ESLint ignore test edge-provider-bindings

### DIFF
--- a/test/eslint.config.mjs
+++ b/test/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
   {
     ignores: [
       "**/.gen/**",
+      "edge-provider-bindings/**",
       "**/cdktf.out/**",
       "storage/**",
       "**/dist/**",


### PR DESCRIPTION
### Description

The `test/edge-provider-bindings` directory needs adding to the test package ESLint `ignores` config so that it is not linted, as these files are dynamically generated. This is an issue when running eslint on the `test` package locally, when the `edge-provider-bindings` have been generated.

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
