### PR TITLE
fix(lib): Disallow constructs 10.8 until support can be added

### DIFF
--- a/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
@@ -28,7 +28,13 @@ exports.post = (ctx) => {
     throw new Error(`missing context "npm_cdktf"`);
   }
 
-  installDeps([npm_cdktf, `constructs@10`], false, silent);
+  // Mirrors the `constructs` peer dependency range declared by the cdktn
+  // package. 10.8.0 is excluded because it dropped `jsii.tsc.outDir` from its
+  // package.json, which jsii-rosetta needs to map the shipped .d.ts files back
+  // to the symbol ids in the assembly; without it `cdktn convert` emits
+  // unresolved Java/Go imports (`constructs.Construct` instead of
+  // `software.constructs.Construct`). Keep both ranges in sync.
+  installDeps([npm_cdktf, `constructs@>=10.6.0 <10.8.0`], false, silent);
   installDeps(
     ["@types/node", "typescript@5.x", "jest", "@types/jest", "ts-jest", "ts-node"],
     true,
@@ -46,7 +52,13 @@ function installDeps(deps, isDev, silent) {
   const env = Object.assign({}, process.env);
   env["NODE_ENV"] = "development";
 
-  execSync(`npm install ${devDep} ${deps.join(" ")}`, {
+  // Each spec is double-quoted so ranges containing spaces or shell
+  // metacharacters survive the shell. Double quotes (rather than single) work
+  // on both POSIX shells and cmd.exe, where an unquoted `^` is the escape
+  // character and would silently turn `cdktn@^1.2.3` into `cdktn@1.2.3`.
+  const specs = deps.map((dep) => `"${dep}"`).join(" ");
+
+  execSync(`npm install ${devDep} ${specs}`, {
     stdio: silent ? "ignore" : "inherit",
     env,
   });

--- a/packages/cdktn/package.json
+++ b/packages/cdktn/package.json
@@ -96,6 +96,6 @@
     ],
     "stability": "experimental",
     "peerDependencies": {
-        "constructs": "^10.6.0"
+        "constructs": ">=10.6.0 <10.8.0"
     }
 }


### PR DESCRIPTION
<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes https://github.com/open-constructs/cdk-terrain/actions/runs/30545326461/job/90912362214

### Description

constructs 10.8.0 moved to the jsii 6.0.7 compiler and dropped jsii.tsc: {outDir: "lib", rootDir: "src"} from its package.json (replaced by jsii.tsconfig/validateTsconfig).

In jsii/lib/common/symbol-id.js, findPackageInfo reads tscOutDir only from jsii.tsc.outDir in package.json. tscRootDir has an assembly-metadata fallback (asm.metadata.tscRootDir); tscOutDir does not, and no tsconfig.json ships in the tarball. So normalizePath bails, the computed symbolId stays lib/construct:Construct instead of src/construct:Construct, misses the assembly's symbolIdMap, and importedSymbol comes back undefined. assemblies.js:234 swallows this in a bare catch {}/undefined path, so you get silently wrong output instead of an error.
See https://github.com/aws/jsii-compiler/issues/2740 for more details.

Needed to additionally quote the installed dependency in the template so that shell wouldn't mangle the updated version range.

We could skip the peer dependency constraint, but it's clear that cdktn isn't fully compatible with constructs 10.8 at this time. We can revisit when we update to JSII 6.x.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
