### PR TITLE
chore(deps): update ci-info to 4.4.0 across all packages

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -44,7 +44,7 @@
     "cdktn": "workspace:*",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",
-    "ci-info": "3.9.0",
+    "ci-info": "4.4.0",
     "codemaker": "1.128.0",
     "constructs": "10.6.0",
     "cross-spawn": "7.0.6",

--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@sentry/node": "7.120.4",
     "cdktn": "workspace:*",
-    "ci-info": "3.9.0",
+    "ci-info": "4.4.0",
     "codemaker": "1.128.0",
     "cross-spawn": "7.0.6",
     "follow-redirects": "1.15.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1012,8 +1012,8 @@ importers:
         specifier: 3.6.0
         version: 3.6.0
       ci-info:
-        specifier: 3.9.0
-        version: 3.9.0
+        specifier: 4.4.0
+        version: 4.4.0
       codemaker:
         specifier: 1.128.0
         version: 1.128.0
@@ -1097,8 +1097,8 @@ importers:
         specifier: workspace:*
         version: link:../../cdktn
       ci-info:
-        specifier: 3.9.0
-        version: 3.9.0
+        specifier: 4.4.0
+        version: 4.4.0
       codemaker:
         specifier: 1.128.0
         version: 1.128.0
@@ -4301,10 +4301,6 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
-
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -11005,8 +11001,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  ci-info@3.9.0: {}
 
   ci-info@4.4.0: {}
 


### PR DESCRIPTION
### Description

Bumps `ci-info` from `3.9.0` to `4.4.0` (latest) in the two packages that declare it as a dependency:

- `@cdktn/commons`
- `@cdktn/cli-core`

This is a major version bump (3.x → 4.x). The only API used in the codebase is `ciInfo.isCI` and `ciInfo.name` (in [`commons/src/checkpoint.ts`](../packages/@cdktn/commons/src/checkpoint.ts) and [`cli-core/src/lib/error-reporting.ts`](../packages/@cdktn/cli-core/src/lib/error-reporting.ts)), both of which are unchanged in v4. v4's breaking change was dropping support for Node < 8; it still ships CommonJS, so the existing default `import ciInfo from "ci-info"` continues to work with no code changes.

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes
