### PR TITLE
fix(cli): don't downgrade prebuilt providers on a transient registry failure

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/dependencies/dependency-manager.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/dependency-manager.ts
@@ -3,6 +3,7 @@
 import {
   Language,
   Errors,
+  IsErrorType,
   logger,
   TerraformDependencyConstraint,
 } from "@cdktn/commons";
@@ -345,6 +346,9 @@ export class DependencyManager {
           return { name: languagePackageName, version };
         }
       } catch (err) {
+        if (IsErrorType(err, "External")) {
+          throw err;
+        }
         logger.info(
           `Could not find version ${version} for package ${name}: '${err}'. Skipping...`,
         );

--- a/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
@@ -14,8 +14,108 @@ import path from "path";
 import { xml2js, js2xml, Element } from "xml-js";
 import * as fs from "fs-extra";
 import * as semver from "semver";
-import fetch from "node-fetch";
+import fetch, { RequestInit, Response } from "node-fetch";
 import * as z from "zod";
+
+/**
+ * Number of attempts (initial try + retries) for a registry probe before we give up and treat the registry as
+ * unreachable. Transient failures (network errors / 408 / 429 / 5xx) are retried; definitive responses are not.
+ */
+const REGISTRY_PROBE_ATTEMPTS = 3;
+
+/** Base backoff between retries, doubled each attempt (250ms, 500ms). */
+const REGISTRY_PROBE_BACKOFF_MS = 250;
+
+/**
+ * HTTP 408 Request Timeout — a transient status worth retrying.
+ */
+const HTTP_REQUEST_TIMEOUT = 408;
+
+/**
+ * HTTP 429 Too Many Requests (rate limit) — a transient status worth retrying.
+ */
+const HTTP_TOO_MANY_REQUESTS = 429;
+
+/**
+ * Lowest HTTP 5xx status — any status at or above this is a server error and treated as a transient status worth
+ * retrying.
+ */
+const HTTP_SERVER_ERROR_MIN = 500;
+
+/**
+ * HTTP 404 Not Found — a definitive "the version is not published" answer from a registry (not transient).
+ */
+const HTTP_NOT_FOUND = 404;
+
+/**
+ * Reports whether an HTTP status is transient and therefore worth retrying: request timeout (408), rate limit (429),
+ * or any server error (5xx). Definitive statuses (2xx, 404, other 4xx) are not transient.
+ *
+ * @param status - The HTTP status code from a registry response.
+ * @returns `true` if the status is transient and the request should be retried, `false` otherwise.
+ */
+function isTransientStatus(status: number): boolean {
+  return (
+    status === HTTP_REQUEST_TIMEOUT ||
+    status === HTTP_TOO_MANY_REQUESTS ||
+    status >= HTTP_SERVER_ERROR_MIN
+  );
+}
+
+/**
+ * Resolves after `ms` milliseconds; used to back off between registry-probe retries.
+ *
+ * @param ms - The number of milliseconds to wait.
+ * @returns A promise that resolves once the delay has elapsed.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fetches `url`, retrying only on transient failures — network errors and HTTP 408/429/5xx — so a registry hiccup is
+ * not mistaken for a definitive answer. Definitive responses (2xx, 404, other 4xx) are returned immediately without
+ * retry. If every attempt fails transiently, throws an `External` error so callers can distinguish "registry
+ * unreachable" from "version absent" rather than silently treating a hiccup as absence.
+ *
+ * @param url - The registry URL to fetch.
+ * @param init - Optional `fetch` request options (e.g. headers), passed through unchanged on every attempt.
+ * @returns The `Response` for the first definitive (non-transient) result.
+ * @throws An `External` error if every attempt (up to `REGISTRY_PROBE_ATTEMPTS`) fails transiently.
+ */
+async function fetchWithRetry(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= REGISTRY_PROBE_ATTEMPTS; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (!isTransientStatus(response.status)) {
+        return response;
+      }
+      lastError = new Error(`registry responded HTTP ${response.status}`);
+      logger.debug(
+        `Transient HTTP ${response.status} from '${url}' (attempt ${attempt}/${REGISTRY_PROBE_ATTEMPTS})`,
+      );
+    } catch (e: any) {
+      // fetch rejects on network-level failures (DNS, connection reset, timeout) — always transient.
+      lastError = e;
+      logger.debug(
+        `Network error fetching '${url}' (attempt ${attempt}/${REGISTRY_PROBE_ATTEMPTS}): ${e}`,
+      );
+    }
+
+    if (attempt < REGISTRY_PROBE_ATTEMPTS) {
+      await delay(REGISTRY_PROBE_BACKOFF_MS * 2 ** (attempt - 1));
+    }
+  }
+
+  throw Errors.External(
+    `Could not reach the registry at '${url}' after ${REGISTRY_PROBE_ATTEMPTS} attempts: ${lastError}`,
+  );
+}
 
 // Can't use CDKTF_ as prefix because yargs .env("CDKTF") in strict mode does not allow us to
 // Refer to: https://github.com/yargs/yargs/issues/873
@@ -351,7 +451,12 @@ class PythonPackageManager extends PackageManager {
     const url = `https://pypi.org/pypi/${packageName}/${packageVersion}/json`;
     logger.debug(`Fetching package information for ${packageName} from ${url}`);
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url);
+    if (response.status === HTTP_NOT_FOUND) {
+      logger.debug(`PyPI reports ${packageName}@${packageVersion} not found`);
+      return false;
+    }
+
     const json = (await response.json()) as any;
     logger.debug(
       `Got response from PyPI for ${packageName}@${packageVersion}: ${JSON.stringify(
@@ -359,15 +464,7 @@ class PythonPackageManager extends PackageManager {
       )}`,
     );
 
-    if (json.info) {
-      // We found the version, so it exists
-      return true;
-    } else {
-      logger.debug(
-        `Could not get PyPI package info, got: ${JSON.stringify(json)}`,
-      );
-      return false;
-    }
+    return Boolean(json.info);
   }
 
   public async listPipenvPackages(): Promise<
@@ -461,7 +558,11 @@ class NugetPackageManager extends PackageManager {
     const url = `https://azuresearch-usnc.nuget.org/query?q=owner:${owner}%20id:${id}&prerelease=false&semVerLevel=2.0.0`;
     logger.debug(`Fetching package metadata from Nuget: '${url}'`);
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url);
+    if (response.status === HTTP_NOT_FOUND) {
+      logger.debug(`NuGet reports ${packageName}@${packageVersion} not found`);
+      return false;
+    }
     const json = (await response.json()) as {
       data: { id: string; versions: { version: string }[] }[];
     };
@@ -558,7 +659,13 @@ abstract class JavaPackageManager extends PackageManager {
     logger.debug(
       `Checking whether ${packageName}@${packageVersion} exists on Maven Central under '${url}'`,
     );
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url);
+    if (response.status === HTTP_NOT_FOUND) {
+      logger.debug(
+        `Maven Central reports ${packageName}@${packageVersion} not found`,
+      );
+      return false;
+    }
     logger.debug(
       `Maven Central responded HTTP ${response.status} for ${packageName}@${packageVersion}`,
     );
@@ -791,7 +898,7 @@ class GoPackageManager extends PackageManager {
 
     const url = `https://api.github.com/repos/${org}/${repo}/git/ref/tags/${packagePath}/v${packageVersion}`;
     logger.debug(`Fetching tags for ${org}/${repo} from '${url}'`);
-    const response = await fetch(url, {
+    const response = await fetchWithRetry(url, {
       headers: {
         Accept: "application/vnd.github+json",
         "User-Agent": "OpenConstructs/cdktn-cli",
@@ -801,6 +908,13 @@ class GoPackageManager extends PackageManager {
       },
     });
 
+    if (response.status === HTTP_NOT_FOUND) {
+      logger.info(
+        `Could not find the tag ${packagePath}/v${packageVersion} in the repository ${org}/${repo}`,
+      );
+      return false;
+    }
+
     const json = (await response.json()) as any;
     logger.debug(
       `Got response from GitHubs repository tag endpoint for ${packageName}: ${JSON.stringify(
@@ -808,17 +922,7 @@ class GoPackageManager extends PackageManager {
       )}`,
     );
 
-    if (json && json.ref) {
-      return true;
-    }
-
-    logger.info(
-      `Could not find the tag ${packagePath}/v${packageVersion} in the repository ${org}/${repo}: ${JSON.stringify(
-        json,
-      )}}`,
-    );
-
-    return false;
+    return Boolean(json && json.ref);
   }
 
   public async listProviderPackages(): Promise<

--- a/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
@@ -37,8 +37,7 @@ const HTTP_REQUEST_TIMEOUT = 408;
 const HTTP_TOO_MANY_REQUESTS = 429;
 
 /**
- * Lowest HTTP 5xx status — any status at or above this is a server error and treated as a transient status worth
- * retrying.
+ * Lowest HTTP 5xx status — any status at or above this is a server error and treated as a transient status worth retrying.
  */
 const HTTP_SERVER_ERROR_MIN = 500;
 

--- a/packages/@cdktn/cli-core/src/test/lib/dependencies/package-manager.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/dependencies/package-manager.test.ts
@@ -8,6 +8,9 @@ import { Language } from "@cdktn/commons";
 import { PackageManager } from "../../../lib/dependencies/package-manager";
 
 const MAVEN_HOST = "https://repo1.maven.org";
+const GITHUB_HOST = "https://api.github.com";
+const PYPI_HOST = "https://pypi.org";
+const NUGET_HOST = "https://azuresearch-usnc.nuget.org";
 
 describe("package-manager", () => {
   beforeAll(() => {
@@ -61,15 +64,148 @@ describe("package-manager", () => {
       ).resolves.toBe(false);
     });
 
-    it("returns false on a non-200 response from Maven Central", async () => {
-      nock(MAVEN_HOST).get(pomPath("0.2.64")).reply(503);
+    it("throws (rather than reporting absent) when Maven Central stays unreachable", async () => {
+      // A transient 5xx is retried; after all attempts fail we must abort, not report the version as missing.
+      nock(MAVEN_HOST).get(pomPath("0.2.64")).times(3).reply(503);
 
       await expect(
         manager.isNpmVersionAvailable(
           "com.hashicorp.cdktf-provider-random",
           "0.2.64",
         ),
-      ).resolves.toBe(false);
+      ).rejects.toThrow(/Could not reach the registry/);
+    });
+  });
+
+  describe("GoPackageManager.isNpmVersionAvailable", () => {
+    let manager: PackageManager;
+    const pkg = "github.com/cdktf/cdktf-provider-random-go/random";
+
+    function refPath(version: string) {
+      // Mirrors the GitHub tag-ref endpoint probed by GoPackageManager.isNpmVersionAvailable.
+      return `/repos/cdktf/cdktf-provider-random-go/git/ref/tags/random/v${version}`;
+    }
+
+    beforeEach(() => {
+      const dir = mkdtempSync(join(tmpdir(), "cdktn-pm-test-"));
+      manager = PackageManager.forLanguage(Language.GO, dir);
+    });
+
+    it("returns true when GitHub returns the tag ref (HTTP 200)", async () => {
+      nock(GITHUB_HOST)
+        .get(refPath("0.2.64"))
+        .reply(200, { ref: "refs/tags/random/v0.2.64" });
+
+      await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
+        true,
+      );
+    });
+
+    it("returns false when GitHub reports the tag missing (HTTP 404)", async () => {
+      nock(GITHUB_HOST)
+        .get(refPath("0.2.64"))
+        .reply(404, { message: "Not Found" });
+
+      await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("throws on a rate-limit response instead of reading it as absent", async () => {
+      // GitHub returns a JSON body on rate-limit, so the old missing-`ref` check mistook a 429 for "tag absent".
+      // A 429 is transient: retried, then aborts.
+      nock(GITHUB_HOST)
+        .get(refPath("0.2.64"))
+        .times(3)
+        .reply(429, { message: "API rate limit exceeded" });
+
+      await expect(
+        manager.isNpmVersionAvailable(pkg, "0.2.64"),
+      ).rejects.toThrow(/Could not reach the registry/);
+    });
+  });
+
+  describe("PythonPackageManager.isNpmVersionAvailable", () => {
+    let manager: PackageManager;
+    const pkg = "cdktf-cdktf-provider-random";
+
+    function jsonPath(version: string) {
+      return `/pypi/${pkg}/${version}/json`;
+    }
+
+    beforeEach(() => {
+      const dir = mkdtempSync(join(tmpdir(), "cdktn-pm-test-"));
+      manager = PackageManager.forLanguage(Language.PYTHON, dir);
+    });
+
+    it("returns true when PyPI has the version (info present)", async () => {
+      nock(PYPI_HOST)
+        .get(jsonPath("0.2.64"))
+        .reply(200, { info: { version: "0.2.64" } });
+
+      await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
+        true,
+      );
+    });
+
+    it("returns false when PyPI reports the version missing (HTTP 404)", async () => {
+      nock(PYPI_HOST).get(jsonPath("0.2.64")).reply(404, {});
+
+      await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("throws when PyPI stays unreachable rather than reporting absent", async () => {
+      nock(PYPI_HOST).get(jsonPath("0.2.64")).times(3).reply(502);
+
+      await expect(
+        manager.isNpmVersionAvailable(pkg, "0.2.64"),
+      ).rejects.toThrow(/Could not reach the registry/);
+    });
+  });
+
+  describe("NugetPackageManager.isNpmVersionAvailable", () => {
+    let manager: PackageManager;
+    const pkg = "HashiCorp.Cdktf.Providers.Random";
+    const query = {
+      q: "owner:HashiCorp id:Random",
+      prerelease: "false",
+      semVerLevel: "2.0.0",
+    };
+
+    beforeEach(() => {
+      const dir = mkdtempSync(join(tmpdir(), "cdktn-pm-test-"));
+      manager = PackageManager.forLanguage(Language.CSHARP, dir);
+    });
+
+    it("returns true when NuGet lists the version", async () => {
+      nock(NUGET_HOST)
+        .get("/query")
+        .query(query)
+        .reply(200, {
+          data: [{ id: pkg, versions: [{ version: "0.2.64" }] }],
+        });
+
+      await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
+        true,
+      );
+    });
+
+    it("returns false when NuGet returns no matching package", async () => {
+      nock(NUGET_HOST).get("/query").query(query).reply(200, { data: [] });
+
+      await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
+        false,
+      );
+    });
+
+    it("throws when NuGet stays unreachable rather than reporting absent", async () => {
+      nock(NUGET_HOST).get("/query").query(query).times(3).reply(500);
+
+      await expect(
+        manager.isNpmVersionAvailable(pkg, "0.2.64"),
+      ).rejects.toThrow(/Could not reach the registry/);
     });
   });
 });


### PR DESCRIPTION
### Related issue

Fixes #297

### Description

When `cdktn provider add` resolves which prebuilt-provider version to install, it walks the npm candidate versions highest-to-lowest and installs the first that `isNpmVersionAvailable` reports as present. The problem: for most languages a *transient* registry failure (network error, rate limit, 5xx) was indistinguishable from "this version doesn't exist", so the resolver skipped the present newest version and silently installed an older one — no error, no warning.

The probes conflated the two failure modes, and the resolution loop's `catch` swallowed anything that threw:

- **Go** — GitHub returns a JSON body on rate-limit / 5xx, so `response.json()` succeeded, `json.ref` was `undefined`, and the probe returned `false`. A throttled request read as "version absent".
- **Python** (PyPI) and **.NET** (NuGet) — bare `fetch` with no status check; a non-JSON error body made `response.json()` throw.
- The loop in `DependencyManager.getLanguageSpecificPackageVersion` wrapped the body in `try { … } catch { logger.info("… Skipping…") }`, so any throw was logged at `info` and the loop moved on to an older version.

This PR gives the probes a shared, deliberate transient-vs-definitive distinction and decides at the loop level what a transient failure should do:

- **Shared retry helper** ([`package-manager.ts`](packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts)): a new `fetchWithRetry` classifies transient failures — network errors and HTTP `408` / `429` / `5xx` — and retries them (3 attempts, short exponential backoff), while definitive responses (`2xx`, `404`, other `4xx`) return immediately. If the registry stays unreachable after all attempts, it throws an `External` error rather than reporting the version as absent.
- **Status-based probes**: each `isNpmVersionAvailable` now routes through `fetchWithRetry` and keys off the HTTP status instead of inferring absence from a missing field. Go checks `200` vs `404` (fixing the rate-limit-reads-as-absent bug), Python and .NET check `404` explicitly, and Java (already probing `repo1.maven.org` directly) shares the same retry behaviour.
- **Narrowed the resolution loop's `catch`** ([`dependency-manager.ts`](packages/@cdktn/cli-core/src/lib/dependencies/dependency-manager.ts)): a registry-unreachable (`External`) error now propagates and aborts the resolution, so the CLI never silently downgrades on an infrastructure hiccup. A definitive "not available" (a `false` return, no throw) still advances to the next-oldest candidate as before.

**Why abort rather than retry-forever or degrade silently:** installing an older version than is actually available is a silent correctness problem that's hard to notice after the fact. Surfacing a clear "could not reach the registry" error lets the user retry against a recovered network and get the version they expect.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
