### PR TITLE
fix(gha): pass the Go-publish App token as x-access-token userinfo

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -222,6 +222,12 @@ jobs:
       - name: Release
         run: npx --no publib-golang
         env:
-          GITHUB_TOKEN: ${{ steps.go-app-token.outputs.token }}
+          # The x-access-token: prefix is load-bearing: publib embeds this value
+          # as URL userinfo, and App installation tokens only authenticate over
+          # HTTPS as username x-access-token with the token as password. A bare
+          # ghs_ token becomes username-only, GitHub rejects it, and headless
+          # git dies prompting for a password. Same wiring as the
+          # @cdktn/provider-project fleet's release_golang.
+          GITHUB_TOKEN: x-access-token:${{ steps.go-app-token.outputs.token }}
           GIT_USER_NAME: "CDK Terrain Bot"
           GIT_USER_EMAIL: "gh-actions@cdktn.io"


### PR DESCRIPTION
Third and final piece of the Go-publish credential fix (#368 → #369 → this). Run [31111049134](https://github.com/open-constructs/cdk-terrain/actions/runs/31111049134) proved the mint works (CDKTN Maintainers app, installation covers `cdk-terrain-go`) — the job got all the way to `git push origin cdktn/v0.24.0-pre.97` before dying with the same password prompt.

Cause: publib embeds `GITHUB_TOKEN` verbatim as URL userinfo. A bare `ghs_` installation token becomes a **username-only** URL, which GitHub rejects for App tokens — they authenticate over HTTPS only as `x-access-token:<token>`. PATs tolerate the bare form, which is why this never bit before the PAT died.

Fix is the one-line prefix — the exact wiring `@cdktn/provider-project` generates for the provider fleet's `release_golang`, proven green on cdktn-provider-snowflake's Go publish this morning:

```yaml
GITHUB_TOKEN: x-access-token:${{ steps.go-app-token.outputs.token }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)