### PR TITLE
fix(cli): include dev dependencies in npm version lookup

### DIFF
--- a/packages/@cdktn/commons/src/debug.test.ts
+++ b/packages/@cdktn/commons/src/debug.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import * as fs from "fs";
+import * as path from "path";
+
+jest.mock("./terraform", () => ({
+  terraformVersion: Promise.resolve("1.7.5"),
+}));
+
+import { collectDebugInformation } from "./debug";
+import { withTempDir } from "./util";
+
+function writeInstalledPackage(packageName: string, version: string) {
+  const packageDir = path.join(process.cwd(), "node_modules", packageName);
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({ name: packageName, version }, null, 2),
+  );
+}
+
+describe("collectDebugInformation()", () => {
+  let previousNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    previousNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it("detects TypeScript packages installed as npm dev dependencies in production", async () => {
+    await withTempDir("debug.test", async () => {
+      fs.writeFileSync(
+        "cdktf.json",
+        JSON.stringify({ language: "typescript" }),
+      );
+      fs.writeFileSync(
+        "package.json",
+        JSON.stringify(
+          {
+            name: "debug-dev-dependency-fixture",
+            version: "1.0.0",
+            devDependencies: {
+              cdktn: "0.23.3",
+              cdktf: "0.20.11",
+              constructs: "10.3.0",
+              jsii: "5.5.0",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      writeInstalledPackage("cdktn", "0.23.3");
+      writeInstalledPackage("cdktf", "0.20.11");
+      writeInstalledPackage("constructs", "10.3.0");
+      writeInstalledPackage("jsii", "5.5.0");
+
+      process.env.NODE_ENV = "production";
+
+      await expect(collectDebugInformation()).resolves.toEqual(
+        expect.objectContaining({
+          language: "typescript",
+          cdktn: "0.23.3",
+          cdktf: "0.20.11",
+          constructs: "10.3.0",
+          jsii: "5.5.0",
+        }),
+      );
+    });
+  });
+});

--- a/packages/@cdktn/commons/src/debug.ts
+++ b/packages/@cdktn/commons/src/debug.ts
@@ -135,9 +135,13 @@ async function getNpmNodeModuleVersion(
   let output;
 
   try {
-    output = await exec("npm", ["list", packageName, "--json"], {
-      env: { ...process.env },
-    });
+    output = await exec(
+      "npm",
+      ["list", packageName, "--json", "--include=dev"],
+      {
+        env: { ...process.env },
+      },
+    );
   } catch (e) {
     logger.debug(`Unable to run 'npm list ${packageName} --json': ${e}`);
     return undefined;


### PR DESCRIPTION
## Summary

- Include dev dependencies when npm is used to detect the installed `cdktn` / `cdktf` package version.
- Add regression coverage for the npm package-version lookup arguments.

Fixes: #278

## Testing

- `pnpm nx test @cdktn/commons --runInBand --testFile=src/debug.test.ts`
- `pnpm nx build cdktn-cli`
- Validated the linked repro with the locally built CLI:
  - `cdktn debug`
  - `cdktn provider list`
  - `cdktn provider add random`
