### PR TITLE
chore(cli)!: replace node-fetch with undici

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -49,14 +49,13 @@
     "constructs": "10.6.0",
     "cross-spawn": "7.0.6",
     "fs-extra": "8.1.0",
-    "https-proxy-agent": "5.0.1",
     "indent-string": "4.0.0",
     "minimatch": "5.1.9",
-    "node-fetch": "2.7.0",
     "pkg-up": "3.1.0",
     "semver": "7.7.4",
     "sscaff": "1.2.274",
     "strip-ansi": "6.0.1",
+    "undici": "8.6.0",
     "xml-js": "1.6.11",
     "xstate": "4.38.3",
     "zod": "3.25.76"
@@ -70,11 +69,13 @@
     "@types/fs-extra": "8.1.5",
     "@types/minimatch": "5.1.2",
     "@types/node": "20.19.1",
-    "@types/node-fetch": "2.6.13",
     "@types/semver": "7.7.1",
-    "nock": "13.5.6",
+    "nock": "^14.0.0",
     "prettier": "2.8.8",
     "tsc-files": "1.1.4",
     "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=22.19.0"
   }
 }

--- a/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
@@ -14,8 +14,13 @@ import path from "path";
 import { xml2js, js2xml, Element } from "xml-js";
 import * as fs from "fs-extra";
 import * as semver from "semver";
-import fetch, { RequestInit, Response } from "node-fetch";
+import { fetch, ProxyAgent, RequestInit, Response } from "undici";
 import * as z from "zod";
+
+const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
+const dispatcher: ProxyAgent | undefined = proxy
+  ? new ProxyAgent(proxy)
+  : undefined;
 
 /**
  * Number of attempts (initial try + retries) for a registry probe before we give up and treat the registry as
@@ -90,7 +95,7 @@ async function fetchWithRetry(
 
   for (let attempt = 1; attempt <= REGISTRY_PROBE_ATTEMPTS; attempt++) {
     try {
-      const response = await fetch(url, init);
+      const response = await fetch(url, { ...init, dispatcher });
       if (!isTransientStatus(response.status)) {
         return response;
       }

--- a/packages/@cdktn/cli-core/src/lib/dependencies/prebuilt-providers.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/prebuilt-providers.ts
@@ -1,18 +1,16 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
 
-import { HttpsProxyAgent } from "https-proxy-agent";
-import fetch from "node-fetch";
+import { fetch, ProxyAgent } from "undici";
 import * as semver from "semver";
 import { logger } from "@cdktn/commons";
 import { ProviderConstraint } from "./dependency-manager";
 import { versionMatchesConstraint } from "./version-constraints";
 
 const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
-let agent: HttpsProxyAgent | undefined;
-if (proxy) {
-  agent = new HttpsProxyAgent(proxy);
-}
+const dispatcher: ProxyAgent | undefined = proxy
+  ? new ProxyAgent(proxy)
+  : undefined;
 
 // uses https://github.com/hashicorp/cdktf-repository-manager/blob/main/provider.json
 // However, it got cleared out. We'll need to host the existing list somewhere
@@ -44,7 +42,7 @@ async function fetchWrapped<T>(url: string): Promise<T> {
   let response;
   try {
     response = await fetch(url, {
-      agent,
+      dispatcher,
       headers: { "User-Agent": "OpenConstructs/cdktn-cli" },
     });
   } catch {

--- a/packages/@cdktn/cli-core/src/lib/dependencies/registry-api.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/registry-api.ts
@@ -1,7 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import fetch from "node-fetch";
-import { HttpsProxyAgent } from "https-proxy-agent";
+import { fetch, ProxyAgent } from "undici";
 import { ProviderConstraint } from "./dependency-manager";
 import * as semver from "semver";
 import { Errors } from "@cdktn/commons";
@@ -19,14 +18,11 @@ async function fetchVersions(
   constraint: ProviderConstraint,
 ): Promise<VersionsReturnType["versions"] | null> {
   const proxy = process.env.http_proxy || process.env.HTTP_PROXY;
-  let agent;
-  if (proxy) {
-    agent = new HttpsProxyAgent(proxy);
-  }
+  const dispatcher = proxy ? new ProxyAgent(proxy) : undefined;
   const url = `https://registry.terraform.io/v1/providers/${constraint.namespace}/${constraint.name}/versions`;
 
   const result = await fetch(url, {
-    agent,
+    dispatcher,
     headers: { "User-Agent": "OpenConstructs/cdktn-cli" },
   });
   if (!result.ok) {

--- a/packages/@cdktn/cli-core/src/test/lib/dependencies/package-manager.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/dependencies/package-manager.test.ts
@@ -3,7 +3,12 @@
 import { mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import nock from "nock";
+import {
+  MockAgent,
+  setGlobalDispatcher,
+  getGlobalDispatcher,
+  Dispatcher,
+} from "undici";
 import { Language } from "@cdktn/commons";
 import { PackageManager } from "../../../lib/dependencies/package-manager";
 
@@ -13,18 +18,19 @@ const PYPI_HOST = "https://pypi.org";
 const NUGET_HOST = "https://azuresearch-usnc.nuget.org";
 
 describe("package-manager", () => {
-  beforeAll(() => {
-    nock.disableNetConnect();
-  });
+  let originalDispatcher: Dispatcher;
+  let mockAgent: MockAgent;
 
-  afterAll(() => {
-    nock.cleanAll();
-    nock.enableNetConnect();
+  beforeEach(() => {
+    originalDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
   });
 
   afterEach(() => {
-    expect(nock.pendingMocks()).toEqual([]);
-    nock.cleanAll();
+    mockAgent.assertNoPendingInterceptors();
+    setGlobalDispatcher(originalDispatcher);
   });
 
   describe("JavaPackageManager.isNpmVersionAvailable", () => {
@@ -43,7 +49,10 @@ describe("package-manager", () => {
     });
 
     it("returns true when the .pom exists on Maven Central (HTTP 200)", async () => {
-      nock(MAVEN_HOST).get(pomPath("0.2.64")).reply(200);
+      mockAgent
+        .get(MAVEN_HOST)
+        .intercept({ path: pomPath("0.2.64"), method: "GET" })
+        .reply(200, "");
 
       await expect(
         manager.isNpmVersionAvailable(
@@ -54,7 +63,10 @@ describe("package-manager", () => {
     });
 
     it("returns false when the .pom is absent on Maven Central (HTTP 404)", async () => {
-      nock(MAVEN_HOST).get(pomPath("0.2.64")).reply(404);
+      mockAgent
+        .get(MAVEN_HOST)
+        .intercept({ path: pomPath("0.2.64"), method: "GET" })
+        .reply(404, "");
 
       await expect(
         manager.isNpmVersionAvailable(
@@ -66,7 +78,11 @@ describe("package-manager", () => {
 
     it("throws (rather than reporting absent) when Maven Central stays unreachable", async () => {
       // A transient 5xx is retried; after all attempts fail we must abort, not report the version as missing.
-      nock(MAVEN_HOST).get(pomPath("0.2.64")).times(3).reply(503);
+      mockAgent
+        .get(MAVEN_HOST)
+        .intercept({ path: pomPath("0.2.64"), method: "GET" })
+        .reply(503, "")
+        .times(3);
 
       await expect(
         manager.isNpmVersionAvailable(
@@ -92,8 +108,9 @@ describe("package-manager", () => {
     });
 
     it("returns true when GitHub returns the tag ref (HTTP 200)", async () => {
-      nock(GITHUB_HOST)
-        .get(refPath("0.2.64"))
+      mockAgent
+        .get(GITHUB_HOST)
+        .intercept({ path: refPath("0.2.64"), method: "GET" })
         .reply(200, { ref: "refs/tags/random/v0.2.64" });
 
       await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
@@ -102,8 +119,9 @@ describe("package-manager", () => {
     });
 
     it("returns false when GitHub reports the tag missing (HTTP 404)", async () => {
-      nock(GITHUB_HOST)
-        .get(refPath("0.2.64"))
+      mockAgent
+        .get(GITHUB_HOST)
+        .intercept({ path: refPath("0.2.64"), method: "GET" })
         .reply(404, { message: "Not Found" });
 
       await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
@@ -114,10 +132,11 @@ describe("package-manager", () => {
     it("throws on a rate-limit response instead of reading it as absent", async () => {
       // GitHub returns a JSON body on rate-limit, so the old missing-`ref` check mistook a 429 for "tag absent".
       // A 429 is transient: retried, then aborts.
-      nock(GITHUB_HOST)
-        .get(refPath("0.2.64"))
-        .times(3)
-        .reply(429, { message: "API rate limit exceeded" });
+      mockAgent
+        .get(GITHUB_HOST)
+        .intercept({ path: refPath("0.2.64"), method: "GET" })
+        .reply(429, { message: "API rate limit exceeded" })
+        .times(3);
 
       await expect(
         manager.isNpmVersionAvailable(pkg, "0.2.64"),
@@ -139,8 +158,9 @@ describe("package-manager", () => {
     });
 
     it("returns true when PyPI has the version (info present)", async () => {
-      nock(PYPI_HOST)
-        .get(jsonPath("0.2.64"))
+      mockAgent
+        .get(PYPI_HOST)
+        .intercept({ path: jsonPath("0.2.64"), method: "GET" })
         .reply(200, { info: { version: "0.2.64" } });
 
       await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
@@ -149,7 +169,10 @@ describe("package-manager", () => {
     });
 
     it("returns false when PyPI reports the version missing (HTTP 404)", async () => {
-      nock(PYPI_HOST).get(jsonPath("0.2.64")).reply(404, {});
+      mockAgent
+        .get(PYPI_HOST)
+        .intercept({ path: jsonPath("0.2.64"), method: "GET" })
+        .reply(404, {});
 
       await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
         false,
@@ -157,7 +180,11 @@ describe("package-manager", () => {
     });
 
     it("throws when PyPI stays unreachable rather than reporting absent", async () => {
-      nock(PYPI_HOST).get(jsonPath("0.2.64")).times(3).reply(502);
+      mockAgent
+        .get(PYPI_HOST)
+        .intercept({ path: jsonPath("0.2.64"), method: "GET" })
+        .reply(502, "")
+        .times(3);
 
       await expect(
         manager.isNpmVersionAvailable(pkg, "0.2.64"),
@@ -180,9 +207,9 @@ describe("package-manager", () => {
     });
 
     it("returns true when NuGet lists the version", async () => {
-      nock(NUGET_HOST)
-        .get("/query")
-        .query(query)
+      mockAgent
+        .get(NUGET_HOST)
+        .intercept({ path: "/query", method: "GET", query })
         .reply(200, {
           data: [{ id: pkg, versions: [{ version: "0.2.64" }] }],
         });
@@ -193,7 +220,10 @@ describe("package-manager", () => {
     });
 
     it("returns false when NuGet returns no matching package", async () => {
-      nock(NUGET_HOST).get("/query").query(query).reply(200, { data: [] });
+      mockAgent
+        .get(NUGET_HOST)
+        .intercept({ path: "/query", method: "GET", query })
+        .reply(200, { data: [] });
 
       await expect(manager.isNpmVersionAvailable(pkg, "0.2.64")).resolves.toBe(
         false,
@@ -201,7 +231,11 @@ describe("package-manager", () => {
     });
 
     it("throws when NuGet stays unreachable rather than reporting absent", async () => {
-      nock(NUGET_HOST).get("/query").query(query).times(3).reply(500);
+      mockAgent
+        .get(NUGET_HOST)
+        .intercept({ path: "/query", method: "GET", query })
+        .reply(500, "")
+        .times(3);
 
       await expect(
         manager.isNpmVersionAvailable(pkg, "0.2.64"),

--- a/packages/@cdktn/cli-core/src/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/dependencies/prebuilt-providers.test.ts
@@ -91,9 +91,11 @@ describe("prebuilt-providers", () => {
       mockAgent
         .get("https://registry.npmjs.org")
         .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
-        .replyWithError(Object.assign(new Error("connection error"), {
-          code: "ETIMEDOUT",
-        }));
+        .replyWithError(
+          Object.assign(new Error("connection error"), {
+            code: "ETIMEDOUT",
+          }),
+        );
 
       await expect(
         getAllPrebuiltProviderVersions("@cdktf/test"),
@@ -204,9 +206,11 @@ describe("prebuilt-providers", () => {
           path: "/.well-known/prebuilt-providers.json",
           method: "GET",
         })
-        .replyWithError(Object.assign(new Error("connection error"), {
-          code: "ETIMEDOUT",
-        }));
+        .replyWithError(
+          Object.assign(new Error("connection error"), {
+            code: "ETIMEDOUT",
+          }),
+        );
 
       await expect(
         getNpmPackageName(ProviderConstraint.fromConfigEntry("test"), false),
@@ -267,9 +271,11 @@ describe("prebuilt-providers", () => {
           path: "/.well-known/prebuilt-providers.json",
           method: "GET",
         })
-        .replyWithError(Object.assign(new Error("connection error"), {
-          code: "ETIMEDOUT",
-        }));
+        .replyWithError(
+          Object.assign(new Error("connection error"), {
+            code: "ETIMEDOUT",
+          }),
+        );
 
       await expect(
         getPrebuiltProviderVersions(
@@ -293,9 +299,11 @@ describe("prebuilt-providers", () => {
       mockAgent
         .get("https://registry.npmjs.org")
         .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
-        .replyWithError(Object.assign(new Error("connection error"), {
-          code: "ETIMEDOUT",
-        }));
+        .replyWithError(
+          Object.assign(new Error("connection error"), {
+            code: "ETIMEDOUT",
+          }),
+        );
 
       await expect(
         getPrebuiltProviderVersions(

--- a/packages/@cdktn/cli-core/src/test/lib/dependencies/prebuilt-providers.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/dependencies/prebuilt-providers.test.ts
@@ -1,6 +1,11 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import nock from "nock";
+import {
+  MockAgent,
+  setGlobalDispatcher,
+  getGlobalDispatcher,
+  Dispatcher,
+} from "undici";
 import { ProviderConstraint } from "../../../lib/dependencies/dependency-manager";
 import {
   getNpmPackageName,
@@ -44,27 +49,35 @@ function buildNpmResponse(
 
 describe("prebuilt-providers", () => {
   const initialLogLevel = process.env.CDKTF_LOG_LEVEL;
+  let originalDispatcher: Dispatcher;
+  let mockAgent: MockAgent;
+
   beforeAll(() => {
     // Prevent logging outputs from polluting the test results
     process.env.CDKTF_LOG_LEVEL = "error";
-    nock.disableNetConnect();
   });
 
   afterAll(() => {
     process.env.CDKTF_LOG_LEVEL = initialLogLevel;
-    nock.cleanAll();
-    nock.enableNetConnect();
+  });
+
+  beforeEach(() => {
+    originalDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
   });
 
   afterEach(() => {
     resetFetchCache();
-    nock.cleanAll();
+    setGlobalDispatcher(originalDispatcher);
   });
 
   describe("getPrebuiltProviderRepositoryName", () => {
     it("reads the repository field", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
         .reply(200, buildNpmResponse("2.3.0", "test1"));
 
       await expect(
@@ -75,9 +88,12 @@ describe("prebuilt-providers", () => {
 
   describe("getPrebuiltProviderVersions", () => {
     it("fails when connection error", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
-        .replyWithError({ code: "ETIMEDOUT" });
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
+        .replyWithError(Object.assign(new Error("connection error"), {
+          code: "ETIMEDOUT",
+        }));
 
       await expect(
         getAllPrebuiltProviderVersions("@cdktf/test"),
@@ -85,8 +101,9 @@ describe("prebuilt-providers", () => {
     });
 
     it("fails when npm responds with 5xx", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
         .reply(502, "Gateway error");
 
       await expect(
@@ -95,8 +112,9 @@ describe("prebuilt-providers", () => {
     });
 
     it("fails when package doesn't exist", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
         .reply(404, "Not found");
 
       await expect(
@@ -105,8 +123,9 @@ describe("prebuilt-providers", () => {
     });
 
     it("succeeds when package found", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
         .reply(200, buildNpmResponse("2.3.0"));
 
       await expect(
@@ -121,8 +140,9 @@ describe("prebuilt-providers", () => {
     });
 
     it("returns using cache the second time", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
         .reply(200, buildNpmResponse("2.4.2", "cachey"));
 
       await expect(
@@ -135,10 +155,13 @@ describe("prebuilt-providers", () => {
         ]),
       );
 
-      // Since we're expecting the cache to respond, the actual URL can fail
-      const scope = nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
-        .reply(500);
+      // Since we're expecting the cache to respond, the actual URL can fail.
+      // This interceptor must stay unconsumed — if it were hit, the reply(500)
+      // would surface instead of the cached value.
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
+        .reply(500, "");
 
       await expect(
         getAllPrebuiltProviderVersions("@cdktf/cachey"),
@@ -150,14 +173,14 @@ describe("prebuilt-providers", () => {
         ]),
       );
 
-      // ensure we never made the request
-      expect(scope.isDone()).toBeFalsy();
-      nock.cleanAll();
+      // ensure we never made the request: the reply(500) interceptor is still pending
+      expect(mockAgent.pendingInterceptors().length).toBeGreaterThan(0);
     });
 
     it("succeeds when package cdktn found", async () => {
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktn/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktn/.*"), method: "GET" })
         .reply(200, buildNpmResponse("2.3.0", "test", "^0.12.2", true, true));
 
       await expect(
@@ -175,9 +198,15 @@ describe("prebuilt-providers", () => {
   // TODO rebuild these tests when final url is known
   describe.skip("getNpmPackageName", () => {
     it("fails when connection error", async () => {
-      nock("https://www.cdk.tf/")
-        .get("/.well-known/prebuilt-providers.json")
-        .replyWithError({ code: "ETIMEDOUT" });
+      mockAgent
+        .get("https://www.cdk.tf")
+        .intercept({
+          path: "/.well-known/prebuilt-providers.json",
+          method: "GET",
+        })
+        .replyWithError(Object.assign(new Error("connection error"), {
+          code: "ETIMEDOUT",
+        }));
 
       await expect(
         getNpmPackageName(ProviderConstraint.fromConfigEntry("test"), false),
@@ -185,15 +214,25 @@ describe("prebuilt-providers", () => {
     });
 
     it("succeeds when cdk.tf redirect and Github work", async () => {
-      nock("https://www.cdk.tf/")
-        .get("/.well-known/prebuilt-providers.json")
+      mockAgent
+        .get("https://www.cdk.tf")
+        .intercept({
+          path: "/.well-known/prebuilt-providers.json",
+          method: "GET",
+        })
         .reply(307, undefined, {
-          Location:
-            "https://raw.githubusercontent.com/cdktf/cdktf-repository-manager/main/provider.json",
+          headers: {
+            Location:
+              "https://raw.githubusercontent.com/cdktf/cdktf-repository-manager/main/provider.json",
+          },
         });
 
-      nock("https://raw.githubusercontent.com/")
-        .get("/cdktf/cdktf-repository-manager/main/provider.json")
+      mockAgent
+        .get("https://raw.githubusercontent.com")
+        .intercept({
+          path: "/cdktf/cdktf-repository-manager/main/provider.json",
+          method: "GET",
+        })
         .reply(200, {
           test: "hashicorp/test@~> 0.3.3",
         });
@@ -204,8 +243,12 @@ describe("prebuilt-providers", () => {
     });
 
     it("succeeds when cdk.tf directly returns result", async () => {
-      nock("https://www.cdk.tf/")
-        .get("/.well-known/prebuilt-providers.json")
+      mockAgent
+        .get("https://www.cdk.tf")
+        .intercept({
+          path: "/.well-known/prebuilt-providers.json",
+          method: "GET",
+        })
         .reply(200, {
           test: "hashicorp/test@~> 0.3.3",
         });
@@ -218,9 +261,15 @@ describe("prebuilt-providers", () => {
 
   describe.skip("getPrebuiltProviderVersion", () => {
     it("returns null on connection error with github", async () => {
-      nock("https://www.cdk.tf/")
-        .get("/.well-known/prebuilt-providers.json")
-        .replyWithError({ code: "ETIMEDOUT" });
+      mockAgent
+        .get("https://www.cdk.tf")
+        .intercept({
+          path: "/.well-known/prebuilt-providers.json",
+          method: "GET",
+        })
+        .replyWithError(Object.assign(new Error("connection error"), {
+          code: "ETIMEDOUT",
+        }));
 
       await expect(
         getPrebuiltProviderVersions(
@@ -231,15 +280,22 @@ describe("prebuilt-providers", () => {
     });
 
     it("returns null on connection error with npm", async () => {
-      nock("https://www.cdk.tf/")
-        .get("/.well-known/prebuilt-providers.json")
+      mockAgent
+        .get("https://www.cdk.tf")
+        .intercept({
+          path: "/.well-known/prebuilt-providers.json",
+          method: "GET",
+        })
         .reply(200, {
           test: "hashicorp/test@~> 0.3.3",
         });
 
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
-        .replyWithError({ code: "ETIMEDOUT" });
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
+        .replyWithError(Object.assign(new Error("connection error"), {
+          code: "ETIMEDOUT",
+        }));
 
       await expect(
         getPrebuiltProviderVersions(
@@ -250,13 +306,18 @@ describe("prebuilt-providers", () => {
     });
 
     it("succeeds when both cdk.tf and npm work", async () => {
-      nock("https://www.cdk.tf/")
-        .get("/.well-known/prebuilt-providers.json")
+      mockAgent
+        .get("https://www.cdk.tf")
+        .intercept({
+          path: "/.well-known/prebuilt-providers.json",
+          method: "GET",
+        })
         .reply(200, {
           test: "hashicorp/test@~> 0.3.3",
         });
-      nock("https://registry.npmjs.org/")
-        .get(new RegExp("/@cdktf/.*"))
+      mockAgent
+        .get("https://registry.npmjs.org")
+        .intercept({ path: new RegExp("/@cdktf/.*"), method: "GET" })
         .reply(200, buildNpmResponse("2.3.0"));
 
       await expect(

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -36,6 +36,9 @@
     "terraform"
   ],
   "license": "MPL-2.0",
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "files": [
     "bundle"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1026,18 +1026,12 @@ importers:
       fs-extra:
         specifier: 8.1.0
         version: 8.1.0
-      https-proxy-agent:
-        specifier: 5.0.1
-        version: 5.0.1
       indent-string:
         specifier: 4.0.0
         version: 4.0.0
       minimatch:
         specifier: 5.1.9
         version: 5.1.9
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0(encoding@0.1.13)
       pkg-up:
         specifier: 3.1.0
         version: 3.1.0
@@ -1050,6 +1044,9 @@ importers:
       strip-ansi:
         specifier: 6.0.1
         version: 6.0.1
+      undici:
+        specifier: 8.6.0
+        version: 8.6.0
       xml-js:
         specifier: 1.6.11
         version: 1.6.11
@@ -1075,15 +1072,12 @@ importers:
       '@types/node':
         specifier: 20.19.1
         version: 20.19.1
-      '@types/node-fetch':
-        specifier: 2.6.13
-        version: 2.6.13
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
       nock:
-        specifier: 13.5.6
-        version: 13.5.6
+        specifier: ^14.0.0
+        version: 14.0.16
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -1512,7 +1506,7 @@ importers:
     devDependencies:
       jsii-docgen:
         specifier: ^10.4.20
-        version: 10.12.3(jsii-rosetta@5.9.39)
+        version: 10.12.4(jsii-rosetta@5.9.39)
       jsii-rosetta:
         specifier: ~5.9.0
         version: 5.9.39
@@ -2917,6 +2911,10 @@ packages:
     resolution: {integrity: sha512-zp8+IbcAEG/XbTQf88xsg/3bJUYt9dDzGFkK9YKhnbwzylcAUzTm7Ca/hVFDdIaP9I00Z+yZ/bioaUV58w0cNQ==}
     engines: {node: '>= 14.17.0'}
 
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -3041,6 +3039,15 @@ packages:
 
   '@nx/workspace@22.7.5':
     resolution: {integrity: sha512-f3zx8EAOl0ANd2UXZIniBoHfDvNvi2Uy65R9Rp6emdcx7rxsuTU5Eaidryleo9wIQ5cZAcMx7Wvzp5Srj8diKA==}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     resolution: {integrity: sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==}
@@ -3560,9 +3567,6 @@ packages:
 
   '@types/mute-stream@0.0.4':
     resolution: {integrity: sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==}
-
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -5527,6 +5531,9 @@ packages:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
     engines: {node: '>= 0.4'}
@@ -5795,8 +5802,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsii-docgen@10.12.3:
-    resolution: {integrity: sha512-isPOrp66Qyrl60wnqScj2tgl/Xjad6EKV0czO8/ditnP7JMUzIAl6T4bFYa5eQLOVwi/OLH4om7yUsMLwAihDw==}
+  jsii-docgen@10.12.4:
+    resolution: {integrity: sha512-CHtSyZFKjtgfB+UCz/tguRn001XQ7gtD7qw2EFS9WIjnfWGqV22zWzT6TPyZABYhxkqNz8LFFpCcGJ3xO+S6+A==}
     hasBin: true
     peerDependencies:
       jsii-rosetta: ^1.85.0 || ~5.0.14 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0 || ~5.5.0 || ~5.6.0 || ~5.7.0 || ~5.8.0 || ~5.9.1 || ~6.0.0
@@ -6289,17 +6296,12 @@ packages:
     resolution: {integrity: sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==}
     engines: {node: '>= 10.13'}
 
+  nock@14.0.16:
+    resolution: {integrity: sha512-8r4KEc6nT1D/fdLD/R1BO1CPaVEL8o40u/guFRJlXabN7vr3RmMqyjsY5Krt0nMwhsOAwXQ/mtN5vy5Jh3aErg==}
+    engines: {node: '>=18.20.0 <20 || >=20.12.1'}
+
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -6425,6 +6427,9 @@ packages:
   os-tmpdir@1.0.2:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   oxc-parser@0.133.0:
     resolution: {integrity: sha512-661RSx+ZcjBmjBYid+Fpp/2F5EbtildpeoZh5HdgnGs+jZ03nqQEQW8yGkt4BGyOC3OMPDQQRl8M5kqD2/g6jw==}
@@ -7091,6 +7096,9 @@ packages:
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -7421,6 +7429,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@8.6.0:
+    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
+    engines: {node: '>=22.19.0'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -9469,6 +9481,15 @@ snapshots:
 
   '@jsii/spec@1.138.0': {}
 
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -9678,6 +9699,15 @@ snapshots:
       - '@swc-node/register'
       - '@swc/core'
       - debug
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     optional: true
@@ -10095,11 +10125,6 @@ snapshots:
   '@types/mute-stream@0.0.4':
     dependencies:
       '@types/node': 20.19.37
-
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 20.19.37
-      form-data: 4.0.5
 
   '@types/node@18.19.130':
     dependencies:
@@ -10545,6 +10570,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   ajv@6.14.0:
     dependencies:
@@ -12244,6 +12270,7 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   human-signals@2.1.0: {}
 
@@ -12372,6 +12399,8 @@ snapshots:
   is-interactive@1.0.0: {}
 
   is-map@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -13008,7 +13037,7 @@ snapshots:
 
   jsesc@3.1.0: {}
 
-  jsii-docgen@10.12.3(jsii-rosetta@5.9.39):
+  jsii-docgen@10.12.4(jsii-rosetta@5.9.39):
     dependencies:
       '@jsii/spec': 1.138.0
       case: 1.6.3
@@ -13666,18 +13695,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  nock@14.0.16:
+    dependencies:
+      '@mswjs/interceptors': 0.41.9
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+
   node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
     optional: true
-
-  node-fetch@2.7.0(encoding@0.1.13):
-    dependencies:
-      whatwg-url: 5.0.0
-    optionalDependencies:
-      encoding: 0.1.13
 
   node-int64@0.4.0: {}
 
@@ -13923,6 +13952,8 @@ snapshots:
       wcwidth: 1.0.1
 
   os-tmpdir@1.0.2: {}
+
+  outvariant@1.4.3: {}
 
   oxc-parser@0.133.0:
     dependencies:
@@ -14700,6 +14731,8 @@ snapshots:
       - react-native-b4a
     optional: true
 
+  strict-event-emitter@0.5.1: {}
+
   string-argv@0.3.2: {}
 
   string-length@4.0.2:
@@ -14863,7 +14896,8 @@ snapshots:
       tldts: 6.1.86
     optional: true
 
-  tr46@0.0.3: {}
+  tr46@0.0.3:
+    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -15040,6 +15074,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
+
+  undici@8.6.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -15256,12 +15292,14 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  webidl-conversions@3.0.1: {}
+  webidl-conversions@3.0.1:
+    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+    optional: true
 
   which-boxed-primitive@1.1.1:
     dependencies:


### PR DESCRIPTION
<!--
Drafted to be pasted into the GitHub PR body. Follows
.github/pull_request_template.md verbatim.

Suggested title (per CDKTN style guide — conventional commits, scope `cli`):
  chore(cli): replace node-fetch with undici
-->

### Description

`@cdktn/cli-core` depended on the legacy `node-fetch` package and its proxy helper `https-proxy-agent`. This PR replaces that with the `undici` package — a modern, actively maintained `fetch` implementation with first-class proxy and mocking support — and removes `node-fetch`, `@types/node-fetch`, and `https-proxy-agent`.

#### Changes

- **Fetch → `undici`.** All three files now `import { fetch } from "undici"` instead of `node-fetch`.  We use undici's exported `fetch` rather than the global `fetch` deliberately: it keeps the whole HTTP stack — code and test mocks — on a single undici instance. `globalThis.fetch` uses Node's *internal* undici, which is a different instance from the `undici` npm package, so mocking has to target the same one the code uses.

- **Proxy → undici `ProxyAgent` via the `dispatcher` option.** `node-fetch`'s `agent` option (a Node `http.Agent` from `https-proxy-agent`) is replaced by an undici `ProxyAgent` built from the same `http_proxy` / `HTTP_PROXY` env vars and passed as the request `dispatcher`.

- **Proxy support extended to `package-manager.ts`.** Previously only `registry-api.ts` and `prebuilt-providers.ts` honoured a proxy; `package-manager.ts` (the PyPI / NuGet / Maven Central / GitHub / npm availability probes) never did. It now uses the same `dispatcher`, so all registry traffic respects a corporate proxy consistently.

- **`undici@8.6.0` dependency + Node floor.** `undici` is added to `@cdktn/cli-core`. undici 8 requires Node ≥ 22.19.0, so both published packages (`@cdktn/cli-core` and `cdktn-cli`) declare `"engines": { "node": ">=22.19.0" }` — surfacing a clear install-time warning on older Node instead of an opaque runtime failure.

- **Tests → undici `MockAgent`.** `prebuilt-providers.test.ts` and `package-manager.test.ts` exercise undici's `fetch`, so their `nock` scopes are replaced with an undici `MockAgent` wired via `setGlobalDispatcher`.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

