### PR TITLE
fix(gha): mint the Go-publish token from the open-constructs-cdktn App

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,7 +30,12 @@ on:
         required: true
       NUGET_API_KEY:
         required: true
-      TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN:
+      # Credentials of the open-constructs-cdktn GitHub App; release_golang
+      # mints a per-run installation token from them. Callers pass these via
+      # `secrets: inherit`.
+      GH_APP_ID:
+        required: true
+      GH_APP_PRIVATE_KEY:
         required: true
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -194,9 +194,22 @@ jobs:
         with:
           name: ${{ inputs.dist_artifact_name }}
           path: dist
+      # Minted fresh each run by the open-constructs-cdktn GitHub App, replacing
+      # the TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN user PAT that silently expired
+      # and failed every Go publish with git prompting for a password (#66).
+      # Scoped to the one repo publib-golang pushes to; expires after an hour,
+      # which comfortably outlives this job.
+      - name: Generate GitHub App token
+        id: go-app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: open-constructs
+          repositories: cdk-terrain-go
       - name: Release
         run: npx --no publib-golang
         env:
-          GITHUB_TOKEN: ${{ secrets.TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.go-app-token.outputs.token }}
           GIT_USER_NAME: "CDK Terrain Bot"
           GIT_USER_EMAIL: "gh-actions@cdktn.io"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -207,6 +207,10 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: open-constructs
           repositories: cdk-terrain-go
+          # Push access to the Go bindings repo is all publib-golang needs;
+          # without this the token inherits every permission the installation
+          # has (zizmor: github-app).
+          permission-contents: write
       - name: Release
         run: npx --no publib-golang
         env:


### PR DESCRIPTION
## Problem

The `release_golang` job authenticates with `TERRAFORM_CDK_GO_REPO_GITHUB_TOKEN` — a user PAT that has expired. GitHub 401s the push, headless git falls back to an interactive password prompt, and the job dies:

```
fatal: could not read Password for 'https://***@github.com': No such device or address
    Command failed: git push origin cdktn/v0.24.0-pre.95
```

Both the original `publish_next` run and a fresh rerun ([31085026499](https://github.com/open-constructs/cdk-terrain/actions/runs/31085026499)) failed identically, so this is credential death, not token-TTL flakiness. **This currently blocks the 0.24.0 release cut** (#303) — the stable flow publishes Go with the same secret.

## Fix

Mint an installation token from the **open-constructs-cdktn** GitHub App ([installation 138220829](https://github.com/apps/open-constructs-cdktn/installations/138220829)) whose credentials are already in this repo's secrets (`GH_APP_ID` / `GH_APP_PRIVATE_KEY`), scoped to `cdk-terrain-go`, and use it as `GITHUB_TOKEN` for `publib-golang`. Fresh every run, expires in an hour, no PAT to rot. Same pinned `create-github-app-token@v2` SHA as release-please.yml / pnpm-upgrade.yml.

If the App installation turns out not to cover `cdk-terrain-go`, the mint step fails fast with a clear error — fallback is rotating the PAT.

Closes #66 (this was exactly the failure mode that issue predicted).

## Verification

Merging this triggers the `next` pre-release flow on main, which will exercise the new token path end-to-end (expect `v0.24.0-pre.96` to land in cdk-terrain-go). A green `publish_next / Release Go to Github Repo (next)` is the all-clear to merge #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)