### PR TITLE
fix(gha): flip merged release PR label to autorelease: tagged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,7 @@ jobs:
         # PR's label from "autorelease: pending" to "autorelease: tagged" itself.
         # Without this, release-please permanently refuses to open the next
         # release PR ("There are untagged, merged release PRs outstanding").
+        # The "autorelease: tagged" label itself is created once, repo-wide.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -362,8 +363,6 @@ jobs:
             echo "No pull request associated with ${{ github.sha }}, skipping relabel"
             exit 0
           fi
-          gh label create "autorelease: tagged" --color 0E8A16 \
-            --description "This PR represents a release that has been tagged and published" 2>/dev/null || true
           gh pr edit "${pr}" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
 
   publish_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     needs:
       - prepare-release
       - integration_test
@@ -347,6 +348,23 @@ jobs:
         run: pnpm run release-github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Mark merged release PR as tagged
+        # skip-github-release in release-please-config.json means release-please
+        # never sees this release finalized, so it never flips the merged release
+        # PR's label from "autorelease: pending" to "autorelease: tagged" itself.
+        # Without this, release-please permanently refuses to open the next
+        # release PR ("There are untagged, merged release PRs outstanding").
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].number // empty')
+          if [ -z "${pr}" ]; then
+            echo "No pull request associated with ${{ github.sha }}, skipping relabel"
+            exit 0
+          fi
+          gh label create "autorelease: tagged" --color 0E8A16 \
+            --description "This PR represents a release that has been tagged and published" 2>/dev/null || true
+          gh pr edit "${pr}" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
 
   publish_release:
     permissions:


### PR DESCRIPTION
## Summary
- `release-please-config.json` sets `skip-github-release: true` so `release.yml`'s stable job (not release-please) creates the tag/GitHub Release, avoiding a double-create race.
- Because release-please never creates that release itself, it never flips the merged release PR's label from `autorelease: pending` to `autorelease: tagged`.
- Release-please refuses to open a new release PR while a merged one is still labeled `autorelease: pending` ("There are untagged, merged release PRs outstanding - aborting") — this silently blocked every release PR after v0.23.4 shipped.
- Adds a step to the `release_github` job that relabels the merged PR right after the GitHub release is created, so release-please's bookkeeping matches reality going forward.

PR #254 (v0.23.4) was manually relabeled `autorelease: tagged` already to unblock the standing PR immediately; this change prevents the same thing from recurring on every future release.

### One-off setup performed by hand (label didn't exist yet)
```bash
gh label create "autorelease: tagged" --repo open-constructs/cdk-terrain --color 0E8A16 \
  --description "This PR represents a release that has been tagged and published"

gh pr edit 254 --repo open-constructs/cdk-terrain \
  --remove-label "autorelease: pending" --add-label "autorelease: tagged"
```

## Test plan
- [x] `actionlint .github/workflows/release.yml` — no new findings (only pre-existing unrelated warnings)
- [ ] Next stable release run creates a GitHub Release and the relabel step succeeds
- [ ] Release Please workflow opens a new release PR afterward instead of aborting
