### PR TITLE
fix(provider-generator): collapse unsupported nested collections to nearest Any wrapper

### DIFF
--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/__snapshots__/types.test.ts.snap
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/__snapshots__/types.test.ts.snap
@@ -2172,6 +2172,155 @@ export class ComputedOptionalComplex extends cdktn.TerraformResource {
 "
 `;
 
+exports[`deeply nested (unsupported) collection attribute types 1`] = `
+"// https://registry.terraform.io/providers/hashicorp/test/latest/docs/data-sources/deeply_nested_collections
+// generated from terraform resource schema
+
+import { Construct } from 'constructs';
+import * as cdktn from 'cdktn';
+
+// Configuration
+
+export interface DataDeeplyNestedCollectionsConfig extends cdktn.TerraformMetaArguments {
+}
+
+/**
+* Represents a {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/data-sources/deeply_nested_collections deeply_nested_collections}
+*/
+export class DataDeeplyNestedCollections extends cdktn.TerraformDataSource {
+
+  // =================
+  // STATIC PROPERTIES
+  // =================
+  public static readonly tfResourceType = "deeply_nested_collections";
+
+  // ==============
+  // STATIC Methods
+  // ==============
+  /**
+  * Generates CDKTN code for importing a DataDeeplyNestedCollections resource upon running "cdktn plan <stack-name>"
+  * @param scope The scope in which to define this construct
+  * @param importToId The construct id used in the generated config for the DataDeeplyNestedCollections to import
+  * @param importFromId The id of the existing DataDeeplyNestedCollections that should be imported. Refer to the {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/data-sources/deeply_nested_collections#import import section} in the documentation of this resource for the id to use
+  * @param provider? Optional instance of the provider where the DataDeeplyNestedCollections to import is found
+  */
+  public static generateConfigForImport(scope: Construct, importToId: string, importFromId: string, provider?: cdktn.TerraformProvider) {
+        return new cdktn.ImportableResource(scope, importToId, { terraformResourceType: "deeply_nested_collections", importId: importFromId, provider });
+      }
+
+  // ===========
+  // INITIALIZER
+  // ===========
+
+  /**
+  * Create a new {@link https://registry.terraform.io/providers/hashicorp/test/latest/docs/data-sources/deeply_nested_collections deeply_nested_collections} Data Source
+  *
+  * @param scope The scope in which to define this construct
+  * @param id The scoped construct ID. Must be unique amongst siblings in the same scope
+  * @param options DataDeeplyNestedCollectionsConfig = {}
+  */
+  public constructor(scope: Construct, id: string, config: DataDeeplyNestedCollectionsConfig = {}) {
+    super(scope, id, {
+      terraformResourceType: 'deeply_nested_collections',
+      terraformGeneratorMetadata: {
+        providerName: 'test'
+      },
+      provider: config.provider,
+      dependsOn: config.dependsOn,
+      count: config.count,
+      lifecycle: config.lifecycle,
+      provisioners: config.provisioners,
+      connection: config.connection,
+      forEach: config.forEach
+    });
+  }
+
+  // ==========
+  // ATTRIBUTES
+  // ==========
+
+  // map_map_list_string - computed: true, optional: false, required: false
+  private _mapMapListString = new cdktn.AnyMapMap(this, "map_map_list_string");
+  /**
+  * Terraform type: \`map(map(list(string)))\`.
+  * This nesting is deeper than the typed wrapper classes in the core cdktn package; it is exposed as \`AnyMapMap\` and values below that boundary are untyped tokens.
+  */
+  public get mapMapListString() {
+    return this._mapMapListString;
+  }
+
+  // list_map_map_string - computed: true, optional: false, required: false
+  private _listMapMapString = new cdktn.AnyMapList(this, "list_map_map_string", false);
+  /**
+  * Terraform type: \`list(map(map(string)))\`.
+  * This nesting is deeper than the typed wrapper classes in the core cdktn package; it is exposed as \`AnyMapList\` and values below that boundary are untyped tokens.
+  */
+  public get listMapMapString() {
+    return this._listMapMapString;
+  }
+
+  // set_map_list_number - computed: true, optional: false, required: false
+  private _setMapListNumber = new cdktn.AnyMapList(this, "set_map_list_number", true);
+  /**
+  * Terraform type: \`set(map(list(number)))\`.
+  * This nesting is deeper than the typed wrapper classes in the core cdktn package; it is exposed as \`AnyMapList\` and values below that boundary are untyped tokens.
+  */
+  public get setMapListNumber() {
+    return this._setMapListNumber;
+  }
+
+  // map_list_string - computed: true, optional: false, required: false
+  private _mapListString = new cdktn.StringListMap(this, "map_list_string");
+  public get mapListString() {
+    return this._mapListString;
+  }
+
+  // map_map_number - computed: true, optional: false, required: false
+  private _mapMapNumber = new cdktn.NumberMapMap(this, "map_map_number");
+  public get mapMapNumber() {
+    return this._mapMapNumber;
+  }
+
+  // map_map_bool - computed: true, optional: false, required: false
+  private _mapMapBool = new cdktn.BooleanMapMap(this, "map_map_bool");
+  public get mapMapBool() {
+    return this._mapMapBool;
+  }
+
+  // map_map_string - computed: true, optional: false, required: false
+  private _mapMapString = new cdktn.StringMapMap(this, "map_map_string");
+  public get mapMapString() {
+    return this._mapMapString;
+  }
+
+  // map_map_map_list_string - computed: true, optional: false, required: false
+  private _mapMapMapListString = new cdktn.AnyMapMap(this, "map_map_map_list_string");
+  /**
+  * Terraform type: \`map(map(map(list(string))))\`.
+  * This nesting is deeper than the typed wrapper classes in the core cdktn package; it is exposed as \`AnyMapMap\` and values below that boundary are untyped tokens.
+  */
+  public get mapMapMapListString() {
+    return this._mapMapMapListString;
+  }
+
+  // =========
+  // SYNTHESIS
+  // =========
+
+  protected synthesizeAttributes(): { [name: string]: any } {
+    return {
+    };
+  }
+
+  protected synthesizeHclAttributes(): { [name: string]: any } {
+    const attrs = {
+    };
+    return attrs;
+  }
+}
+"
+`;
+
 exports[`deeply nested block types 1`] = `
 "// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/deeply_nested_block_types
 // generated from terraform resource schema

--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/fixtures/deeply-nested-collections.test.fixture.json
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/fixtures/deeply-nested-collections.test.fixture.json
@@ -1,0 +1,129 @@
+{
+  "format_version": "1.0",
+  "provider_schemas": {
+    "registry.terraform.io/hashicorp/test": {
+      "data_source_schemas": {
+        "deeply_nested_collections": {
+          "version": 0,
+          "block": {
+            "attributes": {
+              "map_map_list_string": {
+                "type": [
+                  "map",
+                  [
+                    "map",
+                    [
+                      "list",
+                      "string"
+                    ]
+                  ]
+                ],
+                "description": "map(map(list(string))) - unsupported triple nesting, reproduces open-constructs/cdk-terrain#11.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "list_map_map_string": {
+                "type": [
+                  "list",
+                  [
+                    "map",
+                    [
+                      "map",
+                      "string"
+                    ]
+                  ]
+                ],
+                "description": "list(map(map(string))) - unsupported triple nesting.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "set_map_list_number": {
+                "type": [
+                  "set",
+                  [
+                    "map",
+                    [
+                      "list",
+                      "number"
+                    ]
+                  ]
+                ],
+                "description": "set(map(list(number))) - unsupported triple nesting.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "map_list_string": {
+                "type": [
+                  "map",
+                  [
+                    "list",
+                    "string"
+                  ]
+                ],
+                "description": "map(list(string)) - supported double nesting, must still emit cdktn.StringListMap.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "map_map_number": {
+                "type": [
+                  "map",
+                  [
+                    "map",
+                    "number"
+                  ]
+                ],
+                "description": "map(map(number)) - now directly supported via cdktn.NumberMapMap.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "map_map_bool": {
+                "type": [
+                  "map",
+                  [
+                    "map",
+                    "bool"
+                  ]
+                ],
+                "description": "map(map(bool)) - now directly supported via cdktn.BooleanMapMap.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "map_map_string": {
+                "type": [
+                  "map",
+                  [
+                    "map",
+                    "string"
+                  ]
+                ],
+                "description": "map(map(string)) - pre-existing support via cdktn.StringMapMap, unchanged.",
+                "description_kind": "plain",
+                "computed": true
+              },
+              "map_map_map_list_string": {
+                "type": [
+                  "map",
+                  [
+                    "map",
+                    [
+                      "map",
+                      [
+                        "list",
+                        "string"
+                      ]
+                    ]
+                  ]
+                ],
+                "description": "map(map(map(list(string)))) - unsupported quadruple nesting, collapses to cdktn.AnyMapMap.",
+                "description_kind": "plain",
+                "computed": true
+              }
+            },
+            "description": "Data source used to verify deeply nested collection attribute types are handled without generating references to non-existent cdktn classes.",
+            "description_kind": "plain"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/supported-stored-classes.test.ts
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/supported-stored-classes.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { logger } from "@cdktn/commons";
+import { resolveStoredClassName } from "../../generator/models/supported-stored-classes";
+import {
+  AttributeModel,
+  AttributeTypeModel,
+  MapAttributeTypeModel,
+} from "../../generator/models";
+
+describe("resolveStoredClassName", () => {
+  test("own composed name resolves as-is when supported (not collapsed)", () => {
+    expect(resolveStoredClassName("stringListMap", "list")).toEqual({
+      name: "StringListMap",
+      collapsed: false,
+    });
+    expect(resolveStoredClassName("stringMapMap", "map")).toEqual({
+      name: "StringMapMap",
+      collapsed: false,
+    });
+    expect(resolveStoredClassName("numberMapMap", "map")).toEqual({
+      name: "NumberMapMap",
+      collapsed: false,
+    });
+    expect(resolveStoredClassName("booleanMapMap", "map")).toEqual({
+      name: "BooleanMapMap",
+      collapsed: false,
+    });
+  });
+
+  test("unsupported own composed name collapses to nearest Any-wrapper", () => {
+    // map(map(list(string))) - own "stringListMapMap" unsupported, element is a map
+    expect(resolveStoredClassName("stringListMapMap", "map")).toEqual({
+      name: "AnyMapMap",
+      collapsed: true,
+    });
+    // list(map(map(string))) - own "stringMapMapList" unsupported, element is a map
+    expect(resolveStoredClassName("stringMapMapList", "map")).toEqual({
+      name: "AnyMapList",
+      collapsed: true,
+    });
+    // set(map(list(number))) - own "numberListMapList" unsupported, element is a map
+    expect(resolveStoredClassName("numberListMapList", "map")).toEqual({
+      name: "AnyMapList",
+      collapsed: true,
+    });
+    // map(map(map(list(string)))) - own "stringListMapMapMap" unsupported, element is a map
+    expect(resolveStoredClassName("stringListMapMapMap", "map")).toEqual({
+      name: "AnyMapMap",
+      collapsed: true,
+    });
+  });
+
+  test("returns undefined when neither the own name nor a collapsed Any-wrapper exists", () => {
+    // Own name doesn't end in List/Map at all.
+    expect(resolveStoredClassName("somethingWeird", "map")).toBeUndefined();
+    // Own name ends in Map, but the element isn't itself a list/set/map, so there is no
+    // "AnyXMap" candidate to fall back to.
+    expect(resolveStoredClassName("weirdMap", "struct")).toBeUndefined();
+    expect(resolveStoredClassName("weirdMap", "simple")).toBeUndefined();
+  });
+});
+
+// A minimal stand-in for a non-complex, non-collection AttributeTypeModel whose
+// typeModelType is neither "list", "set", "map", nor "simple"/"struct" - i.e. a shape the
+// generator's collapse logic has no candidate class name for. Used to exercise the
+// defensive plain-getter fallback in AttributeModel.getterType without needing a real
+// (currently nonexistent) unsupported shape.
+class UnresolvableStubTypeModel implements AttributeTypeModel {
+  get struct() {
+    return undefined;
+  }
+  get isComplex() {
+    return false;
+  }
+  getStoredClassInitializer(_name: string) {
+    return "";
+  }
+  get storedClassType() {
+    return "unresolvable";
+  }
+  get inputTypeDefinition() {
+    return "any";
+  }
+  getAttributeAccessFunction(name: string) {
+    return `this.interpolationForAttribute('${name}')`;
+  }
+  get toTerraformFunction() {
+    return "cdktn.anyToTerraform";
+  }
+  get toHclTerraformFunction() {
+    return "cdktn.anyToHclTerraform";
+  }
+  get typeModelType() {
+    return "unresolvable-shape";
+  }
+  get hasReferenceClass() {
+    return false;
+  }
+  get isTokenizable() {
+    return false;
+  }
+  get isStoredClassUnavailable() {
+    return false;
+  }
+}
+
+describe("AttributeModel.getterType loud fallback", () => {
+  test("falls back to a plain getter and logs a debug breadcrumb when no stored class (not even a collapsed Any-wrapper) is available", () => {
+    const debugSpy = jest.spyOn(logger, "debug").mockImplementation();
+
+    try {
+      // A map whose element is itself an unrecognized shape: own composed name
+      // ("unresolvableMap") isn't in the supported set, and the element's typeModelType
+      // isn't "list"/"set"/"map", so there is no "AnyXMap" candidate either.
+      const type = new MapAttributeTypeModel(new UnresolvableStubTypeModel());
+      expect(type.isStoredClassUnavailable).toBe(true);
+
+      const attribute = new AttributeModel({
+        storageName: "_weirdAttribute",
+        name: "weirdAttribute",
+        type,
+        optional: false,
+        computed: true,
+        terraformName: "weird_attribute",
+        terraformFullName: "test_resource.weird_attribute",
+        provider: false,
+        required: false,
+      });
+
+      expect(attribute.getterType).toEqual({ _type: "plain" });
+      expect(attribute.storedClassBoundaryKind).toEqual("fallback");
+
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      const [message] = debugSpy.mock.calls[0];
+      expect(message).toContain("test_resource.weird_attribute");
+      expect(message).toContain("unresolvableMap");
+
+      // Repeated access must not spam the logger.
+      void attribute.getterType;
+      void attribute.getterType;
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+});

--- a/packages/@cdktn/provider-generator/src/get/__tests__/generator/types.test.ts
+++ b/packages/@cdktn/provider-generator/src/get/__tests__/generator/types.test.ts
@@ -609,3 +609,78 @@ test("case-insensitive base name collision", async () => {
     expect(output).toMatchSnapshot(file);
   }
 });
+
+test("deeply nested (unsupported) collection attribute types", async () => {
+  // Regression test for https://github.com/open-constructs/cdk-terrain/issues/11:
+  // computed attributes whose type nests list/set/map more than two levels deep (e.g.
+  // map(map(list(string)))) must not generate a reference to a "cdktn.*" stored class
+  // that doesn't exist (e.g. "StringListMapMap"). Instead of falling straight back to a
+  // plain, untyped getter, the generator collapses these into the nearest typed
+  // "Any"-wrapper that does exist (e.g. "AnyMapMap"), preserving typed navigation for the
+  // outer layers. Only shapes with no available stored class at all fall back to a plain
+  // getter.
+  const code = new CodeMaker();
+  const workdir = tmp("deeply-nested-collections.test");
+  const spec = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        "fixtures",
+        "deeply-nested-collections.test.fixture.json",
+      ),
+      "utf-8",
+    ),
+  );
+  new TerraformProviderGenerator(code, spec).generateAll();
+  await code.save(workdir);
+
+  const output = fs.readFileSync(
+    path.join(
+      workdir,
+      "providers/test/data-deeply-nested-collections/index.ts",
+    ),
+    "utf-8",
+  );
+  expect(output).toMatchSnapshot();
+
+  // None of the unsupported nested attributes should reference a non-existent "cdktn.*"
+  // wrapper class.
+  expect(output).not.toContain("StringListMapMap");
+  expect(output).not.toContain("StringMapMapList");
+  expect(output).not.toContain("NumberListMapList");
+  expect(output).not.toContain("StringListMapMapMap");
+
+  // Unsupported triple nestings collapse to the nearest typed "Any"-wrapper instead of
+  // falling back to a plain getter.
+  expect(output).toContain('new cdktn.AnyMapMap(this, "map_map_list_string")');
+  expect(output).toContain(
+    'new cdktn.AnyMapList(this, "list_map_map_string", false)',
+  );
+  expect(output).toContain(
+    'new cdktn.AnyMapList(this, "set_map_list_number", true)',
+  );
+  expect(output).toContain(
+    'new cdktn.AnyMapMap(this, "map_map_map_list_string")',
+  );
+
+  // A supported double nesting (map(list(string))) must still emit its stored class.
+  expect(output).toContain('new cdktn.StringListMap(this, "map_list_string")');
+
+  // map(map(number)) / map(map(bool)) are now directly supported by new core classes.
+  expect(output).toContain('new cdktn.NumberMapMap(this, "map_map_number")');
+  expect(output).toContain('new cdktn.BooleanMapMap(this, "map_map_bool")');
+
+  // map(map(string)) is pre-existing, unchanged support.
+  expect(output).toContain('new cdktn.StringMapMap(this, "map_map_string")');
+
+  // Collapsed getters get a JSDoc documenting the Terraform type and the collapse
+  // boundary.
+  expect(output).toContain("Terraform type: `map(map(list(string)))`");
+  expect(output).toContain(
+    "it is exposed as `AnyMapMap` and values below that boundary are untyped tokens",
+  );
+
+  // Supported, non-collapsed attributes must NOT get this JSDoc (avoids snapshot churn).
+  expect(output).not.toContain("Terraform type: `map(list(string))`");
+  expect(output).not.toContain("Terraform type: `map(map(string))`");
+});

--- a/packages/@cdktn/provider-generator/src/get/generator/emitter/attributes-emitter.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/emitter/attributes-emitter.ts
@@ -1,8 +1,13 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 import { CodeMaker } from "codemaker";
-import { AttributeModel } from "../models";
+import {
+  AttributeModel,
+  CollectionAttributeTypeModel,
+  describeTerraformType,
+} from "../models";
 import { CUSTOM_DEFAULTS } from "../custom-defaults";
+import { sanitizedComment } from "../sanitized-comments";
 
 function titleCase(value: string) {
   return value[0].toUpperCase() + value.slice(1);
@@ -33,6 +38,8 @@ export class AttributesEmitter {
         `private ${att.storageName}?: ${att.type.inputTypeDefinition}; `,
       );
     }
+
+    this.emitStoredClassBoundaryDoc(att);
 
     switch (getterType._type) {
       case "plain":
@@ -119,6 +126,35 @@ export class AttributesEmitter {
   // returns an invocation of a stored class, e.g. 'new DeplotmentMetadataOutputReference(this, "metadata")'
   private storedClassInit(att: AttributeModel) {
     return att.type.getStoredClassInitializer(att.terraformName);
+  }
+
+  // Emits a JSDoc block documenting the Terraform type immediately before getters whose
+  // stored class either collapsed a deeper, unsupported nesting into the nearest typed
+  // "Any"-wrapper, or fell all the way back to a plain, untyped getter because no stored
+  // class (not even a collapsed one) is available. Normal, fully-supported getters get no
+  // such doc, to limit snapshot churn.
+  private emitStoredClassBoundaryDoc(att: AttributeModel) {
+    const boundaryKind = att.storedClassBoundaryKind;
+    if (!boundaryKind) {
+      return;
+    }
+
+    const comment = sanitizedComment(this.code);
+    comment.line(`Terraform type: \`${describeTerraformType(att.type)}\`.`);
+
+    if (boundaryKind === "collapsed") {
+      const collapsedName = (att.type as CollectionAttributeTypeModel)
+        .resolvedStoredClass!.name;
+      comment.line(
+        `This nesting is deeper than the typed wrapper classes in the core cdktn package; it is exposed as \`${collapsedName}\` and values below that boundary are untyped tokens.`,
+      );
+    } else {
+      comment.line(
+        `No typed wrapper class for this shape exists in the core cdktn package; the value is returned as an untyped token (IResolvable).`,
+      );
+    }
+
+    comment.end();
   }
 
   public determineGetAttCall(att: AttributeModel): string {

--- a/packages/@cdktn/provider-generator/src/get/generator/models/attribute-model.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/models/attribute-model.ts
@@ -1,6 +1,10 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { AttributeTypeModel } from "./attribute-type-model";
+import { logger } from "@cdktn/commons";
+import {
+  AttributeTypeModel,
+  CollectionAttributeTypeModel,
+} from "./attribute-type-model";
 
 export type GetterType =
   | { _type: "plain" }
@@ -69,6 +73,7 @@ export class AttributeModel {
   public provider: boolean;
   public required: boolean;
   public forcePlainGetterType?: boolean;
+  private loggedStoredClassUnavailable = false;
 
   constructor(options: AttributeModelOptions) {
     this.storageName = options.storageName;
@@ -125,12 +130,61 @@ export class AttributeModel {
       !this.isAssignable &&
       (!this.type.isTokenizable || this.type.typeModelType === "map")
     ) {
-      getterType = {
-        _type: "stored_class",
-      };
+      if (this.type.isStoredClassUnavailable) {
+        // Defensive fallback: neither the composed stored class name (e.g.
+        // "StringListMapMap") nor a collapsed nearest-Any wrapper (e.g. "AnyMapMap")
+        // exists in the core cdktn package for this type. This should be rare - see
+        // resolveStoredClassName in supported-stored-classes.ts - so log it loudly to
+        // make regressions in the collapse logic visible.
+        if (!this.loggedStoredClassUnavailable) {
+          this.loggedStoredClassUnavailable = true;
+          logger.debug(
+            `No stored class (not even a collapsed nearest-Any wrapper) is available for computed attribute "${this.terraformFullName}" (composed storedClassType: "${this.type.storedClassType}"). Falling back to a plain, untyped getter.`,
+          );
+        }
+      } else {
+        getterType = {
+          _type: "stored_class",
+        };
+      }
     }
 
     return getterType;
+  }
+
+  // Reports whether this attribute's getter sits at a "stored class boundary" that is
+  // worth documenting: "collapsed" when a deeper, unsupported nesting was collapsed into
+  // the nearest typed "Any"-wrapper (e.g. "AnyMapMap"), or "fallback" when no stored class
+  // at all is available and a plain, untyped getter is emitted instead. Mirrors the same
+  // condition tree as getterType above, so it only ever reports a boundary for attributes
+  // that actually went through that computed-collection branch - plain getters for
+  // ordinary tokenizable types (e.g. list(string)) are never flagged.
+  public get storedClassBoundaryKind(): "collapsed" | "fallback" | undefined {
+    if (this.forcePlainGetterType || this.isProvider) {
+      return undefined;
+    }
+
+    if (this.type.hasReferenceClass) {
+      return undefined;
+    }
+
+    if (
+      this.computed &&
+      !this.isAssignable &&
+      (!this.type.isTokenizable || this.type.typeModelType === "map")
+    ) {
+      if (this.type.isStoredClassUnavailable) {
+        return "fallback";
+      }
+
+      const resolvedStoredClass = (this.type as CollectionAttributeTypeModel)
+        .resolvedStoredClass;
+      if (resolvedStoredClass?.collapsed) {
+        return "collapsed";
+      }
+    }
+
+    return undefined;
   }
 
   public get isStored(): boolean {

--- a/packages/@cdktn/provider-generator/src/get/generator/models/attribute-type-model.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/models/attribute-type-model.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import { Struct } from "./struct";
 import { uppercaseFirst, downcaseFirst } from "../../../util";
+import { resolveStoredClassName } from "./supported-stored-classes";
 
 export interface AttributeTypeModel {
   readonly struct?: Struct; // complex object type contained within the type
@@ -15,6 +16,37 @@ export interface AttributeTypeModel {
   readonly typeModelType: string; // so we don't need to use instanceof
   readonly hasReferenceClass: boolean; // used to determine if a stored_class getter should be used
   readonly isTokenizable: boolean; // can the type be represented by a token type
+  readonly isStoredClassUnavailable: boolean; // true when no "cdktn.<Name>" stored class (not even a collapsed nearest-Any wrapper) is available for this type
+}
+
+// Describes the Terraform type of an attribute as its `list(...)`/`set(...)`/`map(...)`
+// composed notation (matching how Terraform itself describes nested collection types),
+// for use in generated JSDoc. Used only for collapsed/fallback getters (see
+// AttributesEmitter) so it never needs to be exhaustive/perfectly stable for every shape.
+export function describeTerraformType(model: AttributeTypeModel): string {
+  switch (model.typeModelType) {
+    case "list":
+      return `list(${describeTerraformType(
+        (model as CollectionAttributeTypeModel).elementType,
+      )})`;
+    case "set":
+      return `set(${describeTerraformType(
+        (model as CollectionAttributeTypeModel).elementType,
+      )})`;
+    case "map":
+      return `map(${describeTerraformType(
+        (model as CollectionAttributeTypeModel).elementType,
+      )})`;
+    case "struct":
+      return "object";
+    default:
+      // Covers both SimpleAttributeTypeModel (storedClassType is the Terraform primitive
+      // name, e.g. "string" | "number" | "boolean" | "any") and SkippedAttributeTypeModel
+      // (storedClassType is always "any").
+      return model.storedClassType === "boolean"
+        ? "bool"
+        : model.storedClassType;
+  }
 }
 
 export class SkippedAttributeTypeModel implements AttributeTypeModel {
@@ -62,6 +94,10 @@ export class SkippedAttributeTypeModel implements AttributeTypeModel {
   }
 
   get isTokenizable() {
+    return false;
+  }
+
+  get isStoredClassUnavailable() {
     return false;
   }
 }
@@ -117,6 +153,10 @@ export class SimpleAttributeTypeModel implements AttributeTypeModel {
   get isTokenizable() {
     return true;
   }
+
+  get isStoredClassUnavailable() {
+    return false;
+  }
 }
 
 export class StructAttributeTypeModel implements AttributeTypeModel {
@@ -162,10 +202,21 @@ export class StructAttributeTypeModel implements AttributeTypeModel {
   get isTokenizable() {
     return false;
   }
+
+  get isStoredClassUnavailable() {
+    return false;
+  }
 }
 
 export interface CollectionAttributeTypeModel extends AttributeTypeModel {
   elementType: AttributeTypeModel;
+  // Resolves the "cdktn.<name>" stored class to instantiate for this (non-complex)
+  // collection type, and whether that resolution collapsed a deeper, unsupported nesting
+  // into the nearest typed "Any"-wrapper. undefined only defensively - see
+  // resolveStoredClassName in supported-stored-classes.ts.
+  readonly resolvedStoredClass:
+    | { name: string; collapsed: boolean }
+    | undefined;
 }
 
 export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
@@ -198,15 +249,20 @@ export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
       if (this.isComplex) {
         return `new ${this.storedClassType}(this, "${name}", false)`;
       } else {
-        return `new cdktn.${uppercaseFirst(
-          this.storedClassType,
-        )}(this, "${name}", false)`;
+        return `new cdktn.${this.resolvedStoredClass!.name}(this, "${name}", false)`;
       }
     }
   }
 
   get storedClassType() {
     return `${this.elementType.storedClassType}List`;
+  }
+
+  get resolvedStoredClass() {
+    return resolveStoredClassName(
+      this.storedClassType,
+      this.elementType.typeModelType,
+    );
   }
 
   get inputTypeDefinition() {
@@ -263,6 +319,34 @@ export class ListAttributeTypeModel implements CollectionAttributeTypeModel {
         return false;
     }
   }
+
+  // Complex (struct) elements generate their own class in the provider output, so they
+  // are always fine. Otherwise a stored class is only emitted if resolvedStoredClass
+  // finds one - see getStoredClassInitializer above. Note: hasReferenceClass (which
+  // triggers a stored_class getter) is only ever true here when isSingleItem or isComplex
+  // is true, and isSingleItem is only set for struct/block nesting (which is also
+  // isComplex), so this check only needs to guard the non-complex, non-single-item case.
+  //
+  // storedClassType is itself built up recursively (elementType.storedClassType is
+  // composed the same way for nested collections), so it already fully encodes the
+  // entire nested chain in one string (e.g. map(map(list(string))) composes all the way
+  // up to "stringListMapMap"). resolvedStoredClass first checks this type's own composed
+  // name (e.g. "StringListMapMap") against the fixed set of hand-written core classes; if
+  // that name doesn't exist, it falls back to the nearest typed "Any"-wrapper that still
+  // encodes this type's own layer and its element's layer (e.g. "AnyMapMap"), collapsing
+  // only the unsupported inner shape while preserving typed navigation for the outer
+  // layers; only if neither exists does it fall through to the plain, untyped getter (see
+  // AttributeModel.getterType). It must NOT also OR in
+  // elementType.isStoredClassUnavailable, since an inner element's un-composed name (e.g.
+  // "StringList" for a plain list(string) nested inside a map) is never separately
+  // instantiated and is irrelevant on its own; ORing it in would produce false positives
+  // that regress supported nestings such as map(list(string)) => cdktn.StringListMap.
+  get isStoredClassUnavailable() {
+    if (this.isComplex) {
+      return false;
+    }
+    return this.resolvedStoredClass === undefined;
+  }
 }
 
 export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
@@ -295,15 +379,20 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
       if (this.isComplex) {
         return `new ${this.storedClassType}(this, "${name}", true)`;
       } else {
-        return `new cdktn.${uppercaseFirst(
-          this.storedClassType,
-        )}(this, "${name}", true)`;
+        return `new cdktn.${this.resolvedStoredClass!.name}(this, "${name}", true)`;
       }
     }
   }
 
   get storedClassType() {
     return `${this.elementType.storedClassType}List`;
+  }
+
+  get resolvedStoredClass() {
+    return resolveStoredClassName(
+      this.storedClassType,
+      this.elementType.typeModelType,
+    );
   }
 
   get inputTypeDefinition() {
@@ -365,6 +454,15 @@ export class SetAttributeTypeModel implements CollectionAttributeTypeModel {
         return false;
     }
   }
+
+  // See comment on ListAttributeTypeModel.isStoredClassUnavailable above - same
+  // reasoning applies here.
+  get isStoredClassUnavailable() {
+    if (this.isComplex) {
+      return false;
+    }
+    return this.resolvedStoredClass === undefined;
+  }
 }
 
 export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
@@ -386,14 +484,19 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
     if (this.isComplex) {
       return `new ${this.storedClassType}(this, "${name}")`;
     } else {
-      return `new cdktn.${uppercaseFirst(
-        this.storedClassType,
-      )}(this, "${name}")`;
+      return `new cdktn.${this.resolvedStoredClass!.name}(this, "${name}")`;
     }
   }
 
   get storedClassType() {
     return `${this.elementType.storedClassType}Map`;
+  }
+
+  get resolvedStoredClass() {
+    return resolveStoredClassName(
+      this.storedClassType,
+      this.elementType.typeModelType,
+    );
   }
 
   get inputTypeDefinition() {
@@ -444,5 +547,14 @@ export class MapAttributeTypeModel implements CollectionAttributeTypeModel {
       default:
         return false;
     }
+  }
+
+  // See comment on ListAttributeTypeModel.isStoredClassUnavailable above - same
+  // reasoning applies here (MapAttributeTypeModel.hasReferenceClass is just isComplex).
+  get isStoredClassUnavailable() {
+    if (this.isComplex) {
+      return false;
+    }
+    return this.resolvedStoredClass === undefined;
   }
 }

--- a/packages/@cdktn/provider-generator/src/get/generator/models/supported-stored-classes.ts
+++ b/packages/@cdktn/provider-generator/src/get/generator/models/supported-stored-classes.ts
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { uppercaseFirst } from "../../../util";
+
+// The core cdktn package (packages/cdktn/src/complex-computed-list.ts) only hand-writes
+// this fixed set of wrapper classes for computed, non-complex collection attributes.
+// Arbitrarily deep nestings of list/set/map (e.g. map(map(list(string)))) compose a
+// storedClassType (e.g. "stringListMapMap") that has no corresponding class. Rather than
+// falling back straight to a plain, untyped getter, resolveStoredClassName below first
+// looks for the nearest typed "Any"-wrapper that still exists in this set, collapsing the
+// unsupported inner shape into an untyped boundary while preserving typed navigation for
+// the outer layers (see https://github.com/open-constructs/cdk-terrain/issues/11).
+const SUPPORTED_STORED_CLASSES = new Set([
+  "StringMap",
+  "NumberMap",
+  "BooleanMap",
+  "AnyMap",
+  "StringMapMap",
+  "NumberMapMap",
+  "BooleanMapMap",
+  "AnyMapMap",
+  "BooleanList",
+  "StringListList",
+  "NumberListList",
+  "BooleanListList",
+  "AnyListList",
+  "StringMapList",
+  "NumberMapList",
+  "BooleanMapList",
+  "AnyMapList",
+  "StringListMap",
+  "NumberListMap",
+  "BooleanListMap",
+  "AnyListMap",
+]);
+
+// Resolves the composed stored class name to use for a collection attribute (list/set/map)
+// whose element is itself a non-complex collection (or simple type).
+//
+// `ownStoredClassType` is this type's own composed storedClassType (e.g. "stringListMapMap"
+// for map(map(list(string)))) and `elementTypeModelType` is the element's typeModelType
+// ("list" | "set" | "map" | "simple" | ...).
+//
+// Resolution order:
+//   1. The own composed name (e.g. "StringListMapMap") - used as-is when it refers to a
+//      class that is hand-written in the core package (not collapsed).
+//   2. Otherwise, the nearest typed "Any"-wrapper that still encodes the outer two layers
+//      (this type's own layer and its element's layer), e.g. "AnyMapMap" - collapsing the
+//      unsupported inner shape into an untyped boundary while preserving typed navigation
+//      for the outer layers.
+//   3. Otherwise (defensively; every depth should resolve via 1 or 2), undefined - the
+//      caller must fall back to a plain, untyped getter.
+export function resolveStoredClassName(
+  ownStoredClassType: string,
+  elementTypeModelType: string,
+): { name: string; collapsed: boolean } | undefined {
+  const candidate1 = uppercaseFirst(ownStoredClassType);
+  if (SUPPORTED_STORED_CLASSES.has(candidate1)) {
+    return { name: candidate1, collapsed: false };
+  }
+
+  let ownLayer: "List" | "Map" | undefined;
+  if (ownStoredClassType.endsWith("List")) {
+    ownLayer = "List";
+  } else if (ownStoredClassType.endsWith("Map")) {
+    ownLayer = "Map";
+  }
+  if (!ownLayer) {
+    return undefined;
+  }
+
+  let innerLayer: "List" | "Map" | undefined;
+  if (elementTypeModelType === "list" || elementTypeModelType === "set") {
+    innerLayer = "List";
+  } else if (elementTypeModelType === "map") {
+    innerLayer = "Map";
+  }
+  if (!innerLayer) {
+    return undefined;
+  }
+
+  const candidate2 = `Any${innerLayer}${ownLayer}`;
+  if (SUPPORTED_STORED_CLASSES.has(candidate2)) {
+    return { name: candidate2, collapsed: true };
+  }
+
+  return undefined;
+}

--- a/packages/cdktn/src/complex-computed-list.ts
+++ b/packages/cdktn/src/complex-computed-list.ts
@@ -237,6 +237,84 @@ export class StringMapMap
   }
 }
 
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class NumberMapMap
+  extends ComplexResolvable
+  implements ITerraformAddressable
+{
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string,
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public lookup(key: string): NumberMap {
+    return new NumberMap(
+      this.terraformResource,
+      `${this.terraformAttribute}["${key}"]`,
+    );
+  }
+
+  computeFqn(): string {
+    return Token.asString(
+      this.terraformResource.interpolationForAttribute(this.terraformAttribute),
+    );
+  }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class BooleanMapMap
+  extends ComplexResolvable
+  implements ITerraformAddressable
+{
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string,
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public lookup(key: string): BooleanMap {
+    return new BooleanMap(
+      this.terraformResource,
+      `${this.terraformAttribute}["${key}"]`,
+    );
+  }
+
+  computeFqn(): string {
+    return Token.asString(
+      this.terraformResource.interpolationForAttribute(this.terraformAttribute),
+    );
+  }
+}
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export class AnyMapMap
+  extends ComplexResolvable
+  implements ITerraformAddressable
+{
+  constructor(
+    protected terraformResource: IInterpolatingParent,
+    protected terraformAttribute: string,
+  ) {
+    super(terraformResource, terraformAttribute);
+  }
+
+  public lookup(key: string): AnyMap {
+    return new AnyMap(
+      this.terraformResource,
+      `${this.terraformAttribute}["${key}"]`,
+    );
+  }
+
+  computeFqn(): string {
+    return Token.asString(
+      this.terraformResource.interpolationForAttribute(this.terraformAttribute),
+    );
+  }
+}
+
 /**
  * @deprecated Going to be replaced by Array of ComplexListItem
  * and will be removed in the future

--- a/packages/cdktn/test/__snapshots__/data-source.test.ts.snap
+++ b/packages/cdktn/test/__snapshots__/data-source.test.ts.snap
@@ -89,6 +89,68 @@ exports[`with any map 1`] = `
 }"
 `;
 
+exports[`with any map map - lookup returns AnyMap reference 1`] = `
+"{
+  "data": {
+    "test_data_source": {
+      "test": {
+        "name": "foo"
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test-resource": {
+        "name": "\${data.test_data_source.test.any_map_map[\\"outer_key\\"]}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`with any map map - nested lookup produces correct reference 1`] = `
+"{
+  "data": {
+    "test_data_source": {
+      "test": {
+        "name": "foo"
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test-resource": {
+        "name": "\${data.test_data_source.test.any_map_map[\\"outer_key\\"][\\"inner_key\\"]}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
 exports[`with boolean map 1`] = `
 "{
   "data": {
@@ -107,6 +169,68 @@ exports[`with boolean map 1`] = `
     "test_resource": {
       "test-resource": {
         "name": "\${data.test_data_source.test.boolean_map[\\"id\\"]}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`with boolean map map - lookup returns BooleanMap reference 1`] = `
+"{
+  "data": {
+    "test_data_source": {
+      "test": {
+        "name": "foo"
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test-resource": {
+        "name": "\${data.test_data_source.test.boolean_map_map[\\"outer_key\\"]}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`with boolean map map - nested lookup produces correct reference 1`] = `
+"{
+  "data": {
+    "test_data_source": {
+      "test": {
+        "name": "foo"
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test-resource": {
+        "name": "\${data.test_data_source.test.boolean_map_map[\\"outer_key\\"][\\"inner_key\\"]}"
       }
     }
   },
@@ -169,6 +293,68 @@ exports[`with number map 1`] = `
     "test_resource": {
       "test-resource": {
         "name": "\${data.test_data_source.test.number_map[\\"id\\"]}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`with number map map - lookup returns NumberMap reference 1`] = `
+"{
+  "data": {
+    "test_data_source": {
+      "test": {
+        "name": "foo"
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test-resource": {
+        "name": "\${data.test_data_source.test.number_map_map[\\"outer_key\\"]}"
+      }
+    }
+  },
+  "terraform": {
+    "required_providers": {
+      "test": {
+        "version": "~> 2.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`with number map map - nested lookup produces correct reference 1`] = `
+"{
+  "data": {
+    "test_data_source": {
+      "test": {
+        "name": "foo"
+      }
+    }
+  },
+  "provider": {
+    "test": [
+      {}
+    ]
+  },
+  "resource": {
+    "test_resource": {
+      "test-resource": {
+        "name": "\${data.test_data_source.test.number_map_map[\\"outer_key\\"][\\"inner_key\\"]}"
       }
     }
   },

--- a/packages/cdktn/test/data-source.test.ts
+++ b/packages/cdktn/test/data-source.test.ts
@@ -121,6 +121,102 @@ test("with string map map - nested lookup produces correct reference", () => {
   ).toMatchSnapshot();
 });
 
+test("with number map map - lookup returns NumberMap reference", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(dataSource.numberMapMap.lookup("outer_key")),
+      });
+    }),
+  ).toMatchSnapshot();
+});
+
+test("with number map map - nested lookup produces correct reference", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(
+          dataSource.numberMapMap.lookup("outer_key").lookup("inner_key"),
+        ),
+      });
+    }),
+  ).toMatchSnapshot();
+});
+
+test("with boolean map map - lookup returns BooleanMap reference", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(dataSource.booleanMapMap.lookup("outer_key")),
+      });
+    }),
+  ).toMatchSnapshot();
+});
+
+test("with boolean map map - nested lookup produces correct reference", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(
+          dataSource.booleanMapMap.lookup("outer_key").lookup("inner_key"),
+        ),
+      });
+    }),
+  ).toMatchSnapshot();
+});
+
+test("with any map map - lookup returns AnyMap reference", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(dataSource.anyMapMap.lookup("outer_key")),
+      });
+    }),
+  ).toMatchSnapshot();
+});
+
+test("with any map map - nested lookup produces correct reference", () => {
+  expect(
+    Testing.synthScope((stack) => {
+      new TestProvider(stack, "provider", {});
+
+      const dataSource = new TestDataSource(stack, "test", {
+        name: "foo",
+      });
+      new TestResource(stack, "test-resource", {
+        name: Token.asString(
+          dataSource.anyMapMap.lookup("outer_key").lookup("inner_key"),
+        ),
+      });
+    }),
+  ).toMatchSnapshot();
+});
+
 test("dependent data source", () => {
   expect(
     Testing.synthScope((stack) => {

--- a/packages/cdktn/test/helper/data-source.ts
+++ b/packages/cdktn/test/helper/data-source.ts
@@ -7,8 +7,11 @@ import {
   StringMap,
   StringMapMap,
   NumberMap,
+  NumberMapMap,
   BooleanMap,
+  BooleanMapMap,
   AnyMap,
+  AnyMapMap,
   ComplexObject,
   ComplexList,
   IResolvable,
@@ -65,6 +68,18 @@ export class TestDataSource extends TerraformDataSource {
 
   public get stringMapMap() {
     return new StringMapMap(this, "string_map_map");
+  }
+
+  public get numberMapMap() {
+    return new NumberMapMap(this, "number_map_map");
+  }
+
+  public get booleanMapMap() {
+    return new BooleanMapMap(this, "boolean_map_map");
+  }
+
+  public get anyMapMap() {
+    return new AnyMapMap(this, "any_map_map");
   }
 
   public get listValue() {


### PR DESCRIPTION
Fixes #11

### Problem

Running `cdktn get` for the `awscc` provider generates bindings that fail to compile:

```
.gen/providers/awscc/data-awscc-appintegrations-data-integration/index.ts(327,44): error TS2551: Property 'StringListMapMap' does not exist on type
```

The generator composes stored-class names recursively (`string` → `stringList` → `stringListMap` → `stringListMapMap` for `map(map(list(string)))`) and emits `new cdktn.StringListMapMap(...)` for computed attributes — but the core `cdktn` package only hand-writes a fixed set of collection wrapper classes, so triple-nested combinations reference classes that don't exist. Upstream's attempt (hashicorp/terraform-cdk#3922, closed unmerged) skipped the attribute entirely.

### Fix: collapse to the nearest typed `Any` wrapper

**`feat(lib)`** — adds `NumberMapMap`, `BooleanMapMap` (typed depth-2 shapes that were also broken; mirrors of the existing `StringMapMap`) and `AnyMapMap`. `AnyMapMap` closes the set: any collection nesting of any depth now collapses to one of `AnyListList` / `AnyMapList` / `AnyListMap` / `AnyMapMap`, which all exist. Additive JSII API.

**`fix(provider-generator)`** — `resolveStoredClassName()` checks the composed name against the verified set of core classes; when unsupported it collapses to the nearest `Any` wrapper that still encodes the outer two collection layers. The `any` boundary sits exactly where core's class coverage ends, preserving typed navigation above it:

```typescript
di.objectConfiguration          // AnyMapMap — typed, autocompleted
  .lookup("SourceObject")       //  → AnyMap
  .lookup("Fields")             //  → any token (the list(string) layer)
```

Collapsed getters carry a JSDoc block so the full shape stays visible in IntelliSense (attribute getters previously had no JSDoc at all):

```typescript
/**
 * Terraform type: `map(map(list(string)))`.
 * This nesting is deeper than the typed wrapper classes in the core cdktn package; it is exposed as `AnyMapMap` and values below that boundary are untyped tokens.
 */
public get mapMapListString() { ... }
```

Supported shapes are untouched (`map(list(string))` still emits `cdktn.StringListMap`, no JSDoc added — all pre-existing snapshots pass byte-for-byte), and input/setter types keep their full precision. If no stored class can be resolved at all — should be unreachable now — the getter falls back to a plain untyped interpolation getter, kept loud by a direct unit test on the branch plus a debug-log breadcrumb (attribute name + composed type) so a wild firing leaves evidence instead of a silent typing downgrade.

Note on version alignment: bindings generated by this CLI reference the new core classes, so `cdktn` and `cdktn-cli` must be on the same release (the standard support contract — first troubleshooting step for post-upgrade tsc errors is aligning the two).

### Worked examples (all covered by the new fixture/snapshot test)

| Terraform type | Emitted class |
|---|---|
| `map(map(list(string)))` (awscc repro) | `AnyMapMap` (collapsed) |
| `list(map(map(string)))` | `AnyMapList` (collapsed) |
| `set(map(list(number)))` | `AnyMapList` (collapsed, set-wrapped) |
| `map(map(map(list(string))))` | `AnyMapMap` (collapsed) |
| `map(map(number))` / `map(map(bool))` | `NumberMapMap` / `BooleanMapMap` (newly typed) |
| `map(list(string))` (control) | `StringListMap` (unchanged) |

### Validation

- `pnpm nx build cdktn` (tsc + jsii): clean
- `pnpm nx test @cdktn/provider-generator`: 18/18 suites, 84/84 tests, 89/89 snapshots
- `pnpm nx test cdktn`: 443/444 (the one failure is the pre-existing `toPlanSuccessfully` matcher test requiring a live `terraform plan` with Docker; fails identically on `main`)
- New core unit tests mirror the existing `StringMapMap` lookup tests for the three new classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)