### PR TITLE
chore(deps): replace uuid dependency with node:crypto.randomUUID

### DIFF
--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -48,7 +48,6 @@
     "log4js": "6.9.1",
     "semver": "7.7.4",
     "strip-ansi": "6.0.1",
-    "uuid": "9.0.1",
     "validator": "13.15.35"
   },
   "devDependencies": {
@@ -56,7 +55,6 @@
     "@types/follow-redirects": "1.14.4",
     "@types/fs-extra": "11.0.4",
     "@types/semver": "7.7.1",
-    "@types/uuid": "9.0.8",
     "@types/validator": "13.15.10",
     "tsc-files": "1.1.4",
     "typescript": "^5.0.0"

--- a/packages/@cdktn/commons/src/checkpoint.ts
+++ b/packages/@cdktn/commons/src/checkpoint.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import * as https from "https";
 import { format } from "url";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import * as os from "os";
 import ciInfo from "ci-info";
 import { logger, processLoggerError } from "./logging";
@@ -101,7 +101,7 @@ function getId(
   forceCreation = false,
   explanatoryComment?: string,
 ): string {
-  const _uuid = uuidv4(); // create a new UUID in case we don't find one
+  const _uuid = randomUUID(); // create a new UUID in case we don't find one
 
   let jsonFile;
   try {
@@ -157,7 +157,7 @@ export async function ReportRequest(reportParams: ReportParams): Promise<void> {
   }
 
   if (!reportParams.runID) {
-    reportParams.runID = uuidv4();
+    reportParams.runID = randomUUID();
   }
 
   if (!reportParams.dateTime) {

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -72,7 +72,6 @@
     "@types/pidusage": "2.0.5",
     "@types/react": "18.3.28",
     "@types/semver": "7.7.1",
-    "@types/uuid": "8.3.4",
     "@types/yargs": "17.0.35",
     "chalk": "4.1.2",
     "esbuild": "^0.28.0",
@@ -94,7 +93,6 @@
     "semver": "7.7.4",
     "strip-ansi": "6.0.1",
     "tsc-files": "1.1.4",
-    "typescript": "^5.0.0",
-    "uuid": "8.3.2"
+    "typescript": "^5.0.0"
   }
 }

--- a/packages/cdktn-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/init.ts
@@ -24,7 +24,7 @@ import {
 } from "@cdktn/hcl2cdk";
 import { isLocalModule } from "@cdktn/provider-generator";
 import { ExecSyncOptions, execSync } from "child_process";
-import { v4 as uuid } from "uuid";
+import { randomUUID } from "node:crypto";
 import { readSchema } from "@cdktn/provider-schema";
 import {
   LANGUAGES,
@@ -140,7 +140,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
     argv.projectName,
     argv.projectDescription,
   );
-  const projectId = uuid();
+  const projectId = randomUUID();
   telemetryData.projectId = projectId;
 
   let fromTerraformProject = argv.fromTerraformProject || undefined;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1132,9 +1132,6 @@ importers:
       strip-ansi:
         specifier: 6.0.1
         version: 6.0.1
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
       validator:
         specifier: 13.15.35
         version: 13.15.35
@@ -1151,9 +1148,6 @@ importers:
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
-      '@types/uuid':
-        specifier: 9.0.8
-        version: 9.0.8
       '@types/validator':
         specifier: 13.15.10
         version: 13.15.10
@@ -1455,9 +1449,6 @@ importers:
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
-      '@types/uuid':
-        specifier: 8.3.4
-        version: 8.3.4
       '@types/yargs':
         specifier: 17.0.35
         version: 17.0.35
@@ -1524,9 +1515,6 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
-      uuid:
-        specifier: 8.3.2
-        version: 8.3.2
 
   tools/generate-function-bindings:
     dependencies:
@@ -3904,12 +3892,6 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
-
-  '@types/uuid@8.3.4':
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -8555,11 +8537,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -11615,10 +11592,6 @@ snapshots:
   '@types/semver@7.7.1': {}
 
   '@types/stack-utils@2.0.3': {}
-
-  '@types/uuid@8.3.4': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/validator@13.15.10': {}
 
@@ -17632,9 +17605,8 @@ snapshots:
   utils-merge@1.0.1:
     optional: true
 
-  uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
+  uuid@8.3.2:
+    optional: true
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
### Related issue

Fixes #290

### Description

Removes the direct `uuid` / `@types/uuid` dependencies from `cdktn-cli` and `@cdktn/commons`, replacing runtime UUID v4 generation with Node's native `node:crypto.randomUUID()`.

Changes:

- **`@cdktn/commons`** (`src/checkpoint.ts`): swapped `import { v4 as uuidv4 } from "uuid"` for `import { randomUUID } from "node:crypto"`; `getId()` and `ReportRequest()` now call `randomUUID()` for the telemetry user/project/run IDs.
- **`cdktn-cli`** (`src/bin/cmds/helper/init.ts`): swapped `import { v4 as uuid } from "uuid"` for `import { randomUUID } from "node:crypto"`; `cdktn init` generates the project id via `randomUUID()`.
- Dropped `uuid` + `@types/uuid` from both packages' `package.json` and refreshed `pnpm-lock.yaml`, removing the deprecated `uuid@9.0.1` direct entry and the direct `uuid@8.3.2` dev entry.

`randomUUID()` returns a v4 UUID string, identical in shape and usage to the previous `uuid()` call, so behavior is unchanged. The runtime baseline already supports it — the CLI's esbuild target is `node22` and the TypeScript templates require Node `>=20.9`.

This reduces the CLI bundle size and dependency surface, aligning with the AWS CDK CLI dependency-cleanup direction described in the issue.

### Checklist

- [x] I have updated the PR title to match CDKTN's style guide
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Be4NSJa2v5yPrRhfCWvFov)_