### PR TITLE
chore(deps): Update sscaff to v2.0.388

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -53,7 +53,7 @@
     "minimatch": "5.1.9",
     "pkg-up": "3.1.0",
     "semver": "7.7.4",
-    "sscaff": "1.2.274",
+    "sscaff": "2.0.388",
     "strip-ansi": "6.0.1",
     "undici": "8.6.0",
     "xml-js": "1.6.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1039,8 +1039,8 @@ importers:
         specifier: 7.7.4
         version: 7.7.4
       sscaff:
-        specifier: 1.2.274
-        version: 1.2.274
+        specifier: 2.0.388
+        version: 2.0.388
       strip-ansi:
         specifier: 6.0.1
         version: 6.0.1
@@ -7047,9 +7047,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  sscaff@1.2.274:
-    resolution: {integrity: sha512-sztRa50SL1LVxZnF1au6QT1SC2z0S1oEOyi2Kpnlg6urDns93aL32YxiJcNkLcY+VHFtVqm/SRv4cb+6LeoBQA==}
-    engines: {node: '>= 12.13.0'}
+  sscaff@2.0.388:
+    resolution: {integrity: sha512-rt47eYRwZSSwTiawj2C5Eh2I7+DBRCFrjw5med2H1G1x6EnkfoYjKnmCkI4xMoYjdkC4HWPDl8SLSoMVV+iAzA==}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -14652,7 +14651,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sscaff@1.2.274: {}
+  sscaff@2.0.388: {}
 
   sshpk@1.18.0:
     dependencies:


### PR DESCRIPTION
### Description

Bumps `sscaff` from `1.2.274` to `2.0.388` (latest) in `@cdktn/cli-core`.

This is a major version bump (1.x → 2.x) but required no code changes on our side.

The [v2.0.0 breaking change](https://github.com/cdklabs/node-sscaff/releases/tag/v2.0.0) is a single item: sscaff now requires `node >= 14.x`. This package's `engines` field already requires `node >=22.19.0`, so the new floor is satisfied.

The rest of the package is unchanged between the two versions:

- **API is unchanged.** The sole call site, [`init.ts`](../packages/@cdktn/cli-core/src/lib/init.ts), still uses `sscaff(templatePath, destination, vars)` with the same signature.
- **Packaging is unchanged.** 2.0.388 still ships both `.ts` source and compiled `.js` under `lib/`, still points `main` at `lib/index.js`, and remains CommonJS. The [`jest.config.js`](../packages/@cdktn/cli-core/jest.config.js) comments and settings that account for this (`moduleFileExtensions` preferring `.js`, and the `templates/` `transformIgnorePatterns` entry for sloppy-mode template hooks) remain accurate.

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes
