### PR TITLE
fix(gha): pass -R to gh pr edit in release_github relabel step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,7 +363,7 @@ jobs:
             echo "No pull request associated with ${{ github.sha }}, skipping relabel"
             exit 0
           fi
-          gh pr edit "${pr}" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
+          gh pr edit "${pr}" -R "${{ github.repository }}" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
 
   publish_release:
     permissions:


### PR DESCRIPTION
## Summary
- The `release_github` job's "Mark merged release PR as tagged" step calls `gh pr edit` without an explicit repo, so `gh` shells out to `git` to auto-detect it.
- That job runs inside the `jsii-terraform` container, where the checkout is owned by a different UID than the container user, so `git` refuses with "detected dubious ownership" and the step fails (exit code 1), even though the GitHub release itself already succeeded.
- Fix: pass `-R "${{ github.repository }}"` to `gh pr edit` so it never needs `git` to infer the repo — smallest possible fix, no container/git config changes needed.

Note: an alternative fix would be adding a `git config --global --add safe.directory /__w/cdk-terrain/cdk-terrain` step after checkout (as `prepare-release` and `prepare-next` already do), but passing `-R` avoids touching git config in the container entirely.

Diagnosed from the failed run: https://github.com/open-constructs/cdk-terrain/actions/runs/31133236561/job/92730605482

As an immediate unblock, I've also manually relabeled the affected PR (#303) from `autorelease: pending` to `autorelease: tagged` so release-please can open the next release PR.

## Test plan
- [ ] Next release run exercises the `release_github` job's relabel step and confirms `gh pr edit -R ...` succeeds inside the container