### PR TITLE
chore(deps)!: Require Node 22 minimum

### DIFF
--- a/.github/workflows/pnpm-upgrade.yml
+++ b/.github/workflows/pnpm-upgrade.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch: {}
 
 # We special-case @types/node because we want to stay on the current major (minimum supported node release)
-# We special-case @types/node further because of an incompatibility with https-proxy-agent
 # We special-case @types/fs-extra because the current major (9.x) is broken with @types/node >= 10
 # We special-case typescript because it's not semantically versioned
 # We special-case constructs because we want to stay in control of the minimum compatible version
@@ -52,7 +51,7 @@ jobs:
       - name: Run "ncu -u"
         run: |-
           # Upgrade dependencies at repository root
-          ncu --upgrade --filter=@types/fs-extra --target=minor --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+          ncu --upgrade --filter=@types/node,@types/fs-extra --target=minor --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
           ncu --upgrade --filter=typescript --target=patch --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
           ncu --upgrade --reject=@types/node,@types/fs-extra,constructs,typescript,@types/prettier --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
@@ -208,7 +207,7 @@ jobs:
           done
 
           ncu --upgrade "${workspace_args[@]}" --no-root \
-            --filter=@types/fs-extra --target=minor \
+            --filter=@types/node,@types/fs-extra --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
 
           ncu --upgrade "${workspace_args[@]}" --no-root \

--- a/examples/typescript/aws-cloudfront-proxy/package.json
+++ b/examples/typescript/aws-cloudfront-proxy/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/aws-import/package.json
+++ b/examples/typescript/aws-import/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/aws-kubernetes/package.json
+++ b/examples/typescript/aws-kubernetes/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/aws-move/package.json
+++ b/examples/typescript/aws-move/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/aws-multiple-stacks/package.json
+++ b/examples/typescript/aws-multiple-stacks/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "ts-node": "10.9.1",
     "typescript": "^5.0.0"
   },

--- a/examples/typescript/aws-prebuilt/package.json
+++ b/examples/typescript/aws-prebuilt/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/azure-app-service/package.json
+++ b/examples/typescript/azure-app-service/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/azure-service-bus-queue-trigger/package.json
+++ b/examples/typescript/azure-service-bus-queue-trigger/package.json
@@ -15,7 +15,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "@cdktn/provider-azurerm": "16.1.0",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "jest": "^30.3.0",
     "ts-jest": "29.4.9",
     "ts-node": "10.9.1",

--- a/examples/typescript/azure/package.json
+++ b/examples/typescript/azure/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/backends/azurerm/package.json
+++ b/examples/typescript/backends/azurerm/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/cloud/package.json
+++ b/examples/typescript/backends/cloud/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/gcs/package.json
+++ b/examples/typescript/backends/gcs/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/remote/package.json
+++ b/examples/typescript/backends/remote/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "^10.9.1",

--- a/examples/typescript/backends/s3/package.json
+++ b/examples/typescript/backends/s3/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "^10.9.1",

--- a/examples/typescript/docker/package.json
+++ b/examples/typescript/docker/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",
     "typescript": "^5.0.0"

--- a/examples/typescript/documentation/package.json
+++ b/examples/typescript/documentation/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "tsx": "4.6.1",

--- a/examples/typescript/google-cloudrun/package.json
+++ b/examples/typescript/google-cloudrun/package.json
@@ -19,7 +19,6 @@
     "node": ">=22.0"
   },
   "dependencies": {
-    "cdktf": "0.21.0",
     "cdktn": "workspace:*",
     "constructs": "10.6.0"
   },

--- a/examples/typescript/google-cloudrun/package.json
+++ b/examples/typescript/google-cloudrun/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktf": "0.21.0",
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/google/package.json
+++ b/examples/typescript/google/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/kubernetes/package.json
+++ b/examples/typescript/kubernetes/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/provisioner/package.json
+++ b/examples/typescript/provisioner/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",
     "typescript": "^5.0.0"

--- a/examples/typescript/ucloud/package.json
+++ b/examples/typescript/ucloud/package.json
@@ -16,7 +16,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/examples/typescript/vault/package.json
+++ b/examples/typescript/vault/package.json
@@ -19,7 +19,7 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   },
   "dependencies": {
     "cdktn": "workspace:*",
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "30.0.0",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "cdktn-cli": "workspace:*",
     "jest": "^30.3.0",
     "ts-node": "10.9.1",

--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -67,7 +67,7 @@
     "@cdktn/provider-generator": "workspace:*",
     "@types/cross-spawn": "6.0.6",
     "@types/fs-extra": "11.0.4",
-    "@types/node": "20.19.1",
+    "@types/node": "22.20.1",
     "@types/semver": "7.7.1",
     "nock": "^14.0.0",
     "prettier": "2.8.8",

--- a/packages/@cdktn/cli-core/templates/typescript/package.json
+++ b/packages/@cdktn/cli-core/templates/typescript/package.json
@@ -17,6 +17,6 @@
     "upgrade:next": "npm i cdktn@next cdktn-cli@next"
   },
   "engines": {
-    "node": ">=20.9"
+    "node": ">=22.0"
   }
 }

--- a/packages/@cdktn/hcl-tools/package.json
+++ b/packages/@cdktn/hcl-tools/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/@cdktn/hcl2cdk/package.json
+++ b/packages/@cdktn/hcl2cdk/package.json
@@ -58,7 +58,7 @@
     "@types/babel__template": "7.4.4",
     "@types/deep-equal": "1.0.4",
     "@types/fs-extra": "11.0.4",
-    "@types/node": "20.19.37",
+    "@types/node": "22.20.1",
     "@types/prettier": "2.7.3",
     "@types/reserved-words": "0.1.4",
     "execa": "5.1.1",

--- a/packages/@cdktn/hcl2cdk/test/convertProject.test.ts
+++ b/packages/@cdktn/hcl2cdk/test/convertProject.test.ts
@@ -80,7 +80,7 @@ app.synth();`,
           "upgrade:next": "npm i cdktn@next cdktn-cli@next"
         },
         "engines": {
-          "node": ">=20.9"
+          "node": ">=22.0"
         },
         "dependencies": {
           "cdktn": "latest",

--- a/packages/@cdktn/hcl2cdk/test/convertProject.test.ts
+++ b/packages/@cdktn/hcl2cdk/test/convertProject.test.ts
@@ -87,7 +87,7 @@ app.synth();`,
           "constructs": "^10.3.0"
         },
         "devDependencies": {
-          "@types/node": "^14.0.26",
+          "@types/node": "^22.20.1",
           "typescript": "^5.4.5",
           "cdktn-cli": "${CDKTF_CLI}"
         }

--- a/packages/@cdktn/hcl2json/package.json
+++ b/packages/@cdktn/hcl2json/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/node": "20.19.37",
+    "@types/node": "22.20.1",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/@cdktn/provider-generator/package.json
+++ b/packages/@cdktn/provider-generator/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
-    "@types/node": "20.19.37",
+    "@types/node": "22.20.1",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -43,7 +43,7 @@
     "bundle"
   ],
   "dependencies": {
-    "@types/node": "20.19.1",
+    "@types/node": "22.20.1",
     "@cdktn/hcl-tools": "workspace:*",
     "@cdktn/hcl2cdk": "workspace:*",
     "@cdktn/hcl2json": "workspace:*",

--- a/packages/cdktn-cli/src/bin/cmds/helper/check-environment.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/check-environment.ts
@@ -52,7 +52,7 @@ async function checkPythonVersion() {
 
 async function checkNodeVersion() {
   const out = await getNodeVersion();
-  throwIfLowerVersion("Node.js", "20.9.0", out);
+  throwIfLowerVersion("Node.js", "22.0.0", out);
 }
 
 export async function checkEnvironment() {

--- a/packages/cdktn/package.json
+++ b/packages/cdktn/package.json
@@ -77,7 +77,7 @@
     },
     "license": "MPL-2.0",
     "devDependencies": {
-        "@types/node": "18.19.130",
+        "@types/node": "22.20.1",
         "@types/semver": "7.7.1",
         "constructs": "10.6.0",
         "jsii": "~5.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,13 +215,13 @@ importers:
         version: 9.39.4
       '@nx/eslint':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/eslint-plugin':
         specifier: 22.7.5
         version: 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.4.5))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/jest':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@swc/core':
         specifier: ~1.15.5
         version: 1.15.40(@swc/helpers@0.5.21)
@@ -269,7 +269,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+        version: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       knip:
         specifier: ^6.16.1
         version: 6.16.1
@@ -1344,8 +1344,8 @@ importers:
         version: 7.7.4
     devDependencies:
       '@types/node':
-        specifier: 18.19.130
-        version: 18.19.130
+        specifier: 22.20.1
+        version: 22.20.1
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -3561,9 +3561,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@22.19.20':
-    resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
@@ -9031,7 +9028,7 @@ snapshots:
       '@inquirer/figures': 1.0.15
       '@inquirer/type': 2.0.0
       '@types/mute-stream': 0.0.4
-      '@types/node': 22.19.20
+      '@types/node': 22.20.1
       '@types/wrap-ansi': 3.0.0
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
@@ -9131,7 +9128,7 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
@@ -9145,49 +9142,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 18.19.130
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -9215,14 +9177,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -9254,7 +9216,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -9272,7 +9234,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -9290,12 +9252,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.3.0':
@@ -9306,7 +9268,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -9386,7 +9348,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9396,7 +9358,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9528,7 +9490,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/eslint@22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
@@ -9537,7 +9499,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -9548,7 +9510,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.3.0
       '@jest/test-result': 30.3.0
@@ -9556,7 +9518,7 @@ snapshots:
       '@nx/js': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.4.5)
       identity-obj-proxy: 3.0.0
-      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-resolve: 30.3.0
       jest-util: 30.3.0
       minimatch: 10.2.5
@@ -10053,7 +10015,7 @@ snapshots:
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -10074,7 +10036,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -10086,15 +10048,11 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
 
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@22.19.20':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.20.1':
     dependencies:
@@ -10135,7 +10093,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.4.5))(eslint@9.39.4(jiti@2.7.0))(typescript@5.4.5)':
@@ -12472,7 +12430,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
@@ -12492,15 +12450,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)):
+  jest-cli@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -12548,70 +12506,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-
-  jest-config@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0(babel-plugin-macros@3.1.0)
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.130
-      ts-node: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0(babel-plugin-macros@3.1.0)
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.130
-      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
@@ -12733,7 +12627,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -12741,7 +12635,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12780,7 +12674,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -12816,7 +12710,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -12845,7 +12739,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -12892,7 +12786,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -12911,7 +12805,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12920,18 +12814,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)):
+  jest@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
+      jest-cli: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14897,27 +14791,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.21)
-
-  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.130
-      acorn: 8.16.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
-    optional: true
 
   ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -847,9 +847,6 @@ importers:
 
   examples/typescript/google-cloudrun:
     dependencies:
-      cdktf:
-        specifier: 0.21.0
-        version: 0.21.0(constructs@10.6.0)
       cdktn:
         specifier: workspace:*
         version: link:../../../packages/cdktn
@@ -4250,15 +4247,6 @@ packages:
 
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
-
-  cdktf@0.21.0:
-    resolution: {integrity: sha512-bdTOOyrFSXw0p5d7/3dye7ZWYzrUatyMjWEAAwTGoqghjygRj6Q55y1QZnSB021NRDzYZ3BhFGsOkpmIjQMzNQ==}
-    peerDependencies:
-      constructs: ^10.4.2
-    bundledDependencies:
-      - archiver
-      - json-stable-stringify
-      - semver
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -10135,7 +10123,7 @@ snapshots:
 
   '@types/responselike@1.0.0':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
     optional: true
 
   '@types/semver@7.7.1': {}
@@ -10940,10 +10928,6 @@ snapshots:
 
   caseless@0.12.0:
     optional: true
-
-  cdktf@0.21.0(constructs@10.6.0):
-    dependencies:
-      constructs: 10.6.0
 
   chalk@2.4.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,13 +215,13 @@ importers:
         version: 9.39.4
       '@nx/eslint':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/eslint-plugin':
         specifier: 22.7.5
         version: 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.4.5))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@nx/jest':
         specifier: 22.7.5
-        version: 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
+        version: 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@swc/core':
         specifier: ~1.15.5
         version: 1.15.40(@swc/helpers@0.5.21)
@@ -269,7 +269,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+        version: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
       knip:
         specifier: ^6.16.1
         version: 6.16.1
@@ -385,17 +385,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -413,17 +413,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -441,17 +441,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -469,17 +469,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -497,11 +497,11 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -522,17 +522,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -550,17 +550,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -578,17 +578,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -609,17 +609,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-jest:
         specifier: 29.4.9
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -637,17 +637,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -665,17 +665,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -693,17 +693,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -721,17 +721,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -749,17 +749,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -777,14 +777,14 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -802,14 +802,14 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       tsx:
         specifier: 4.6.1
         version: 4.6.1
@@ -830,17 +830,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -861,17 +861,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -889,17 +889,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -917,14 +917,14 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -942,17 +942,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -970,17 +970,17 @@ importers:
         specifier: 30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       cdktn-cli:
         specifier: workspace:*
         version: link:../../../packages/cdktn-cli
       jest:
         specifier: ^30.3.0
-        version: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+        version: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       ts-node:
         specifier: 10.9.1
-        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -1067,8 +1067,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/node':
-        specifier: 20.19.1
-        version: 20.19.1
+        specifier: 22.20.1
+        version: 22.20.1
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -1153,8 +1153,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -1229,8 +1229,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/node':
-        specifier: 20.19.37
-        version: 20.19.37
+        specifier: 22.20.1
+        version: 22.20.1
       '@types/prettier':
         specifier: 2.7.3
         version: 2.7.3
@@ -1260,8 +1260,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/node':
-        specifier: 20.19.37
-        version: 20.19.37
+        specifier: 22.20.1
+        version: 22.20.1
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -1300,8 +1300,8 @@ importers:
         specifier: 11.0.4
         version: 11.0.4
       '@types/node':
-        specifier: 20.19.37
-        version: 20.19.37
+        specifier: 22.20.1
+        version: 22.20.1
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -1380,8 +1380,8 @@ importers:
         specifier: 6.0.0
         version: 6.0.0
       '@types/node':
-        specifier: 20.19.1
-        version: 20.19.1
+        specifier: 22.20.1
+        version: 22.20.1
       ansi-escapes:
         specifier: 4.3.2
         version: 4.3.2
@@ -1545,11 +1545,11 @@ importers:
         specifier: ^7.4.4
         version: 7.4.4
       '@types/node':
-        specifier: 20.17.51
-        version: 20.17.51
+        specifier: 22.20.1
+        version: 22.20.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -3565,17 +3565,11 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@20.17.51':
-    resolution: {integrity: sha512-hccptBl7C8lHiKxTBsY6vYYmqpmw1E/aGR/8fmueE+B390L3pdMOpNSRvFO4ZnXzW5+p2HBXV0yNABd2vdk22Q==}
-
-  '@types/node@20.19.1':
-    resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
-
-  '@types/node@20.19.37':
-    resolution: {integrity: sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==}
-
   '@types/node@22.19.20':
     resolution: {integrity: sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -7409,9 +7403,6 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -8800,12 +8791,21 @@ snapshots:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
 
@@ -9152,13 +9152,13 @@ snapshots:
   '@jest/console@30.3.0':
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       chalk: 4.1.2
       jest-message-util: 30.3.0
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))':
+  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -9166,14 +9166,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -9193,7 +9193,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))':
+  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -9201,14 +9201,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -9228,7 +9228,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))':
+  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -9236,14 +9236,14 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -9275,7 +9275,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       jest-mock: 30.3.0
 
   '@jest/expect-utils@30.3.0':
@@ -9293,7 +9293,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
       '@sinonjs/fake-timers': 15.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       jest-message-util: 30.3.0
       jest-mock: 30.3.0
       jest-util: 30.3.0
@@ -9311,12 +9311,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.3.0':
@@ -9327,7 +9327,7 @@ snapshots:
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -9407,7 +9407,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9417,7 +9417,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9549,7 +9549,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/eslint@22.7.5(@babel/traverse@7.29.0)(@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0)))(@swc/core@1.15.40(@swc/helpers@0.5.21))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 22.7.5(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))
       '@nx/js': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
@@ -9558,7 +9558,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.9.3
     optionalDependencies:
-      '@nx/jest': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/jest': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@zkochan/js-yaml': 0.0.7
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -9569,7 +9569,7 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/jest@22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))(typescript@5.4.5)(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@jest/reporters': 30.3.0
       '@jest/test-result': 30.3.0
@@ -9577,7 +9577,7 @@ snapshots:
       '@nx/js': 22.7.5(@babel/traverse@7.29.0)(@swc/core@1.15.40(@swc/helpers@0.5.21))(nx@22.7.5(@swc/core@1.15.40(@swc/helpers@0.5.21)))(verdaccio@6.6.0(encoding@0.1.13)(typanion@3.14.0))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.4.5)
       identity-obj-proxy: 3.0.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
       jest-resolve: 30.3.0
       jest-util: 30.3.0
       minimatch: 10.2.5
@@ -10049,7 +10049,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
 
   '@types/debug@4.1.13':
     dependencies:
@@ -10065,16 +10065,16 @@ snapshots:
 
   '@types/follow-redirects@1.14.4':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
 
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -10095,7 +10095,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -10107,25 +10107,17 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
 
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.17.51':
-    dependencies:
-      undici-types: 6.19.8
-
-  '@types/node@20.19.1':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@20.19.37':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.19.20':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/node@22.20.1':
     dependencies:
       undici-types: 6.21.0
 
@@ -10143,7 +10135,7 @@ snapshots:
 
   '@types/responselike@1.0.0':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
     optional: true
 
   '@types/semver@7.7.1': {}
@@ -10164,7 +10156,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.4.5))(eslint@9.39.4(jiti@2.7.0))(typescript@5.4.5)':
@@ -12505,7 +12497,7 @@ snapshots:
       '@jest/expect': 30.3.0
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
@@ -12525,15 +12517,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest-cli@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -12544,15 +12536,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest-cli@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -12563,15 +12555,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5)):
+  jest-cli@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+      jest-config: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -12582,7 +12574,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest-config@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -12608,13 +12600,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.17.51
-      ts-node: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+      '@types/node': 18.19.130
+      ts-node: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest-config@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -12640,13 +12632,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.17.51
-      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+      '@types/node': 18.19.130
+      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest-config@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -12672,13 +12664,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.37
-      ts-node: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+      '@types/node': 18.19.130
+      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest-config@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -12704,13 +12696,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.37
-      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)
+      '@types/node': 22.20.1
+      ts-node: 10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5)):
+  jest-config@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -12736,8 +12728,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.19.37
-      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5)
+      '@types/node': 22.20.1
+      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12766,7 +12758,7 @@ snapshots:
       '@jest/environment': 30.3.0
       '@jest/fake-timers': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       jest-mock: 30.3.0
       jest-util: 30.3.0
       jest-validate: 30.3.0
@@ -12774,7 +12766,7 @@ snapshots:
   jest-haste-map@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -12813,7 +12805,7 @@ snapshots:
   jest-mock@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       jest-util: 30.3.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.3.0):
@@ -12849,7 +12841,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -12878,7 +12870,7 @@ snapshots:
       '@jest/test-result': 30.3.0
       '@jest/transform': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -12925,7 +12917,7 @@ snapshots:
   jest-util@30.3.0:
     dependencies:
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -12944,7 +12936,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -12953,18 +12945,18 @@ snapshots:
 
   jest-worker@30.3.0:
     dependencies:
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.3.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest@30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest-cli: 30.3.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12972,12 +12964,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)):
+  jest@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest-cli: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -12985,12 +12977,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5)):
+  jest@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.19.37)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5))
+      jest-cli: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14891,12 +14883,12 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.4.1)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@20.17.51)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5))
+      jest: 30.3.0(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -14911,14 +14903,14 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5):
+  ts-node@10.9.1(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.51
+      '@types/node': 22.20.1
       acorn: 8.16.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -14931,34 +14923,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.21)
 
-  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.17.51)(typescript@5.4.5):
+  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@18.19.130)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.51
-      acorn: 8.16.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
-
-  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@20.19.37)(typescript@5.4.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.37
+      '@types/node': 18.19.130
       acorn: 8.16.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -14971,6 +14943,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.21)
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.20.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.4.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
 
   tsc-files@1.1.4(typescript@5.4.5):
     dependencies:
@@ -15047,8 +15039,6 @@ snapshots:
   unbash@3.0.0: {}
 
   undici-types@5.26.5: {}
-
-  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8779,21 +8779,12 @@ snapshots:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
 
-  '@emnapi/core@1.9.2':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@emnapi/runtime@1.4.5':
-    dependencies:
-      tslib: 2.8.1
-
-  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
 

--- a/tools/generate-function-bindings/package.json
+++ b/tools/generate-function-bindings/package.json
@@ -29,7 +29,7 @@
     "@babel/types": "^7.20.2",
     "@types/babel__generator": "^7.27.0",
     "@types/babel__template": "^7.4.4",
-    "@types/node": "20.17.51",
+    "@types/node": "22.20.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
### Description

Officially set the minimum node version to 22.x as 20.x is EoL.
Updates @types/node to 22.x and restores minor updates.

### Checklist

- [ ] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [ ] I have run the linter on my code locally
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
