### PR TITLE
fix(provider-generator): match shorthand provider sources against OpenTofu schema keys

### DIFF
--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/provider-source-matching.test.ts
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/provider-source-matching.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import {
+  ConstructsMakerProviderTarget,
+  Language,
+  ProviderSchema,
+  TerraformProviderConstraint,
+} from "@cdktn/commons";
+import { CodeMaker } from "codemaker";
+import { TerraformProviderGenerator } from "../../generator/provider-generator";
+
+// Builds a minimal provider schema keyed by a single FQPN. The provider body is
+// intentionally empty (like the empty-provider-resources fixture) since these
+// tests only exercise the schema-key <-> target-source matching logic.
+const schemaWithKey = (fqpn: string): ProviderSchema => ({
+  provider_schemas: {
+    [fqpn]: { resource_schemas: null } as any,
+  },
+  provider_versions: {
+    [fqpn]: "1.84.0",
+  },
+});
+
+const targetForSource = (source: string) =>
+  new ConstructsMakerProviderTarget(
+    new TerraformProviderConstraint(`${source}@1.84.0`),
+    Language.TYPESCRIPT,
+  );
+
+const generateFor = (schemaKey: string, source: string) => {
+  const generator = new TerraformProviderGenerator(
+    new CodeMaker(),
+    schemaWithKey(schemaKey),
+  );
+  generator.generate(targetForSource(source));
+  return generator;
+};
+
+describe("provider source matching against schema keys", () => {
+  it("matches a shorthand source against an OpenTofu registry schema key", () => {
+    // Regression test for #216: `tofu providers schema` returns keys under
+    // registry.opentofu.org, so a shorthand source must not assume
+    // registry.terraform.io.
+    const generator = generateFor(
+      "registry.opentofu.org/hashicorp/awscc",
+      "hashicorp/awscc",
+    );
+
+    expect(Object.keys(generator.versions)).toContain(
+      "registry.opentofu.org/hashicorp/awscc",
+    );
+  });
+
+  it("matches a shorthand source against a Terraform registry schema key", () => {
+    const generator = generateFor(
+      "registry.terraform.io/hashicorp/awscc",
+      "hashicorp/awscc",
+    );
+
+    expect(Object.keys(generator.versions)).toContain(
+      "registry.terraform.io/hashicorp/awscc",
+    );
+  });
+
+  it("keeps an explicit hostname strict and does not cross registries", () => {
+    expect(() =>
+      generateFor(
+        "registry.opentofu.org/hashicorp/awscc",
+        "registry.terraform.io/hashicorp/awscc",
+      ),
+    ).toThrow(/Could not find provider with constraint/);
+  });
+
+  it("matches an explicit hostname when it agrees with the schema key", () => {
+    const generator = generateFor(
+      "registry.opentofu.org/hashicorp/awscc",
+      "registry.opentofu.org/hashicorp/awscc",
+    );
+
+    expect(Object.keys(generator.versions)).toContain(
+      "registry.opentofu.org/hashicorp/awscc",
+    );
+  });
+});

--- a/packages/@cdktn/provider-generator/src/get/generator/provider-generator.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/provider-generator.ts
@@ -54,6 +54,13 @@ const isMatching = (
         name: "",
       };
       const targetElements = target.source.split("/");
+      // Only a 3-part source explicitly pins a registry hostname. Shorthand
+      // sources (e.g. "hashicorp/awscc") omit it, so we must not assume a
+      // default: Terraform resolves them under registry.terraform.io while
+      // OpenTofu resolves them under registry.opentofu.org. Comparing against a
+      // hard-coded default would make schema lookup fail under OpenTofu even
+      // though the provider was installed correctly.
+      const explicitHostname = targetElements.length === 3;
       switch (targetElements.length) {
         case 1: // only name set
           targetSource.name = targetElements[0].toLowerCase();
@@ -74,7 +81,7 @@ const isMatching = (
       }
 
       return (
-        targetSource.hostname === hostname &&
+        (!explicitHostname || targetSource.hostname === hostname) &&
         targetSource.namespace === namespace &&
         targetSource.name === provider
       );


### PR DESCRIPTION
### Related issue

Fixes #216

### Description

**Root cause.** `cdktn get` fails under OpenTofu (`TERRAFORM_BINARY_NAME=tofu`) with `Could not find provider with constraint ...`, even though the provider installs correctly. The failure is in provider-schema → target matching, not in provider download.

In `packages/@cdktn/provider-generator/src/get/generator/provider-generator.ts`, `isMatching` expands a target `source` and compares it to the schema key. When a source omits a registry hostname (a shorthand like `hashicorp/awscc`), the old code assumed the missing hostname was always `registry.terraform.io` and compared it strictly against the schema key's hostname:

- Terraform resolves `hashicorp/awscc` → schema key `registry.terraform.io/hashicorp/awscc` ✅
- OpenTofu resolves `hashicorp/awscc` → schema key `registry.opentofu.org/hashicorp/awscc` ❌ (never matched)

**Fix (minimal, intentionally).** Only compare the hostname when the source *explicitly pins one* (a 3-part source). Shorthand 1- and 2-part sources now match on `namespace`/`name` and ignore the schema key's registry hostname:

```ts
const explicitHostname = targetElements.length === 3;
return (
  (!explicitHostname || targetSource.hostname === hostname) &&
  targetSource.namespace === namespace &&
  targetSource.name === provider
);
```

**Why exactly this shape:**

- **Same `cdktf.json` works under both CLIs.** `emitProvider` writes `terraformProviderSource = constraint.source`, so the shorthand `hashicorp/awscc` is preserved in generated metadata — it stays registry-agnostic instead of being pinned to one registry. This avoids the downside of the documented workaround (`registry.opentofu.org/hashicorp/awscc`), which hard-codes an OpenTofu-only source address.
- **Explicit hostnames stay strict.** A 3-part source like `registry.terraform.io/hashicorp/awscc` still only matches that exact registry and won't cross to `registry.opentofu.org`.
- **Rejected alternatives.** Branching on `TERRAFORM_BINARY_NAME` couples generator logic to the binary and breaks with wrapper scripts/paths. A full "match against actual schema keys + explicit ambiguity error" design adds machinery for a case that can't occur from a single `terraform`/`tofu providers schema` run (each provider resolves to exactly one registry per invocation). Per the project's YAGNI > KISS priority, we kept it minimal; `getProviderByConstraint` uses `.find()`, so the pathological "same namespace/name under two hostnames" schema would deterministically pick the first key rather than throw — acceptable and not worth building around today.

**Scope note.** `hcl2cdk`'s separate matcher (`packages/@cdktn/hcl2cdk/src/provider.ts`) already matches with `.endsWith()` and is hostname-agnostic, so it is unaffected. This change is deliberately confined to the one matcher on the `cdktn get` path.

### Tests

Added `provider-source-matching.test.ts` driving `TerraformProviderGenerator.generate(...)` (since `isMatching` is module-private) over minimal hand-built schemas:

1. shorthand `hashicorp/awscc` ↔ `registry.opentofu.org/hashicorp/awscc` → matches (the #216 regression)
2. shorthand `hashicorp/awscc` ↔ `registry.terraform.io/hashicorp/awscc` → still matches
3. explicit `registry.terraform.io/...` ↔ `registry.opentofu.org/...` → stays strict, throws
4. explicit hostname agreeing with the schema key → matches

**Follow-up (out of scope):** the repo currently has **no integration tests that run with `tofu`**. End-to-end coverage of the OpenTofu `cdktn get` path is tracked as a separate work item rather than bundled here, to keep this PR small and focused on the matcher fix. The unit tests above prove the matching behavior directly.

> Note: the full `nx` unit suite was not run in the authoring environment (workspace `^build` chain was slow); CI runs it here and it will also be validated locally. The change is a single boolean guard plus new tests.

### Checklist

- [x] I have updated the PR title to match CDKTN's style guide
- [x] I have run the linter on my code locally (prettier via pre-commit hook)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if applicable (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [ ] New and existing unit tests pass locally with my changes (deferred to CI — see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BG9ZUpdDa3GDNRkRMC2b5U)_