### PR TITLE
chore(deps): Update xstate to v5.32.4

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -57,7 +57,7 @@
     "strip-ansi": "6.0.1",
     "undici": "8.7.0",
     "xml-js": "1.6.11",
-    "xstate": "4.38.3",
+    "xstate": "5.32.4",
     "zod": "4.4.3"
   },
   "lint-staged": {

--- a/packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts
@@ -4,13 +4,13 @@
  */
 
 import {
-  createMachine,
-  send,
-  interpret,
-  EventObject,
+  setup,
+  createActor,
+  sendTo,
+  fromCallback,
   assign,
-  Sender,
-  Receiver,
+  EventObject,
+  InspectionEvent,
 } from "xstate";
 import { Errors, logger } from "@cdktn/commons";
 import { missingVariable } from "../errors";
@@ -53,40 +53,6 @@ export function isDeployEvent<DeployEventType extends DeployEvent["type"]>(
 ): event is DeployEvent & { type: DeployEventType } {
   return event.type === type;
 }
-
-export type DeployState =
-  | {
-      value: "idle";
-      context: DeployContext;
-    }
-  | {
-      value: "running";
-      context: DeployContext;
-    }
-  | {
-      value: { running: "processing" };
-      context: DeployContext;
-    }
-  | {
-      value: { running: "awaiting_approval" };
-      context: DeployContext;
-    }
-  | {
-      value: { running: "awaiting_sentinel_override" };
-      context: DeployContext;
-    }
-  | {
-      value: { running: "stopping" };
-      context: DeployContext;
-    }
-  | {
-      value: "exited";
-      context: DeployContext & { exitCode: number };
-    }
-  | {
-      value: "stopped";
-      context: DeployContext;
-    };
 
 /**
  * Terraform's interactive prompt for a missing variable looks like:
@@ -211,186 +177,195 @@ export function handleLineReceived(send: (event: DeployEvent) => void) {
   };
 }
 
-export const deployMachine = createMachine<
-  DeployContext,
-  DeployEvent,
-  DeployState
->(
-  {
-    predictableActionArguments: true,
-    context: {},
-    initial: "idle",
-    id: "root",
-    states: {
-      idle: {
-        on: {
-          START: { target: "running" },
-        },
-      },
-      running: {
-        invoke: {
-          id: "pty",
-          src: "runTerraformInPty",
-        },
-        on: {
-          EXITED: "exited",
-          STOP: ".stopping", // wait for terraform to exit, don't stop immediately (see the "stopping" state)
-        },
-        initial: "processing",
-        states: {
-          // TODO: what else might TF CLI be asking? Can we detect any question from the TF CLI to show a good error?
-          processing: {
-            on: {
-              REQUEST_APPROVAL: "awaiting_approval",
-              REQUEST_SENTINEL_OVERRIDE: "awaiting_sentinel_override",
-              VARIABLE_MISSING: {
-                actions: send({ type: "EXITED", exitCode: 1 }),
-              },
-            },
-          },
-          awaiting_approval: {
-            on: {
-              APPROVED_EXTERNALLY: "processing",
-              REJECTED_EXTERNALLY: {
-                target: "#root.exited",
-                actions: assign<
-                  DeployContext,
-                  DeployEvent & { type: "REJECTED_EXTERNALLY" }
-                >({ cancelled: true }),
-              },
-              APPROVE: {
-                target: "processing",
-                actions: send(
-                  { type: "SEND_LINE", input: "yes" },
-                  { to: "pty" },
-                ),
-              },
-              REJECT: {
-                target: "processing",
-                actions: [
-                  send({ type: "SEND_LINE", input: "no" }, { to: "pty" }),
-                  assign<DeployContext, DeployEvent & { type: "REJECT" }>({
-                    cancelled: true,
-                  }),
-                ],
-              },
-            },
-          },
-          awaiting_sentinel_override: {
-            on: {
-              OVERRIDDEN_EXTERNALLY: "processing",
-              OVERRIDE_REJECTED_EXTERNALLY: {
-                target: "#root.exited",
-                actions: assign<
-                  DeployContext,
-                  DeployEvent & { type: "OVERRIDE_REJECTED_EXTERNALLY" }
-                >({ cancelled: true }),
-              },
-              // This is a bit of a hack, because the external discard message
-              // posted by Terraform UI is the same as during apply. So, we capture that
-              // and emit our own event to make it more specific.
-              REJECTED_EXTERNALLY: {
-                actions: send({ type: "OVERRIDE_REJECTED_EXTERNALLY" }),
-              },
-              OVERRIDE: {
-                target: "processing",
-                actions: send(
-                  { type: "SEND_LINE", input: "override" },
-                  { to: "pty" },
-                ),
-              },
-              REJECT_OVERRIDE: {
-                target: "processing",
-                actions: [
-                  send({ type: "SEND_LINE", input: "no" }, { to: "pty" }),
-                  assign<
-                    DeployContext,
-                    DeployEvent & { type: "REJECT_OVERRIDE" }
-                  >({
-                    cancelled: true,
-                  }),
-                ],
-              },
-            },
-          },
-          // On STOP, wait for terraform's own EXITED before reaching the final "stopped" state, so the run only
-          // resolves once it has exited and released its lock. Don't re-signal it — it already got the interrupt via
-          // the process group, and a second signal aborts its graceful shutdown.
-          stopping: {
-            entry: assign<DeployContext, DeployEvent>({ cancelled: true }),
-            on: {
-              EXITED: "#root.stopped",
-            },
-          },
-        },
-      },
-      exited: { type: "final" },
-      stopped: { type: "final" },
-    },
-  },
-  {
-    services: {
-      runTerraformInPty: (context, event) =>
-        terraformPtyService(context, event, spawnInteractive),
-    },
-  },
-);
-
-export function terraformPtyService(
-  _context: DeployContext,
-  event: DeployEvent,
-  spawn = spawnInteractive,
-): (send: Sender<DeployEvent>, onReceive: Receiver<DeployEvent>) => void {
-  return (send: Sender<DeployEvent>, onReceive: Receiver<DeployEvent>) => {
-    if (event.type !== "START") {
-      throw Errors.Internal(
-        `Terraform CLI invocation state machine: Unexpected event caused transition to the running state: ${event.type}`,
-      );
-    }
-
-    // Communication from the pty to the caller
-    const receiver = bufferUnterminatedLines(handleLineReceived(send));
-    const { exitCode, actions } = spawn(event.pty, (data) => {
-      receiver(data);
-    });
-
-    // Communication from the caller to the pty
-    onReceive((event: DeployEvent) => {
-      if (event.type === "SEND_LINE") {
-        actions.writeLine(event.input);
-      }
-    });
-
-    exitCode.then((exitCode) => {
-      const lastBuffer = receiver.getBuffer();
-      if (lastBuffer.length > 0) {
-        logger.debug(
-          `Terraform CLI exited but the last outputted line was not terminated with a newline and hence is still in the buffer and wasn't printed: "${lastBuffer}"`,
-        );
-      }
-
-      send({ type: "EXITED", exitCode });
-    });
-
-    return () => {
-      logger.trace("Terraform CLI state machine: cleaning up pty");
-      actions.stop();
-    };
-  };
+/**
+ * Input passed to the invoked pty actor, carrying the spawn config from the START event.
+ */
+export interface PtyActorInput {
+  pty: InteractiveSpawnConfig;
 }
 
-export function createAndStartDeployService(options: {
-  refreshOnly?: boolean;
-  parallelism: number;
-  extraOptions: string[];
-  terraformBinaryName: string;
-  autoApprove?: boolean;
-  noColor?: boolean;
-  workdir: string;
-  vars?: string[];
-  varFiles?: string[];
-}) {
-  const service = interpret(deployMachine);
+/**
+ * Builds the invoked actor that runs terraform in a pty. It relays completed lines back to the parent machine via
+ * `sendBack` and forwards SEND_LINE events from the parent to the pty via `receive`. The `spawn` function is a
+ * parameter so tests can inject a mock pty.
+ */
+export function makeTerraformPtyService(spawn = spawnInteractive) {
+  return fromCallback<DeployEvent, PtyActorInput>(
+    ({ sendBack, receive, input }) => {
+      const { pty } = input;
+
+      // Communication from the pty to the caller
+      const receiver = bufferUnterminatedLines(handleLineReceived(sendBack));
+      const { exitCode, actions } = spawn(pty, (data) => {
+        receiver(data);
+      });
+
+      // Communication from the caller to the pty
+      receive((event) => {
+        if (event.type === "SEND_LINE") {
+          actions.writeLine(event.input);
+        }
+      });
+
+      exitCode.then((exitCode) => {
+        const lastBuffer = receiver.getBuffer();
+        if (lastBuffer.length > 0) {
+          logger.debug(
+            `Terraform CLI exited but the last outputted line was not terminated with a newline and hence is still in the buffer and wasn't printed: "${lastBuffer}"`,
+          );
+        }
+
+        sendBack({ type: "EXITED", exitCode });
+      });
+
+      return () => {
+        logger.trace("Terraform CLI state machine: cleaning up pty");
+        actions.stop();
+      };
+    },
+  );
+}
+
+export const terraformPtyService = makeTerraformPtyService();
+
+export const deployMachine = setup({
+  types: {
+    context: {} as DeployContext,
+    events: {} as DeployEvent,
+  },
+  actors: {
+    runTerraformInPty: terraformPtyService,
+  },
+}).createMachine({
+  context: {},
+  initial: "idle",
+  id: "root",
+  states: {
+    idle: {
+      on: {
+        START: { target: "running" },
+      },
+    },
+    running: {
+      invoke: {
+        id: "pty",
+        src: "runTerraformInPty",
+        input: ({ event }) => {
+          if (event.type !== "START") {
+            throw Errors.Internal(
+              `Terraform CLI invocation state machine: Unexpected event caused transition to the running state: ${event.type}`,
+            );
+          }
+          return { pty: event.pty };
+        },
+      },
+      on: {
+        EXITED: "exited",
+        STOP: ".stopping", // wait for terraform to exit, don't stop immediately (see the "stopping" state)
+      },
+      initial: "processing",
+      states: {
+        // TODO: what else might TF CLI be asking? Can we detect any question from the TF CLI to show a good error?
+        processing: {
+          on: {
+            REQUEST_APPROVAL: "awaiting_approval",
+            REQUEST_SENTINEL_OVERRIDE: "awaiting_sentinel_override",
+            VARIABLE_MISSING: {
+              // Send to self rather than raise() so consumers observing the actor via inspection still see this event.
+              actions: sendTo(({ self }) => self, {
+                type: "EXITED",
+                exitCode: 1,
+              }),
+            },
+          },
+        },
+        awaiting_approval: {
+          on: {
+            APPROVED_EXTERNALLY: "processing",
+            REJECTED_EXTERNALLY: {
+              target: "#root.exited",
+              actions: assign({ cancelled: true }),
+            },
+            APPROVE: {
+              target: "processing",
+              actions: sendTo("pty", { type: "SEND_LINE", input: "yes" }),
+            },
+            REJECT: {
+              target: "processing",
+              actions: [
+                sendTo("pty", { type: "SEND_LINE", input: "no" }),
+                assign({ cancelled: true }),
+              ],
+            },
+          },
+        },
+        awaiting_sentinel_override: {
+          on: {
+            OVERRIDDEN_EXTERNALLY: "processing",
+            OVERRIDE_REJECTED_EXTERNALLY: {
+              target: "#root.exited",
+              actions: assign({ cancelled: true }),
+            },
+            // The external discard message posted by the Terraform UI is the same as during apply, so we capture it
+            // and re-send a more specific event. Sent to self rather than raise() so consumers observing the actor
+            // via inspection still see it.
+            REJECTED_EXTERNALLY: {
+              actions: sendTo(({ self }) => self, {
+                type: "OVERRIDE_REJECTED_EXTERNALLY",
+              }),
+            },
+            OVERRIDE: {
+              target: "processing",
+              actions: sendTo("pty", { type: "SEND_LINE", input: "override" }),
+            },
+            REJECT_OVERRIDE: {
+              target: "processing",
+              actions: [
+                sendTo("pty", { type: "SEND_LINE", input: "no" }),
+                assign({ cancelled: true }),
+              ],
+            },
+          },
+        },
+        // On STOP, wait for terraform's own EXITED before reaching the final "stopped" state, so the run only
+        // resolves once it has exited and released its lock. Don't re-signal it — it already got the interrupt via
+        // the process group, and a second signal aborts its graceful shutdown.
+        stopping: {
+          entry: assign({ cancelled: true }),
+          on: {
+            EXITED: "#root.stopped",
+          },
+        },
+      },
+    },
+    exited: { type: "final" },
+    stopped: { type: "final" },
+  },
+});
+
+/**
+ * Callback invoked for every inspection event on the deploy actor. Consumers use it to observe both the events
+ * flowing through the machine and each resulting snapshot.
+ */
+export type DeployInspectionHandler = (
+  inspectionEvent: InspectionEvent,
+) => void;
+
+export function createAndStartDeployService(
+  options: {
+    refreshOnly?: boolean;
+    parallelism: number;
+    extraOptions: string[];
+    terraformBinaryName: string;
+    autoApprove?: boolean;
+    noColor?: boolean;
+    workdir: string;
+    vars?: string[];
+    varFiles?: string[];
+  },
+  inspect?: DeployInspectionHandler,
+) {
+  const service = createActor(deployMachine, { inspect });
   const args = [
     "apply",
     ...(options.autoApprove ? ["-auto-approve"] : []),
@@ -427,22 +402,26 @@ export function createAndStartDeployService(options: {
     },
   };
 
+  service.start();
   service.send({ type: "START", pty: config });
 
   return service;
 }
 
-export function createAndStartDestroyService(options: {
-  parallelism: number;
-  extraOptions: string[];
-  terraformBinaryName: string;
-  autoApprove?: boolean;
-  noColor?: boolean;
-  workdir: string;
-  vars?: string[];
-  varFiles?: string[];
-}) {
-  const service = interpret(deployMachine);
+export function createAndStartDestroyService(
+  options: {
+    parallelism: number;
+    extraOptions: string[];
+    terraformBinaryName: string;
+    autoApprove?: boolean;
+    noColor?: boolean;
+    workdir: string;
+    vars?: string[];
+    varFiles?: string[];
+  },
+  inspect?: DeployInspectionHandler,
+) {
+  const service = createActor(deployMachine, { inspect });
 
   const args = [
     "destroy",
@@ -479,6 +458,7 @@ export function createAndStartDestroyService(options: {
     },
   };
 
+  service.start();
   service.send({ type: "START", pty: config });
 
   return service;

--- a/packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/deploy-machine.ts
@@ -9,8 +9,10 @@ import {
   sendTo,
   fromCallback,
   assign,
+  ActorRefFrom,
   EventObject,
   InspectionEvent,
+  SnapshotFrom,
 } from "xstate";
 import { Errors, logger } from "@cdktn/commons";
 import { missingVariable } from "../errors";
@@ -232,6 +234,7 @@ export const deployMachine = setup({
   types: {
     context: {} as DeployContext,
     events: {} as DeployEvent,
+    output: {} as { exitCode?: number },
   },
   actors: {
     runTerraformInPty: terraformPtyService,
@@ -260,7 +263,10 @@ export const deployMachine = setup({
         },
       },
       on: {
-        EXITED: "exited",
+        EXITED: {
+          target: "exited",
+          actions: assign(({ event }) => ({ exitCode: event.exitCode })),
+        },
         STOP: ".stopping", // wait for terraform to exit, don't stop immediately (see the "stopping" state)
       },
       initial: "processing",
@@ -333,7 +339,10 @@ export const deployMachine = setup({
         stopping: {
           entry: assign({ cancelled: true }),
           on: {
-            EXITED: "#root.stopped",
+            EXITED: {
+              target: "#root.stopped",
+              actions: assign(({ event }) => ({ exitCode: event.exitCode })),
+            },
           },
         },
       },
@@ -341,7 +350,20 @@ export const deployMachine = setup({
     exited: { type: "final" },
     stopped: { type: "final" },
   },
+  // The machine's output is produced when it reaches a top-level final state (exited/stopped), carrying the
+  // terraform exit code captured into context on the EXITED transition.
+  output: ({ context }) => ({ exitCode: context.exitCode }),
 });
+
+/**
+ * A snapshot of the deploy machine, carrying the current state value and context.
+ */
+export type DeploySnapshot = SnapshotFrom<typeof deployMachine>;
+
+/**
+ * A running actor for the deploy machine, as returned by the createAndStart* factories.
+ */
+export type DeployActor = ActorRefFrom<typeof deployMachine>;
 
 /**
  * Callback invoked for every inspection event on the deploy actor. Consumers use it to observe both the events

--- a/packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts
@@ -19,7 +19,9 @@ import { SynthesizedStack } from "../synth-stack";
 import {
   createAndStartDeployService,
   createAndStartDestroyService,
+  DeployActor,
   DeployInspectionHandler,
+  DeploySnapshot,
   isDeployEvent,
 } from "./deploy-machine";
 import { waitFor } from "xstate";
@@ -348,16 +350,8 @@ export class TerraformCli implements Terraform {
   private async handleService(
     type: "deploy" | "destroy",
     callback: (state: TerraformDeployState) => void,
-    createService: (
-      inspect: DeployInspectionHandler,
-    ) =>
-      | ReturnType<typeof createAndStartDeployService>
-      | ReturnType<typeof createAndStartDestroyService>,
+    createService: (inspect: DeployInspectionHandler) => DeployActor,
   ): Promise<{ cancelled: boolean }> {
-    // Snapshots don't carry the triggering event, so remember the last EXITED exit code (seen via inspection) to
-    // decide whether the run failed once the machine reaches a final state.
-    let exitCode: number | undefined;
-
     // Events reach us through inspection, which fires for the whole actor tree. Filter to the root deploy actor
     // (its sessionId equals the tree's rootId) so we don't react to the invoked pty child's own events. Comparing
     // sessionId rather than the actor ref keeps this self-contained: inspection fires during startup, before the
@@ -374,8 +368,7 @@ export class TerraformCli implements Terraform {
       logger.trace(
         `Terraform CLI state machine event: ${JSON.stringify(event)}`,
       );
-      if (isDeployEvent(event, "EXITED")) exitCode = event.exitCode;
-      else if (isDeployEvent(event, "OUTPUT_RECEIVED"))
+      if (isDeployEvent(event, "OUTPUT_RECEIVED"))
         this.onStdout(type)(event.output);
       else if (isDeployEvent(event, "APPROVED_EXTERNALLY"))
         callback({ type: "external approval reply", approved: true });
@@ -396,8 +389,8 @@ export class TerraformCli implements Terraform {
     const service = createService(inspect);
 
     // Transitions come from the actor's own subscription, which yields typed snapshots for the root actor only.
-    let previousState: ReturnType<typeof service.getSnapshot>["value"] = "idle";
-    service.subscribe((snapshot) => {
+    let previousState: DeploySnapshot["value"] = "idle";
+    const handleSnapshot = (snapshot: DeploySnapshot) => {
       // Only send updates on actual state change; a snapshot is emitted even when only an event happened.
       if (snapshot.matches(previousState)) return;
 
@@ -426,7 +419,10 @@ export class TerraformCli implements Terraform {
         });
       }
       previousState = snapshot.value;
-    });
+    };
+
+    service.subscribe(handleSnapshot);
+    handleSnapshot(service.getSnapshot());
 
     // stop terraform apply if signaled as such from the outside (e.g. via ctrl+c)
     this.abortSignal.addEventListener(
@@ -444,6 +440,9 @@ export class TerraformCli implements Terraform {
         timeout: Infinity,
       },
     );
+
+    // The final state produces the terraform exit code as the machine's output.
+    const exitCode = snapshot.output?.exitCode;
 
     logger.trace(
       `Invoking Terraform CLI for ${type} done (state machine reached final state). Last exit code: ${JSON.stringify(

--- a/packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts
@@ -19,10 +19,10 @@ import { SynthesizedStack } from "../synth-stack";
 import {
   createAndStartDeployService,
   createAndStartDestroyService,
-  DeployState,
+  DeployInspectionHandler,
   isDeployEvent,
 } from "./deploy-machine";
-import { waitFor } from "xstate/lib/waitFor";
+import { waitFor } from "xstate";
 import { missingVariable } from "../errors";
 import { terraformJsonSchema } from "../terraform-json";
 import { spawnInteractive } from "./interactive-process";
@@ -298,18 +298,22 @@ export class TerraformCli implements Terraform {
     callback: (state: TerraformDeployState) => void,
   ): Promise<{ cancelled: boolean }> {
     await this.setUserAgent();
-    const service = createAndStartDeployService({
-      terraformBinaryName,
-      workdir: this.workdir,
-      refreshOnly,
-      noColor,
-      autoApprove,
-      parallelism,
-      extraOptions,
-      vars,
-      varFiles,
-    });
-    return this.handleService("deploy", service, callback);
+    return this.handleService("deploy", callback, (inspect) =>
+      createAndStartDeployService(
+        {
+          terraformBinaryName,
+          workdir: this.workdir,
+          refreshOnly,
+          noColor,
+          autoApprove,
+          parallelism,
+          extraOptions,
+          vars,
+          varFiles,
+        },
+        inspect,
+      ),
+    );
   }
 
   public async destroy(
@@ -324,41 +328,54 @@ export class TerraformCli implements Terraform {
     callback: (state: TerraformDeployState) => void,
   ): Promise<{ cancelled: boolean }> {
     await this.setUserAgent();
-    const service = createAndStartDestroyService({
-      terraformBinaryName,
-      workdir: this.workdir,
-      autoApprove,
-      parallelism,
-      noColor,
-      extraOptions,
-      vars,
-      varFiles,
-    });
-    return this.handleService("destroy", service, callback);
+    return this.handleService("destroy", callback, (inspect) =>
+      createAndStartDestroyService(
+        {
+          terraformBinaryName,
+          workdir: this.workdir,
+          autoApprove,
+          parallelism,
+          noColor,
+          extraOptions,
+          vars,
+          varFiles,
+        },
+        inspect,
+      ),
+    );
   }
 
   private async handleService(
     type: "deploy" | "destroy",
-    service:
+    callback: (state: TerraformDeployState) => void,
+    createService: (
+      inspect: DeployInspectionHandler,
+    ) =>
       | ReturnType<typeof createAndStartDeployService>
       | ReturnType<typeof createAndStartDestroyService>,
-    callback: (state: TerraformDeployState) => void,
   ): Promise<{ cancelled: boolean }> {
-    // stop terraform apply if signaled as such from the outside (e.g. via ctrl+c)
-    this.abortSignal.addEventListener(
-      "abort",
-      () => {
-        service.send("STOP");
-      },
-      { once: true },
-    );
+    // Snapshots don't carry the triggering event, so remember the last EXITED exit code (seen via inspection) to
+    // decide whether the run failed once the machine reaches a final state.
+    let exitCode: number | undefined;
 
-    // relay logs to stdout
-    service.onEvent((event) => {
+    // Events reach us through inspection, which fires for the whole actor tree. Filter to the root deploy actor
+    // (its sessionId equals the tree's rootId) so we don't react to the invoked pty child's own events. Comparing
+    // sessionId rather than the actor ref keeps this self-contained: inspection fires during startup, before the
+    // `service` binding below is initialized.
+    const inspect: DeployInspectionHandler = (inspectionEvent) => {
+      if (
+        inspectionEvent.type !== "@xstate.event" ||
+        inspectionEvent.actorRef.sessionId !== inspectionEvent.rootId
+      ) {
+        return;
+      }
+
+      const event = inspectionEvent.event;
       logger.trace(
         `Terraform CLI state machine event: ${JSON.stringify(event)}`,
       );
-      if (isDeployEvent(event, "OUTPUT_RECEIVED"))
+      if (isDeployEvent(event, "EXITED")) exitCode = event.exitCode;
+      else if (isDeployEvent(event, "OUTPUT_RECEIVED"))
         this.onStdout(type)(event.output);
       else if (isDeployEvent(event, "APPROVED_EXTERNALLY"))
         callback({ type: "external approval reply", approved: true });
@@ -374,62 +391,75 @@ export class TerraformCli implements Terraform {
           type: "external sentinel override reply",
           overridden: false,
         });
-    });
+    };
 
-    let previousState: DeployState["value"] = "idle";
+    const service = createService(inspect);
 
-    service.onTransition((state) => {
-      // only send updates on actual state change
-      // onTransition is called even if the state didn't change but only an event happened
-      if (state.matches(previousState as DeployState["value"])) return;
+    // Transitions come from the actor's own subscription, which yields typed snapshots for the root actor only.
+    let previousState: ReturnType<typeof service.getSnapshot>["value"] = "idle";
+    service.subscribe((snapshot) => {
+      // Only send updates on actual state change; a snapshot is emitted even when only an event happened.
+      if (snapshot.matches(previousState)) return;
 
       logger.trace(
         `Terraform CLI state machine state transition: ${JSON.stringify(
           previousState,
-        )} => ${JSON.stringify(state.value)}`,
+        )} => ${JSON.stringify(snapshot.value)}`,
       );
 
-      if (state.matches({ running: "awaiting_approval" })) {
+      if (snapshot.matches({ running: "awaiting_approval" })) {
         callback({
           type: "waiting for approval",
-          approve: () => service.send("APPROVE"),
-          reject: () => service.send("REJECT"),
+          approve: () => service.send({ type: "APPROVE" }),
+          reject: () => service.send({ type: "REJECT" }),
         });
-      } else if (state.matches({ running: "awaiting_sentinel_override" })) {
+      } else if (snapshot.matches({ running: "awaiting_sentinel_override" })) {
         callback({
           type: "waiting for sentinel override",
-          override: () => service.send("OVERRIDE"),
-          reject: () => service.send("REJECT_OVERRIDE"),
+          override: () => service.send({ type: "OVERRIDE" }),
+          reject: () => service.send({ type: "REJECT_OVERRIDE" }),
         });
-      } else if (state.matches({ running: "processing" })) {
+      } else if (snapshot.matches({ running: "processing" })) {
         callback({
           type: "running",
-          cancelled: Boolean(state.context.cancelled),
+          cancelled: Boolean(snapshot.context.cancelled),
         });
       }
-      previousState = state.value as DeployState["value"];
-    });
-    service.start();
-    const state = await waitFor(service, (state) => !!state.done, {
-      timeout: Infinity,
+      previousState = snapshot.value;
     });
 
-    logger.trace(
-      `Invoking Terraform CLI for ${type} done (state machine reached final state). Last event: ${JSON.stringify(
-        state.event,
-      )}. Context: ${JSON.stringify(state.context)}`,
+    // stop terraform apply if signaled as such from the outside (e.g. via ctrl+c)
+    this.abortSignal.addEventListener(
+      "abort",
+      () => {
+        service.send({ type: "STOP" });
+      },
+      { once: true },
     );
 
-    // example events: { type: 'EXITED', exitCode: 0 }, { type: 'EXTERNAL_REJECT' }
+    const snapshot = await waitFor(
+      service,
+      (snapshot) => snapshot.status === "done",
+      {
+        timeout: Infinity,
+      },
+    );
+
+    logger.trace(
+      `Invoking Terraform CLI for ${type} done (state machine reached final state). Last exit code: ${JSON.stringify(
+        exitCode,
+      )}. Context: ${JSON.stringify(snapshot.context)}`,
+    );
+
     if (
-      state.event.type === "EXITED" &&
-      state.event.exitCode !== 0 &&
-      !state.context.cancelled // don't fail if we cancelled the run
+      exitCode !== undefined &&
+      exitCode !== 0 &&
+      !snapshot.context.cancelled // don't fail if we cancelled the run
     ) {
-      throw `Invoking Terraform CLI failed with exit code ${state.event.exitCode}`;
+      throw `Invoking Terraform CLI failed with exit code ${exitCode}`;
     }
 
-    return { cancelled: Boolean(state.context.cancelled) };
+    return { cancelled: Boolean(snapshot.context.cancelled) };
   }
 
   public async version(): Promise<string> {

--- a/packages/@cdktn/cli-core/src/test/models/deploy-machine.test.ts
+++ b/packages/@cdktn/cli-core/src/test/models/deploy-machine.test.ts
@@ -3,12 +3,14 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { interpret } from "xstate";
+import { createActor, fromCallback, getNextSnapshot } from "xstate";
 import { spawnInteractive } from "../../lib/models/interactive-process";
 import {
   deployMachine,
+  DeployEvent,
+  PtyActorInput,
   extractVariableNameFromPrompt,
-  terraformPtyService,
+  makeTerraformPtyService,
   handleLineReceived,
   bufferUnterminatedLines,
 } from "../../lib/models/deploy-machine";
@@ -46,30 +48,52 @@ describe("extractVariableNameFromPrompt", () => {
 
 describe("transitions", () => {
   it("reaches the running state after initial", async () => {
-    const actualState = deployMachine.transition("idle", "START");
+    const initialSnapshot = deployMachine.resolveState({
+      value: "idle",
+      context: {},
+    });
+    const actualState = getNextSnapshot(deployMachine, initialSnapshot, {
+      type: "START",
+      pty: { file: "", args: [], options: { cwd: "" } },
+    });
 
     expect(actualState.matches("running")).toBe(true);
   });
 
   it("transitions to processing upon external approval", (done) => {
-    const mockDeployMachine = deployMachine.withConfig({
-      services: {
-        runTerraformInPty: () => (send) => {
-          setTimeout(() => {
-            send({ type: "REQUEST_APPROVAL" });
-
+    const mockDeployMachine = deployMachine.provide({
+      actors: {
+        runTerraformInPty: fromCallback<DeployEvent, PtyActorInput>(
+          ({ sendBack }) => {
             setTimeout(() => {
-              send({ type: "APPROVED_EXTERNALLY" });
+              sendBack({ type: "REQUEST_APPROVAL" });
+
+              setTimeout(() => {
+                sendBack({ type: "APPROVED_EXTERNALLY" });
+              }, 100);
             }, 100);
-          }, 100);
-        },
+          },
+        ),
       },
     });
 
-    const ptyService = interpret(mockDeployMachine).onTransition((state) => {
+    // Observe events via inspection to assert the transition was caused by APPROVED_EXTERNALLY.
+    let lastEvent: string | undefined;
+    const ptyService = createActor(mockDeployMachine, {
+      inspect: (inspectionEvent) => {
+        if (
+          inspectionEvent.type === "@xstate.event" &&
+          inspectionEvent.actorRef === ptyService
+        ) {
+          lastEvent = inspectionEvent.event.type;
+        }
+      },
+    });
+
+    ptyService.subscribe((state) => {
       if (
         state.matches({ running: "processing" }) &&
-        state.event?.type === "APPROVED_EXTERNALLY"
+        lastEvent === "APPROVED_EXTERNALLY"
       ) {
         done();
       }
@@ -121,18 +145,16 @@ function mockPty(ptyEvents: string[]): typeof spawnInteractive {
 describe("pty events", () => {
   it("transitions when pty receives an approval question", (done) => {
     let isDone = false;
-    const mockDeployMachine = deployMachine.withConfig({
-      services: {
-        runTerraformInPty: (context, event) =>
-          terraformPtyService(
-            context,
-            event,
-            mockPty([`Do you want to perform these actions\nEnter a value:`]),
-          ),
+    const mockDeployMachine = deployMachine.provide({
+      actors: {
+        runTerraformInPty: makeTerraformPtyService(
+          mockPty([`Do you want to perform these actions\nEnter a value:`]),
+        ),
       },
     });
 
-    const ptyService = interpret(mockDeployMachine).onTransition((state) => {
+    const ptyService = createActor(mockDeployMachine);
+    ptyService.subscribe((state) => {
       if (state.matches({ running: "awaiting_approval" }) && !isDone) {
         isDone = true;
         done();
@@ -155,21 +177,16 @@ describe("pty events", () => {
 
   it("transitions when pty receives an approval question that is split across two buffers", (done) => {
     let isDone = false;
-    const mockDeployMachine = deployMachine.withConfig({
-      services: {
-        runTerraformInPty: (context, event) =>
-          terraformPtyService(
-            context,
-            event,
-            mockPty([
-              `Do you want to per`,
-              `form these actions\nEnter a value:`,
-            ]),
-          ),
+    const mockDeployMachine = deployMachine.provide({
+      actors: {
+        runTerraformInPty: makeTerraformPtyService(
+          mockPty([`Do you want to per`, `form these actions\nEnter a value:`]),
+        ),
       },
     });
 
-    const ptyService = interpret(mockDeployMachine).onTransition((state) => {
+    const ptyService = createActor(mockDeployMachine);
+    ptyService.subscribe((state) => {
       if (state.matches({ running: "awaiting_approval" }) && !isDone) {
         isDone = true;
         done();
@@ -191,23 +208,21 @@ describe("pty events", () => {
   });
 
   it("transitions when pty receives an override question", (done) => {
-    const mockDeployMachine = deployMachine.withConfig({
-      services: {
-        runTerraformInPty: (context, event) =>
-          terraformPtyService(
-            context,
-            event,
-            mockPty([
-              `Do you want to override the soft failed policy check?
+    const mockDeployMachine = deployMachine.provide({
+      actors: {
+        runTerraformInPty: makeTerraformPtyService(
+          mockPty([
+            `Do you want to override the soft failed policy check?
           Only 'override' will be accepted to override.
-          
+
           Enter a value:`,
-            ]),
-          ),
+          ]),
+        ),
       },
     });
 
-    const ptyService = interpret(mockDeployMachine).onTransition((state) => {
+    const ptyService = createActor(mockDeployMachine);
+    ptyService.subscribe((state) => {
       if (state.matches({ running: "awaiting_sentinel_override" })) {
         done();
       }
@@ -239,15 +254,15 @@ describe("pty events", () => {
       }),
     });
 
-    const mockDeployMachine = deployMachine.withConfig({
-      services: {
-        runTerraformInPty: (context, event) =>
-          terraformPtyService(context, event, controllablePty),
+    const mockDeployMachine = deployMachine.provide({
+      actors: {
+        runTerraformInPty: makeTerraformPtyService(controllablePty),
       },
     });
 
     let interrupted = false;
-    const ptyService = interpret(mockDeployMachine).onTransition((state) => {
+    const ptyService = createActor(mockDeployMachine);
+    ptyService.subscribe((state) => {
       if (state.matches({ running: "stopping" }) && !interrupted) {
         interrupted = true;
         // We are waiting for terraform to exit, not yet at the final "stopped" state, and we have not re-signalled it.
@@ -274,28 +289,35 @@ describe("pty events", () => {
   });
 
   it("transitions to rejected state when done externally", (done) => {
-    const mockDeployMachine = deployMachine.withConfig({
-      services: {
-        runTerraformInPty: (context, event) =>
-          terraformPtyService(
-            context,
-            event,
-            mockPty([
-              `Do you want to override the soft failed policy check?
+    const mockDeployMachine = deployMachine.provide({
+      actors: {
+        runTerraformInPty: makeTerraformPtyService(
+          mockPty([
+            `Do you want to override the soft failed policy check?
           Only 'override' will be accepted to override.
-          
+
           Enter a value:`,
-              `discarded using the UI or API\n`,
-            ]),
-          ),
+            `discarded using the UI or API\n`,
+          ]),
+        ),
       },
     });
 
+    // Record events seen by the machine via inspection.
     let enteredAwaiting = false;
     const states: string[] = [];
-    const ptyService = interpret(mockDeployMachine).onTransition((state) => {
-      if (state.event?.type) states.push(state.event.type);
+    const ptyService = createActor(mockDeployMachine, {
+      inspect: (inspectionEvent) => {
+        if (
+          inspectionEvent.type === "@xstate.event" &&
+          inspectionEvent.actorRef === ptyService
+        ) {
+          states.push(inspectionEvent.event.type);
+        }
+      },
+    });
 
+    ptyService.subscribe((state) => {
       if (enteredAwaiting && state.matches("exited")) {
         expect(states).toEqual(
           expect.arrayContaining(["OVERRIDE_REJECTED_EXTERNALLY"]),

--- a/packages/@cdktn/cli-core/src/test/models/terraform-cli.test.ts
+++ b/packages/@cdktn/cli-core/src/test/models/terraform-cli.test.ts
@@ -1,8 +1,70 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { TerraformCliPlan } from "../../lib/models/terraform-cli";
+import { TerraformCli, TerraformCliPlan } from "../../lib/models/terraform-cli";
+import { spawnInteractive } from "../../lib/models/interactive-process";
+import { SynthesizedStack } from "../../lib/synth-stack";
+import { TerraformDeployState } from "../../lib/models/terraform";
+
+jest.mock("../../lib/models/interactive-process");
+
+// A pty that emits nothing and exits with the given code. Useful for exercising the state machine's lifecycle
+// without a real terraform process.
+function silentPty(exitCode: number): typeof spawnInteractive {
+  return () => ({
+    actions: { write: jest.fn(), writeLine: jest.fn(), stop: jest.fn() },
+    exitCode: Promise.resolve(exitCode),
+  });
+}
+
+function makeCli(): TerraformCli {
+  const stack: SynthesizedStack = {
+    name: "test",
+    constructPath: "test",
+    synthesizedStackPath: "",
+    stackMetadataPath: "",
+    workingDirectory: process.cwd(),
+    annotations: [],
+    dependencies: [],
+    content: "{}",
+  };
+  const cli = new TerraformCli(new AbortController().signal, stack);
+  // Avoid the network call setUserAgent() makes before spawning.
+  jest.spyOn(cli, "setUserAgent").mockResolvedValue();
+  return cli;
+}
 
 describe("terraform-cli", () => {
+  describe("deploy", () => {
+    it("reports running even when the process exits immediately", async () => {
+      // Regression guard: the actor starts and receives START before handleService subscribes, so the initial
+      // idle -> running transition must be replayed from the current snapshot. A silent, immediately-exiting
+      // process has no later output to mask a missed callback.
+      jest.mocked(spawnInteractive).mockImplementation(silentPty(0));
+
+      const states: TerraformDeployState["type"][] = [];
+      await makeCli().deploy({}, (state) => states.push(state.type));
+
+      expect(states).toEqual(["running"]);
+    });
+
+    it("resolves without cancellation on a zero exit code", async () => {
+      jest.mocked(spawnInteractive).mockImplementation(silentPty(0));
+
+      await expect(makeCli().deploy({}, () => {})).resolves.toEqual({
+        cancelled: false,
+      });
+    });
+
+    it("rejects with the exit code on a non-zero exit", async () => {
+      // The exit code is produced as the machine's final-state output and read off the settled snapshot.
+      jest.mocked(spawnInteractive).mockImplementation(silentPty(3));
+
+      await expect(makeCli().deploy({}, () => {})).rejects.toMatch(
+        /exit code 3/,
+      );
+    });
+  });
+
   describe("TerraformCliPlan", () => {
     it("#needsApply is false with no changes", () => {
       const plan = new TerraformCliPlan("./myplan", {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1048,8 +1048,8 @@ importers:
         specifier: 1.6.11
         version: 1.6.11
       xstate:
-        specifier: 4.38.3
-        version: 4.38.3
+        specifier: 5.32.4
+        version: 5.32.4
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -7692,8 +7692,8 @@ packages:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
 
-  xstate@4.38.3:
-    resolution: {integrity: sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==}
+  xstate@5.32.4:
+    resolution: {integrity: sha512-E5WtDB8DBs2ZWliz2Ry9XfbSZTbBRcK/cwefBot04qQ/L5SLP16xpnTDU4/ZFXuXFhNxi7JP2RhuoGwBnM+S4A==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -15338,7 +15338,7 @@ snapshots:
 
   xmlbuilder@15.1.1: {}
 
-  xstate@4.38.3: {}
+  xstate@5.32.4: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
### Description

Bumps `xstate` from `4.38.3` to `5.32.4` (latest) in `@cdktn/cli-core`, the only package that declares it.

This is a major version bump (4.x → 5.x) and required migrating the deploy state machine, its consumer, and its tests to the reworked v5 API.

#### State machine (`deploy-machine.ts`)

- **`createMachine<Ctx, Evt, State>(…)` → `setup({ types, actors }).createMachine(…)`.** The generic-parameter form was replaced by the `setup()` builder with a `types` block. The `predictableActionArguments` flag was dropped (predictable ordering is the default in v5) and `services` became `actors`.
- **Invoked callback service → `fromCallback`.** The v4 `(context, event) => (send, onReceive) => {…}` factory became `fromCallback(({ sendBack, receive, input }) => …)`. Since v5 invoked actors receive `input` rather than the triggering event, the spawn config now flows in through `invoke.input`. The actor is built by `makeTerraformPtyService(spawn)` so tests can inject a mock pty.
- **`send(…, { to })` → `sendTo(…)`; `assign<Ctx, Evt>` → `assign`.** Action creators were split and the `assign` implementation signature changed to a single argument.
- **`raise(…)` → `sendTo(({ self }) => self, …)`.** The two internally re-emitted events (`EXITED` on a missing variable, and the `OVERRIDE_REJECTED_EXTERNALLY` re-label of an external discard) are sent to self rather than raised. Raised events are internal micro-steps and do not surface through the inspection API, so the consumer would otherwise stop observing them.
- **Exit code as final-state output.** The terraform exit code is captured into context on the `EXITED` transitions and surfaced through the machine's root `output`, so consumers read it off the settled snapshot rather than scraping it from an event. This also puts the previously-unused `DeployContext.exitCode` field to work.
- Named helper types `DeploySnapshot` (`SnapshotFrom<typeof deployMachine>`) and `DeployActor` (`ActorRefFrom<typeof deployMachine>`) are exported for the consumer.

#### Consumer (`terraform-cli.ts`)

This needed the most care, because v5 snapshots no longer expose the triggering event (`state.event`):

- **Transitions** come from the actor's own `service.subscribe(…)`, which yields a fully-typed snapshot for the root actor only — replacing `service.onTransition(…)`. Because the factory starts the actor and sends `START` before we subscribe, the current snapshot is processed once immediately after subscribing so the initial `idle → running` transition is not missed.
- **Events** come from the `inspect` callback (the only source that still carries the triggering event), replacing `service.onEvent(…)`. The root actor is identified by `actorRef.sessionId === rootId` — self-contained within the inspection event, so it works even while inspection fires during startup before the `service` binding is initialized. Events are narrowed through the existing `isDeployEvent` guard.
- **`interpret(…)` → `createActor(…, { inspect })`.** The actor is started explicitly before events are sent.
- `waitFor` is imported from `xstate` and its predicate uses `snapshot.status === "done"`; the exit code is read from `snapshot.output`; `service.send("X")` calls became `service.send({ type: "X" })`.

#### Tests

- `deploy-machine.test.ts` was migrated to match: `interpret().onTransition` → `createActor().subscribe`, `withConfig({ services })` → `provide({ actors })`, `machine.transition` → `getNextSnapshot`, and the `state.event` assertions rebuilt on the inspection API.
- A `deploy` suite was added to `terraform-cli.test.ts` covering the previously-untested `deploy()`/`handleService` path: `running` is reported even when the process exits immediately (the subscribe-ordering fix), a zero exit resolves without cancellation, and a non-zero exit rejects with the exit code (the final-state-output path).

`tsc --noEmit` passes cleanly on the package, and all 28 tests across `deploy-machine.test.ts` and `terraform-cli.test.ts` pass.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
