### PR TITLE
feat(lib)!: validate Terraform function versions by default

### DIFF
--- a/packages/cdktn/src/features.ts
+++ b/packages/cdktn/src/features.ts
@@ -30,15 +30,6 @@ export const FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS =
   "failOnConstructsOutsideOfStacks";
 
 /**
- * When enabled, each TerraformStack validates that the Terraform functions
- * used through `Fn` are supported by the runtime versions declared in
- * `targetVersions` (Terraform and/or OpenTofu). This is a purely static check
- * against the vendored function availability matrix; it never executes a
- * Terraform-compatible CLI.
- */
-export const VALIDATE_FUNCTION_VERSIONS = "validateFunctionVersions";
-
-/**
  * When enabled, TerraformAsset and TerraformModuleAsset compute asset hashes
  * with a canonical entry-framed scheme modeled on git trees and Nix NAR:
  * every entry contributes its type, permission mask (for files and
@@ -58,6 +49,5 @@ export const CANONICAL_ASSET_HASHES = "canonicalAssetHashes";
 
 export const FUTURE_FLAGS = {
   [FAIL_ON_CONSTRUCTS_OUTSIDE_OF_STACKS]: "true",
-  [VALIDATE_FUNCTION_VERSIONS]: "true",
   [CANONICAL_ASSET_HASHES]: "true",
 };

--- a/packages/cdktn/src/terraform-stack.ts
+++ b/packages/cdktn/src/terraform-stack.ts
@@ -20,7 +20,6 @@ import {
   ValidateProviderFunctionTargetSupport,
   ValidateProviderPresence,
 } from "./validations";
-import { VALIDATE_FUNCTION_VERSIONS } from "./features";
 import { App } from "./app";
 import { TerraformBackend } from "./terraform-backend";
 import { TerraformResourceTargets } from "./terraform-resource-targets";
@@ -131,9 +130,7 @@ export class TerraformStack extends Construct {
     );
     Object.defineProperty(this, STACK_SYMBOL, { value: true });
     this.node.addValidation(new ValidateProviderPresence(this));
-    if (this.node.tryGetContext(VALIDATE_FUNCTION_VERSIONS)) {
-      this.node.addValidation(new ValidateFunctionVersionSupport(this));
-    }
+    this.node.addValidation(new ValidateFunctionVersionSupport(this));
     this.node.addValidation(new ValidateProviderFunctionTargetSupport(this));
   }
 

--- a/packages/cdktn/src/validations/validate-provider-function-target-support.ts
+++ b/packages/cdktn/src/validations/validate-provider-function-target-support.ts
@@ -21,8 +21,8 @@ import { TerraformStack } from "../terraform-stack";
  * provider function has been used, and otherwise checked once, naming every
  * used function so the error is actionable.
  *
- * Registered unconditionally (no feature flag): this is new API surface, and
- * the check only ever fires when a provider function is actually used —
+ * Registered unconditionally: this is new API surface, and the check only
+ * ever fires when a provider function is actually used —
  * i.e. its token was resolved while rendering this validation's OWNING
  * STACK (`TerraformStack._getUsedProviderFunctions()`), not while rendering
  * some other stack in the same App: this validation is registered in

--- a/packages/cdktn/test/validations.test.ts
+++ b/packages/cdktn/test/validations.test.ts
@@ -11,12 +11,10 @@ import {
   resolveTargetVersions,
   ValidateBinaryVersion,
   ValidateFeatureTargetSupport,
-  ValidateFunctionVersionSupport,
 } from "../src/validations";
 import { TestProvider } from "./helper/provider";
 import { createTmpHelper } from "./helper/tmp";
 import { terraformBinaryName } from "../src/util";
-import { VALIDATE_FUNCTION_VERSIONS } from "../src/features";
 
 const tmp = createTmpHelper();
 
@@ -492,10 +490,7 @@ describe("ValidateFunctionVersionSupport", () => {
   }
 
   test("ignores universally available functions without resolving targets", () => {
-    const { app, stack, testResource } = appWithStack();
-    testResource.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource),
-    );
+    const { app, stack } = appWithStack();
     new TestResource(stack, "usesBaselineFunction", {
       name: Fn.abs(-42).toString(),
     });
@@ -511,17 +506,14 @@ describe("ValidateFunctionVersionSupport", () => {
 
   test("fails against the default baseline targets when a function needs a newer floor", () => {
     const { app, testResource } = appWithStack();
-    testResource.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource),
-    );
     new TestResource(testResource, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
 
     expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
       "Validation failed with the following errors:
-        [MyStack/testResource] Terraform function "templatestring" requires terraform >=1.9.0, but the project targets terraform >=1.5.7. It is available in terraform >=1.9.0 and opentofu >=1.7.0.
-        [MyStack/testResource] Terraform function "templatestring" requires opentofu >=1.7.0, but the project targets opentofu >=1.6.0. It is available in terraform >=1.9.0 and opentofu >=1.7.0.
+        [MyStack] Terraform function "templatestring" requires terraform >=1.9.0, but the project targets terraform >=1.5.7. It is available in terraform >=1.9.0 and opentofu >=1.7.0.
+        [MyStack] Terraform function "templatestring" requires opentofu >=1.7.0, but the project targets opentofu >=1.6.0. It is available in terraform >=1.9.0 and opentofu >=1.7.0.
 
       If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
       "
@@ -532,9 +524,6 @@ describe("ValidateFunctionVersionSupport", () => {
     const { app, testResource } = appWithStack({
       targetVersions: { terraform: ">=1.9.0", opentofu: ">=1.7.0" },
     });
-    testResource.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource),
-    );
     new TestResource(testResource, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
@@ -552,16 +541,13 @@ describe("ValidateFunctionVersionSupport", () => {
     const { app, testResource } = appWithStack({
       targetVersions: { terraform: ">=1.15.0" },
     });
-    testResource.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource),
-    );
     new TestResource(testResource, "usesCidrcontains", {
       name: Fn.cidrcontains("10.0.0.0/8", "10.1.0.0").toString(),
     });
 
     expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
       "Validation failed with the following errors:
-        [MyStack/testResource] Terraform function "cidrcontains" is not supported by terraform, but the project targets terraform >=1.15.0. It is available in opentofu >=1.7.0.
+        [MyStack] Terraform function "cidrcontains" is not supported by terraform, but the project targets terraform >=1.15.0. It is available in opentofu >=1.7.0.
 
       If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
       "
@@ -572,9 +558,6 @@ describe("ValidateFunctionVersionSupport", () => {
     const { app, testResource } = appWithStack({
       targetVersions: { opentofu: ">=1.7.0" },
     });
-    testResource.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource),
-    );
     new TestResource(testResource, "usesCidrcontains", {
       name: Fn.cidrcontains("10.0.0.0/8", "10.1.0.0").toString(),
     });
@@ -586,49 +569,51 @@ describe("ValidateFunctionVersionSupport", () => {
     const { app, testResource } = appWithStack({
       targetVersions: { tofu: ">=1.7.0" },
     });
-    testResource.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource),
-    );
     new TestResource(testResource, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
 
     expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
       "Validation failed with the following errors:
-        [MyStack/testResource] targetVersions has unknown product "tofu" (expected "terraform" or "opentofu")
+        [MyStack] targetVersions has unknown product "tofu" (expected "terraform" or "opentofu")
 
       If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
       "
     `);
   });
 
-  test("is added to stacks via the validateFunctionVersions feature flag", () => {
-    const { app, stack } = appWithStack({
-      [VALIDATE_FUNCTION_VERSIONS]: "true",
-      targetVersions: { terraform: ">=1.9.0", opentofu: ">=1.7.0" },
-    });
+  // The `validateFunctionVersions` context key that used to gate this
+  // validation is gone - it is registered on every stack now. `context` is an
+  // untyped passthrough map, so a cdktf.json that still carries the key stays
+  // valid; the key is simply inert, whichever value it holds. The two tests
+  // below pin both halves of that: a stale truthy key is not an error, and a
+  // falsy one no longer opts out. The literal string is spelled out here
+  // because the constant it came from no longer exists.
+  test("keeps working when a legacy cdktf.json still sets the removed validateFunctionVersions key", () => {
+    const { app, stack } = appWithStack({ validateFunctionVersions: "true" });
     new TestResource(stack, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
 
-    const execSpy = jest.spyOn(child_process, "execSync");
-    try {
-      expect(() => app.synth()).not.toThrow();
-      expect(execSpy).not.toHaveBeenCalled();
-    } finally {
-      execSpy.mockRestore();
-    }
+    expect(() => app.synth()).toThrow(
+      'Terraform function "templatestring" requires terraform >=1.9.0',
+    );
   });
 
-  test("is not added to stacks without the feature flag", () => {
-    const { app, testResource } = appWithStack();
-    new TestResource(testResource, "usesTemplatestring", {
+  test("still validates when a legacy cdktf.json explicitly disables the removed key", () => {
+    const { app, stack } = appWithStack({ validateFunctionVersions: false });
+    new TestResource(stack, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
 
-    // no validation registered: even a function outside the default baseline
-    // does not fail synth
-    expect(() => app.synth()).not.toThrow();
+    expect(() => app.synth()).toThrowErrorMatchingInlineSnapshot(`
+      "Validation failed with the following errors:
+        [MyStack] Terraform function "templatestring" requires terraform >=1.9.0, but the project targets terraform >=1.5.7. It is available in terraform >=1.9.0 and opentofu >=1.7.0.
+        [MyStack] Terraform function "templatestring" requires opentofu >=1.7.0, but the project targets opentofu >=1.6.0. It is available in terraform >=1.9.0 and opentofu >=1.7.0.
+
+      If you wish to ignore these validations, pass 'skipValidation: true' to your App configuration.
+      "
+    `);
   });
 
   test("does not leak Fn usage from one App into a later, unrelated App in the same process", () => {
@@ -638,12 +623,8 @@ describe("ValidateFunctionVersionSupport", () => {
     // structural, not something that depends on a reset running between
     // tests.
     const { app: app1, testResource: testResource1 } = appWithStack({
-      [VALIDATE_FUNCTION_VERSIONS]: "true",
       targetVersions: { terraform: ">=1.9.0", opentofu: ">=1.7.0" },
     });
-    testResource1.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource1),
-    );
     new TestResource(testResource1, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
@@ -651,12 +632,7 @@ describe("ValidateFunctionVersionSupport", () => {
 
     // app2 targets the default baseline (which does NOT support
     // templatestring) but never calls Fn.templatestring itself.
-    const { app: app2, testResource: testResource2 } = appWithStack({
-      [VALIDATE_FUNCTION_VERSIONS]: "true",
-    });
-    testResource2.node.addValidation(
-      new ValidateFunctionVersionSupport(testResource2),
-    );
+    const { app: app2 } = appWithStack();
     expect(() => app2.synth()).not.toThrow();
   });
 
@@ -669,16 +645,14 @@ describe("ValidateFunctionVersionSupport", () => {
     // entirely. Recording at token-RESOLVE time, onto the stack being
     // resolved, is immune to this: App A's usage is recorded during App A's
     // own prepareStack pass and read back from App A's own stacks.
-    const { app: app1, testResource: testResource1 } = appWithStack({
-      [VALIDATE_FUNCTION_VERSIONS]: "true",
-    });
+    const { app: app1, testResource: testResource1 } = appWithStack();
     new TestResource(testResource1, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });
 
     // App B is constructed here, strictly between App A's usage and App
     // A's synth() call - the interleaving that used to trigger the bug.
-    appWithStack({ [VALIDATE_FUNCTION_VERSIONS]: "true" });
+    appWithStack();
 
     expect(() => app1.synth()).toThrowErrorMatchingInlineSnapshot(`
       "Validation failed with the following errors:
@@ -710,18 +684,12 @@ describe("ValidateFunctionVersionSupport", () => {
       opentofu: ">=1.7.0",
     });
     new TestProvider(compatible, "provider", {});
-    compatible.node.addValidation(
-      new ValidateFunctionVersionSupport(compatible),
-    );
     new TestResource(compatible, "harmless", {
       name: "no gated function used here",
     });
 
     const incompatible = new TerraformStack(app, "IncompatibleStack");
     new TestProvider(incompatible, "provider", {});
-    incompatible.node.addValidation(
-      new ValidateFunctionVersionSupport(incompatible),
-    );
     new TestResource(incompatible, "usesTemplatestring", {
       name: Fn.templatestring("$${greeting}", { greeting: "hello" }),
     });

--- a/test/typescript/function-version-validation/cdktf.json
+++ b/test/typescript/function-version-validation/cdktf.json
@@ -1,7 +1,4 @@
 {
   "language": "typescript",
-  "app": "npx ts-node main.ts",
-  "context": {
-    "validateFunctionVersions": "true"
-  }
+  "app": "npx ts-node main.ts"
 }

--- a/tools/generate-function-bindings/function-availability/README.md
+++ b/tools/generate-function-bindings/function-availability/README.md
@@ -8,8 +8,8 @@ gaps per product). It is consumed by:
   bindings.
 - `../scripts/generate-function-availability.ts` — emits
   `packages/cdktn/src/functions/function-availability.generated.ts`, the
-  version-constraint map used by the synth-time `validateFunctionVersions`
-  check.
+  version-constraint map used by the synth-time function version validation
+  (`ValidateFunctionVersionSupport`).
 
 ## Regenerating
 


### PR DESCRIPTION
Closes #352
Closes #342

Graduates the `validateFunctionVersions` feature flag to always-on so it rides the 0.24 breaking-change release.

## Approach: delete the flag, no no-op shim

Following this repo's one existing graduation precedent, `3c323e76d` ("chore: remove existing feature flags", which graduated `EXCLUDE_STACK_ID_FROM_LOGICAL_IDS` and `ALLOW_SEP_CHARS_IN_LOGICAL_IDS").

"Keep it accepted but ignored" is already what deletion gives us: `cdktf.json`'s `context` is typed `readonly context?: { [key: string]: any }` (`packages/@cdktn/commons/src/config.ts:296`) and passed straight through as `CDKTF_CONTEXT_JSON` with no schema, allowlist, or unknown-key check anywhere in the CLI. So an existing `cdktf.json` that still sets `"validateFunctionVersions": "true"` keeps working — the key just becomes inert. There is no hard-fail to protect against, so a deliberate shim would be dead code (YAGNI > KISS).

**No `.jsii` API diff.** `features.ts` is not re-exported from `packages/cdktn/src/index.ts`, so `VALIDATE_FUNCTION_VERSIONS` was never part of the public/JSII surface. The only in-repo deep importer is `packages/@cdktn/cli-core/src/lib/init.ts`, which imports `FUTURE_FLAGS` (kept), not the constant.

## Changes

- `packages/cdktn/src/features.ts` — drop the constant, its JSDoc, and its `FUTURE_FLAGS` entry. The map keeps `failOnConstructsOutsideOfStacks` and `canonicalAssetHashes`.
- `packages/cdktn/src/terraform-stack.ts` — register `ValidateFunctionVersionSupport` unconditionally, alongside `ValidateProviderPresence` and `ValidateProviderFunctionTargetSupport`.
- `test/typescript/function-version-validation/cdktf.json` — remove the key (and the now-empty `context` object), so the integration fixture becomes the end-to-end proof that validation runs with zero context.
- `tools/generate-function-bindings/function-availability/README.md` — name the validation class instead of the removed context key.
- `packages/cdktn/src/validations/validate-provider-function-target-support.ts` — its JSDoc said "Registered unconditionally (no feature flag)", a contrast drawn against a flag that no longer exists.

`cdktn init` stops emitting the key automatically — `init.ts` iterates `Object.entries(FUTURE_FLAGS)` generically, as does `Testing.enableFutureFlags`.

## Why the test diff is larger than a find/replace

Six tests in the `ValidateFunctionVersionSupport` block registered the validation **manually** on a resource, precisely because the constructor gate was off by default. With the gate always-on, every `TerraformStack` also registers a stack-scoped instance, and both read the same `stack._getUsedFunctions()` — so each error would be reported **twice**, under `[MyStack/testResource]` and `[MyStack]`.

Dropping those manual registrations makes the tests exercise the real always-on path; the inline snapshots then re-prefix to `[MyStack]`. The pre-existing interleaved-Apps test, which already relied on automatic registration, confirms `[MyStack]` is the correct prefix.

Two tests are repurposed to cover migration instead: a stale truthy key is inert, and a falsy one no longer opts out.

## Verification

`pnpm nx test cdktn --skip-nx-cache -- --ci`, compared against untouched `origin/main` in a separate worktree:

| | this branch | `origin/main` |
|---|---|---|
| Test Suites | 1 failed, 42 passed | 1 failed, 42 passed |
| Tests | 1 failed, 541 passed | 1 failed, 541 passed |
| Snapshots | 300 passed | 299 passed |

Identical. The one failure is **pre-existing** — `matchers › toPlanSuccessfully › succeeds if the terraform config passed is valid`, which needs a real `terraform` binary. The extra snapshot is this branch's new assertion. `--skip-nx-cache` on every run so a cached green could not stand in for real work.

**Not verified:** `pnpm integration:single typescript/function-version-validation` was not run — it requires `pnpm package`, which needs `mvn` and `dotnet`, neither available on the machine used. CI should cover it. `@cdktn/cli-core` tests also could not run locally (`hcl2json`'s prebuild needs `go` on `PATH`).

## Note on #352's title

#352 names `validateTerraformFunctionVersions`, which does not exist anywhere in the tree — the real context key is `validateFunctionVersions`. #342 quotes the real code and was used as the source of truth. Flagging it so the wrong key name doesn't propagate into changelogs or migration notes.

## Blast radius

Only 7 functions carry version constraints (`base64gunzip`, `cidrcontains`, `convert`, `ephemeralasnull`, `issensitive`, `templatestring`, `urldecode`), and outside `validations.test.ts` the only usage in the repo is the dedicated integration fixture — so no other test, example, or fixture starts failing when validation becomes unconditional.