### PR TITLE
chore: Add Gradle to Mise config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ idiomatic_version_file_enable_tools = ["node"]
 python = '3.11'
 go = '1.25'
 java = "prefix:corretto-20"
+gradle = "8.2.1"   # Match Dockerfile GRADLE_VERSION
 dotnet = "6.0"  # Match jsii-superchain DOTNET_CHANNEL
 uv = "0.11.19" # Used by the pipx backend
 "pipx:pipenv" = "latest"


### PR DESCRIPTION
### Description

Gradle is missing from the `mise.toml` config and is required for the project so should be added, pinned to the same version used in the `Dockerfile`

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
