### PR TITLE
chore: Fix Verdaccio logging config

### DIFF
--- a/test/verdaccio.yaml
+++ b/test/verdaccio.yaml
@@ -77,10 +77,10 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
-# log settings (renamed from 'logs' to 'log' in v6)
 log:
-  - { type: stdout, format: pretty, level: warn }
-  #- {type: file, path: verdaccio.log, level: info}
+  type: stdout
+  format: pretty
+  level: warn
 
 # See https://github.com/verdaccio/verdaccio/issues/301
 server:


### PR DESCRIPTION
### Description

The Verdaccio log config in the `test` package is currently incorrect and needs updating. The `log` property is an object not an array and is currently being ignored.

Reference: https://www.verdaccio.org/docs/logger

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
