### PR TITLE
fix: typo in `moveFromId` JSDoc

### DIFF
--- a/packages/cdktn/src/terraform-resource.ts
+++ b/packages/cdktn/src/terraform-resource.ts
@@ -515,7 +515,7 @@ export class TerraformResource
   }
 
   /**
-   * Move the resource corresponding to "id" to this resource. Note that the resource being moved from must be marked as moved using it's instance function.
+   * Move the resource corresponding to "id" to this resource. Note that the resource being moved from must be marked as moved using its instance function.
    * @param id Full id of resource being moved from, e.g. "aws_s3_bucket.example"
    */
   public moveFromId(id: string) {


### PR DESCRIPTION
https://www.merriam-webster.com/grammar/when-to-use-its-vs-its

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Description

Despite the presence of an apostrophe, "it's" is *not* possessive. "Its" is the correct possessive form. 

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [ ] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
