### PR TITLE
fix(gha): Allow pnpm to update the lockfile after package updates

### DIFF
--- a/.github/workflows/pnpm-upgrade.yml
+++ b/.github/workflows/pnpm-upgrade.yml
@@ -58,7 +58,7 @@ jobs:
 
       # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
       - name: Run "pnpm install"
-        run: pnpm install --prefer-offline
+        run: pnpm install --prefer-offline --no-frozen-lockfile
 
       # Next, create and upload the changes as a patch file. This will later be downloaded to create a pull request
       # Creating a pull request requires write permissions and it's best to keep write privileges isolated.
@@ -182,7 +182,7 @@ jobs:
           pnpm exec nx exec -p '${{ join(matrix.pr.packages, ',') }}' -- ncu --upgrade --reject='@types/node,@types/fs-extra,constructs,typescript,graphology-types,jsii,jsii-pacmak,jsii-rosetta,jsii-docgen,codemaker,${{ steps.list-packages.outputs.list }}'  --target=minor
       # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
       - name: Run "pnpm install"
-        run: pnpm install --prefer-offline
+        run: pnpm install --prefer-offline --no-frozen-lockfile
 
       - name: Set git identity
         run: |-
@@ -247,7 +247,7 @@ jobs:
           pnpm exec nx exec -- ncu --upgrade --filter='jsii,jsii-pacmak,jsii-rosetta,jsii-docgen,codemaker,constructs' --target=minor
       # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
       - name: Run "pnpm install"
-        run: pnpm install --prefer-offline
+        run: pnpm install --prefer-offline --no-frozen-lockfile
 
       - name: Set git identity
         run: |-


### PR DESCRIPTION
### Description

The pnpm upgrade job has been failing as in ci environments pnpm is by default not allowed to update the lockfile, but that is explicitly what we want to do here.

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
