### PR TITLE
fix(cli): don't crash after a successful deploy when an output is missing

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/models/terraform.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/terraform.ts
@@ -54,6 +54,7 @@ export interface TerraformOutput {
 export function isTerraformOutput(output: any): output is TerraformOutput {
   return (
     typeof output === "object" &&
+    output !== null &&
     typeof output.sensitive === "boolean" &&
     (typeof output.type === "string" || Array.isArray(output.type))
   );

--- a/packages/@cdktn/cli-core/src/lib/output.ts
+++ b/packages/@cdktn/cli-core/src/lib/output.ts
@@ -24,17 +24,26 @@ function unpackTerraformOutput(
   outputs: NestedTerraformOutputs,
   includeSensitiveOutputs: boolean,
 ): Record<string, string> {
-  return Object.entries(outputs).reduce(
-    (acc, [key, entry]) => ({
+  return Object.entries(outputs).reduce((acc, [key, entry]) => {
+    if (isTerraformOutput(entry)) {
+      return {
+        ...acc,
+        [key]:
+          !entry.sensitive || includeSensitiveOutputs ? entry.value : undefined,
+      };
+    }
+    // Defensive hardening: `entry` comes from externally-sourced data (terraform output metadata
+    // mapped by getConstructIdsForOutputs), and Object.entries() below would throw on a null or
+    // undefined entry. Omit the key rather than recurse into it or retain an undefined/null value -
+    // consistent with how getConstructIdsForOutputs omits unresolved outputs.
+    if (entry === null || typeof entry !== "object") {
+      return acc;
+    }
+    return {
       ...acc,
-      [key]: isTerraformOutput(entry)
-        ? !entry.sensitive || includeSensitiveOutputs
-          ? entry.value
-          : undefined
-        : unpackTerraformOutput(entry, includeSensitiveOutputs),
-    }),
-    {},
-  );
+      [key]: unpackTerraformOutput(entry, includeSensitiveOutputs),
+    };
+  }, {});
 }
 
 export async function saveOutputs(
@@ -227,7 +236,17 @@ export const getConstructIdsForOutputs = (
   const mapOutputs = (value: OutputIdMap): NestedTerraformOutputs => {
     return Object.entries(value).reduce((acc, [key, value]) => {
       if (typeof value === "string") {
-        return { ...acc, [key]: outputs[value] };
+        const resolved = outputs[value];
+        if (resolved === undefined) {
+          // The metadata declares an output that terraform did not return (state drift,
+          // --skip-synth, a renamed/removed output, ...). Omit the key entirely rather than
+          // retaining it with an undefined value, which would later crash the renderer.
+          logger.debug(
+            `Output "${value}" (construct id "${key}") declared in stack metadata but absent from terraform output; omitting it.`,
+          );
+          return acc;
+        }
+        return { ...acc, [key]: resolved };
       }
 
       const mapped = mapOutputs(value);

--- a/packages/@cdktn/cli-core/src/lib/output.ts
+++ b/packages/@cdktn/cli-core/src/lib/output.ts
@@ -211,6 +211,12 @@ export const parseOutput = (str: string): DeployingResource[] => {
   }, new Array());
 };
 
+// Matches the prefix TerraformStack.registerOutgoingCrossStackReference() uses when it
+// synthesizes an output for a cross-stack dependency (packages/cdktn/src/terraform-stack.ts).
+// There is no shared constant to import for it - the identifier is not exported anywhere - so the
+// prefix is duplicated here.
+const CROSS_STACK_OUTPUT_PREFIX = "cross-stack-output-";
+
 const isObjectEmpty = (obj: Record<string, any>): boolean => {
   if (typeof obj !== "object") {
     return false;
@@ -241,9 +247,18 @@ export const getConstructIdsForOutputs = (
           // The metadata declares an output that terraform did not return (state drift,
           // --skip-synth, a renamed/removed output, ...). Omit the key entirely rather than
           // retaining it with an undefined value, which would later crash the renderer.
-          logger.debug(
-            `Output "${value}" (construct id "${key}") declared in stack metadata but absent from terraform output; omitting it.`,
-          );
+          //
+          // Cross-stack outputs are generated plumbing for stack dependencies rather than
+          // something the user declared directly, and a dependent stack legitimately produces
+          // many of them - warning on each missing one would be noise the user cannot act on.
+          // A directly user-declared output silently going missing is exactly the kind of
+          // condition that made the original crash hard to diagnose, so it gets a warning.
+          const message = `Output "${value}" (construct id "${key}") declared in stack metadata but absent from terraform output; omitting it.`;
+          if (value.startsWith(CROSS_STACK_OUTPUT_PREFIX)) {
+            logger.debug(message);
+          } else {
+            logger.warn(message);
+          }
           return acc;
         }
         return { ...acc, [key]: resolved };

--- a/packages/@cdktn/cli-core/src/test/lib/output.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/output.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import {
+  getConstructIdsForOutputs,
+  saveOutputs,
+  NestedTerraformOutputs,
+} from "../../lib/output";
+import { TerraformOutput } from "../../lib/models/terraform";
+import * as fs from "fs";
+
+function output(value: string, sensitive = false): TerraformOutput {
+  return { sensitive, type: "string", value };
+}
+
+describe("getConstructIdsForOutputs", () => {
+  it("maps a metadata-declared output that is present in terraform output", () => {
+    const stackContent = {
+      "//": {
+        outputs: {
+          myStack: {
+            myOutput: "cross-stack-output-myOutput",
+          },
+        },
+      },
+    };
+    const outputs = {
+      "cross-stack-output-myOutput": output("hello"),
+    };
+
+    const result = getConstructIdsForOutputs(stackContent, outputs);
+    expect(result).toEqual({
+      myStack: { myOutput: output("hello") },
+    });
+  });
+
+  it("omits only the missing key on a partial miss within one stack (the regression case)", () => {
+    const stackContent = {
+      "//": {
+        outputs: {
+          network: {
+            ipv6_app_address: "ipv6_app_address",
+            public_ipv4_address: "public_ipv4_address",
+            "cross-stack-output-db-host": "cross-stack-output-db-host",
+          },
+        },
+      },
+    };
+    // Only some of the declared outputs come back from `terraform output -json`.
+    const outputs = {
+      ipv6_app_address: output("::1"),
+      "cross-stack-output-db-host": output("db.internal"),
+      // public_ipv4_address is absent -> partial miss
+    };
+
+    const result = getConstructIdsForOutputs(stackContent, outputs) as any;
+
+    expect(result.network).not.toHaveProperty("public_ipv4_address");
+    expect(result.network.public_ipv4_address).toBeUndefined();
+    expect(result.network.ipv6_app_address).toEqual(output("::1"));
+    expect(result.network["cross-stack-output-db-host"]).toEqual(
+      output("db.internal"),
+    );
+  });
+
+  it("drops an entire group when every declared output in it is absent (isObjectEmpty path)", () => {
+    const stackContent = {
+      "//": {
+        outputs: {
+          network: {
+            a: "missing-a",
+            b: "missing-b",
+          },
+        },
+      },
+    };
+    const outputs = {};
+
+    const result = getConstructIdsForOutputs(stackContent, outputs);
+    // NOTE: this assertion alone does not discriminate the omission logic - a group whose every
+    // declared output is missing ends up empty either way (isObjectEmpty() considers it so) whether
+    // or not the missing keys are individually omitted, and the whole group is dropped regardless.
+    // The test that does discriminate it is the partial-miss case above ("omits only the missing key
+    // on a partial miss..."), where a mix of present and absent outputs means the group is NOT empty
+    // and an unguarded lookup would retain the missing key with an `undefined` value instead of
+    // omitting it.
+    expect(result).toEqual({});
+    expect(result).not.toHaveProperty("network");
+  });
+
+  it("passes outputs through unchanged when there is no metadata (older cdktf versions)", () => {
+    const stackContent = {};
+    const outputs = {
+      plain: output("value"),
+    };
+
+    const result = getConstructIdsForOutputs(stackContent, outputs);
+    expect(result).toBe(outputs);
+  });
+});
+
+describe("saveOutputs / unpackTerraformOutput with a partial miss", () => {
+  it("writes only the resolved outputs to disk, without an 'undefined' entry", async () => {
+    const nested: NestedTerraformOutputs = {
+      network: {
+        ipv6_app_address: output("::1"),
+        // public_ipv4_address was already omitted upstream by getConstructIdsForOutputs
+      },
+    };
+
+    const writeFileSpy = jest
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation(() => undefined);
+
+    await saveOutputs("/tmp/outputs.json", nested, false);
+
+    expect(writeFileSpy).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(written).toEqual({ network: { ipv6_app_address: "::1" } });
+    expect(JSON.stringify(written)).not.toContain("undefined");
+
+    writeFileSpy.mockRestore();
+  });
+
+  it("does not throw when a stack group mixes an undefined leaf and a null leaf", async () => {
+    // Both shapes can reach unpackTerraformOutput's Object.entries() recursion unguarded: `undefined`
+    // is the shape left behind when a caller bypasses getConstructIdsForOutputs (which omits
+    // unresolved outputs rather than keeping them as `undefined`), and `null` reaches the
+    // object-recursion branch here because isTerraformOutput(null) returns false, routing it past the
+    // leaf check instead of throwing earlier. Neither is a valid TerraformOutput nor a valid nested
+    // group.
+    const nested: NestedTerraformOutputs = {
+      s: {
+        a: output("hello"),
+        b: undefined,
+        c: null,
+      } as any,
+    };
+
+    const writeFileSpy = jest
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      saveOutputs("/tmp/outputs.json", nested, false),
+    ).resolves.toBeUndefined();
+
+    const written = JSON.parse(writeFileSpy.mock.calls[0][1] as string);
+    expect(written).toEqual({ s: { a: "hello" } });
+    expect(written.s).not.toHaveProperty("b");
+    expect(written.s).not.toHaveProperty("c");
+
+    writeFileSpy.mockRestore();
+  });
+});

--- a/packages/@cdktn/cli-core/src/test/lib/output.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/output.test.ts
@@ -6,6 +6,7 @@ import {
   NestedTerraformOutputs,
 } from "../../lib/output";
 import { TerraformOutput } from "../../lib/models/terraform";
+import { logger } from "@cdktn/commons";
 import * as fs from "fs";
 
 function output(value: string, sensitive = false): TerraformOutput {
@@ -85,6 +86,56 @@ describe("getConstructIdsForOutputs", () => {
     // omitting it.
     expect(result).toEqual({});
     expect(result).not.toHaveProperty("network");
+  });
+
+  it("warns when a user-declared output is absent from terraform output", () => {
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    const debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {});
+
+    const stackContent = {
+      "//": {
+        outputs: {
+          network: {
+            public_ipv4_address: "public_ipv4_address",
+          },
+        },
+      },
+    };
+    const outputs = {};
+
+    getConstructIdsForOutputs(stackContent, outputs);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("public_ipv4_address");
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it("only debug-logs (does not warn) when a missing output is generated cross-stack plumbing", () => {
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    const debugSpy = jest.spyOn(logger, "debug").mockImplementation(() => {});
+
+    const stackContent = {
+      "//": {
+        outputs: {
+          network: {
+            "cross-stack-output-db-host": "cross-stack-output-db-host",
+          },
+        },
+      },
+    };
+    const outputs = {};
+
+    getConstructIdsForOutputs(stackContent, outputs);
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls[0][0]).toContain("cross-stack-output-db-host");
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   it("passes outputs through unchanged when there is no metadata (older cdktf versions)", () => {

--- a/packages/cdktn-cli/src/bin/cmds/helper/__tests__/format.test.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/__tests__/format.test.ts
@@ -56,6 +56,57 @@ describe("renderOutputs", () => {
     expect(out).toContain("  host = example.com");
     expect(out).toContain("  port = 443");
   });
+
+  it("does not throw on a nested group mixing present leaves and an undefined leaf", () => {
+    const out = stripAnsi(
+      renderOutputs({
+        stack: {
+          host: leaf("example.com"),
+          missing: undefined,
+        } as any,
+      }),
+    );
+    expect(out).toContain("stack");
+    expect(out).toContain("  host = example.com");
+  });
+
+  it("does not throw on a group where every leaf is undefined", () => {
+    expect(() =>
+      renderOutputs({
+        stack: {
+          a: undefined,
+          b: undefined,
+        } as any,
+      }),
+    ).not.toThrow();
+  });
+
+  it("omits a group whose leaves all dropped, leaving no stray blank line", () => {
+    const out = stripAnsi(
+      renderOutputs({
+        empty: { x: undefined } as any,
+        db: { host: leaf("db.example.com") } as any,
+      } as any),
+    );
+
+    expect(out).not.toContain("empty");
+    expect(out).toBe("db\n  host = db.example.com");
+  });
+
+  it("does not throw on a top-level stack key whose value is undefined", () => {
+    const out = stripAnsi(
+      renderOutputs({
+        network: undefined,
+        db: {
+          host: leaf("db.example.com"),
+        } as any,
+      } as any),
+    );
+    expect(out).toContain("db");
+    expect(out).toContain("  host = db.example.com");
+    // Regression: a dropped top-level key used to leave a stray leading blank line.
+    expect(out.startsWith("\n")).toBe(false);
+  });
 });
 
 describe("renderProviderTable", () => {

--- a/packages/cdktn-cli/src/bin/cmds/helper/format.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/format.ts
@@ -122,11 +122,22 @@ function renderNested(
   if (isTerraformOutput(value)) {
     return " ".repeat(indent * 2) + renderOutput(name, value);
   }
+  // Defensive hardening: `value` is externally-sourced, and Object.entries() below throws on
+  // `null`/`undefined` (and would silently index a primitive). Bail out to an empty node so a
+  // malformed leaf can never take down the CLI after a successful deploy.
+  if (value === null || typeof value !== "object") return "";
   const header = " ".repeat(indent * 2) + chalk.bold(name);
   const children = Object.entries(value)
     .sort(compareOutputs(value))
     .map(([k, v]) => renderNested(k, v, indent + 1))
+    // A dropped node (undefined/null leaf, or a group that bailed out above) renders as "" - filter
+    // those out so they don't leave a stray blank line when joined.
+    .filter((line) => line !== "")
     .join("\n");
+  // Every child dropped (or the group was empty to begin with, including a legitimately empty `{}`
+  // group - deliberate: it used to print a bare header and now prints nothing): render nothing
+  // rather than a bare header over a blank line, so the caller's filter can drop this node too.
+  if (children === "") return "";
   return `${header}\n${children}`;
 }
 
@@ -138,9 +149,14 @@ function renderNested(
  *          when there are no outputs.
  */
 export function renderOutputs(outputs: NestedTerraformOutputs): string {
-  return Object.entries(outputs)
-    .map(([k, v]) => renderNested(k, v, 0))
-    .join("\n");
+  return (
+    Object.entries(outputs)
+      .map(([k, v]) => renderNested(k, v, 0))
+      // A dropped top-level key (e.g. an undefined stack) renders as "" - filter those out so they
+      // don't leave a stray blank line when joined.
+      .filter((line) => line !== "")
+      .join("\n")
+  );
 }
 
 /**

--- a/packages/cdktn-cli/src/bin/cmds/ui/__tests__/deploy.test.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/__tests__/deploy.test.ts
@@ -198,6 +198,35 @@ describe("runDeploy output rendering", () => {
   });
 });
 
+describe("runDeploy output rendering when every declared output drops", () => {
+  it("prints 'No outputs found.' instead of a stray blank line when the keys survive but renderOutputs collapses to an empty string", async () => {
+    // outputsByConstructId still has a "network" key, but every output under it is an undefined
+    // leaf (dropped upstream), so renderOutputs(outputs) returns "" even though
+    // Object.keys(outputs).length > 0 - the regression case for the stray-blank-line bug.
+    const outputsByConstructId = {
+      network: {
+        public_ipv4_address: undefined,
+      },
+    };
+    mockRunCdktfProject.mockImplementation(async () => ({
+      returnValue: undefined,
+      project: { outputsByConstructId },
+    }));
+    const onOutputsRetrieved = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    await expect(
+      runDeploy({ ...baseConfig, onOutputsRetrieved } as any),
+    ).resolves.toBeUndefined();
+
+    const printed = logSpy.mock.calls.map((call) => call[0]);
+    expect(printed).toContain("No outputs found.");
+    expect(printed).not.toContain("");
+
+    logSpy.mockRestore();
+  });
+});
+
 describe("runDeploy output rendering is non-fatal", () => {
   const outputsByConstructId = {
     db: { host: { sensitive: false, type: "string", value: "db.example.com" } },

--- a/packages/cdktn-cli/src/bin/cmds/ui/__tests__/deploy.test.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/__tests__/deploy.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
+import stripAnsi from "strip-ansi";
 import { PROMPT_NEEDS_TTY } from "../../helper/prompts";
 
 // Mock the prompts module so we can control what promptApprove / promptOverride throw.
@@ -22,11 +23,13 @@ jest.mock("../../helper/project-runner", () => ({
     mockRunCdktfProject(opts, cb),
 }));
 
-// Suppress noise from the StreamRenderer in unit tests.
+// Suppress noise from the StreamRenderer in unit tests, but keep a handle on `stop` so tests can
+// assert it always runs regardless of which path (fatal save error / non-fatal render error) is hit.
+const mockStreamStop = jest.fn();
 jest.mock("../../helper/tty-stream", () => ({
   StreamRenderer: jest.fn().mockImplementation(() => ({
     start: jest.fn(),
-    stop: jest.fn(),
+    stop: mockStreamStop,
     setBar: jest.fn(),
     clearBar: jest.fn(),
     appendLog: jest.fn(),
@@ -34,6 +37,18 @@ jest.mock("../../helper/tty-stream", () => ({
     resume: jest.fn(),
   })),
 }));
+
+// renderOutputs defaults to the real implementation; individual tests override it via
+// mockRenderOutputs.mockImplementationOnce(...) to simulate a rendering failure.
+const actualFormat = jest.requireActual("../../helper/format");
+const mockRenderOutputs = jest.fn(actualFormat.renderOutputs);
+jest.mock("../../helper/format", () => {
+  const actual = jest.requireActual("../../helper/format");
+  return {
+    ...actual,
+    renderOutputs: (...args: unknown[]) => mockRenderOutputs(...args),
+  };
+});
 
 import { runDeploy } from "../deploy";
 
@@ -48,6 +63,9 @@ beforeEach(() => {
   mockPromptApprove.mockReset();
   mockPromptOverride.mockReset();
   mockRunCdktfProject.mockReset();
+  mockStreamStop.mockReset();
+  mockRenderOutputs.mockReset();
+  mockRenderOutputs.mockImplementation(actualFormat.renderOutputs);
 });
 
 describe("runDeploy approval routing", () => {
@@ -141,6 +159,78 @@ describe("runDeploy approval routing", () => {
     expect(errSpy).toHaveBeenCalledWith(
       expect.stringContaining("Approval prompt cancelled"),
     );
+    errSpy.mockRestore();
+  });
+});
+
+describe("runDeploy output rendering", () => {
+  it("prints without throwing for a two-stack outputsByConstructId containing an undefined leaf", async () => {
+    // Regression case: a metadata-declared output that terraform did not return survives as an
+    // `undefined` leaf inside one stack's nested outputs (mixed with resolved outputs), which
+    // used to crash renderOutputs()/console.log() after both stacks had already deployed
+    // successfully.
+    const outputsByConstructId = {
+      network: {
+        ipv6_app_address: { sensitive: false, type: "string", value: "::1" },
+        public_ipv4_address: undefined,
+      },
+      db: {
+        host: { sensitive: false, type: "string", value: "db.example.com" },
+        port: { sensitive: false, type: "string", value: "5432" },
+      },
+    };
+    mockRunCdktfProject.mockImplementation(async () => ({
+      returnValue: undefined,
+      project: { outputsByConstructId },
+    }));
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const onOutputsRetrieved = jest.fn();
+    await expect(
+      runDeploy({ ...baseConfig, onOutputsRetrieved } as any),
+    ).resolves.not.toThrow();
+    expect(onOutputsRetrieved).toHaveBeenCalledWith(outputsByConstructId);
+    const printed = stripAnsi(
+      logSpy.mock.calls.map((call) => call[0]).join("\n"),
+    );
+    expect(printed).toContain("ipv6_app_address = ::1");
+    expect(printed).toContain("host = db.example.com");
+    logSpy.mockRestore();
+  });
+});
+
+describe("runDeploy output rendering is non-fatal", () => {
+  const outputsByConstructId = {
+    db: { host: { sensitive: false, type: "string", value: "db.example.com" } },
+  };
+
+  beforeEach(() => {
+    mockRunCdktfProject.mockImplementation(async () => ({
+      returnValue: undefined,
+      project: { outputsByConstructId },
+    }));
+  });
+
+  it("does not fail the deploy when rendering the outputs throws", async () => {
+    mockRenderOutputs.mockImplementationOnce(() => {
+      throw new Error("render boom");
+    });
+    const onOutputsRetrieved = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      runDeploy({ ...baseConfig, onOutputsRetrieved } as any),
+    ).resolves.toBeUndefined();
+
+    expect(onOutputsRetrieved).toHaveBeenCalledWith(outputsByConstructId);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Deploy succeeded, but rendering the outputs failed",
+      ),
+    );
+    expect(mockStreamStop).toHaveBeenCalledTimes(1);
+
+    logSpy.mockRestore();
     errSpy.mockRestore();
   });
 });

--- a/packages/cdktn-cli/src/bin/cmds/ui/deploy.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/deploy.ts
@@ -162,23 +162,35 @@ export async function runDeploy({
 
     onOutputsRetrieved(outputs);
 
-    if (outputs && Object.keys(outputs).length > 0) {
-      try {
-        console.log(renderOutputs(outputs));
-      } catch (e) {
-        // The deploy already succeeded at this point; a failure rendering the outputs table is
-        // purely cosmetic and must not fail the deploy. Log it so the user still learns something
-        // went wrong, but do not rethrow.
-        console.error(
-          `\nDeploy succeeded, but rendering the outputs failed: ${
-            e instanceof Error ? e.message : e
-          }`,
-        );
-      }
+    let rendered = "";
+    let renderFailed = false;
+    try {
+      rendered = outputs ? renderOutputs(outputs) : "";
+    } catch (e) {
+      // The deploy already succeeded at this point; a failure rendering the outputs table is
+      // purely cosmetic and must not fail the deploy. Log it so the user still learns something
+      // went wrong, but do not rethrow.
+      console.error(
+        `\nDeploy succeeded, but rendering the outputs failed: ${
+          e instanceof Error ? e.message : e
+        }`,
+      );
+      renderFailed = true;
+    }
+
+    if (rendered) {
+      console.log(rendered);
+    }
+
+    if (rendered || renderFailed) {
       if (outputsPath) {
         console.log(`The outputs have been written to ${outputsPath}`);
       }
     } else {
+      // Either there were no declared outputs at all, or every one of them was dropped upstream
+      // (e.g. all missing from `terraform output`, the empty-group case renderOutputs collapses
+      // to ""). Either way there is nothing to show the user, so say so plainly instead of
+      // printing a stray blank line.
       console.log("No outputs found.");
     }
   } finally {

--- a/packages/cdktn-cli/src/bin/cmds/ui/deploy.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/deploy.ts
@@ -40,7 +40,8 @@ export interface DeployConfig {
  * @param config - All deploy options, forwarded near-verbatim to `CdktfProject.deploy`. `onOutputsRetrieved` is
  *                 invoked once the run completes (or is stopped) with the final outputs map.
  * @returns Promise that resolves when the deploy completes, is stopped, or is dismissed. Rejects with whatever
- *          cli-core rejects with for real failures (terraform error, abort signal, etc.).
+ *          cli-core rejects with for real failures (terraform error, abort signal, etc.). A failure *rendering*
+ *          the fetched outputs is non-fatal and does not cause a rejection.
  */
 export async function runDeploy({
   outDir,
@@ -158,10 +159,22 @@ export async function runDeploy({
     );
 
     const outputs = project.outputsByConstructId;
+
     onOutputsRetrieved(outputs);
 
     if (outputs && Object.keys(outputs).length > 0) {
-      console.log(renderOutputs(outputs));
+      try {
+        console.log(renderOutputs(outputs));
+      } catch (e) {
+        // The deploy already succeeded at this point; a failure rendering the outputs table is
+        // purely cosmetic and must not fail the deploy. Log it so the user still learns something
+        // went wrong, but do not rethrow.
+        console.error(
+          `\nDeploy succeeded, but rendering the outputs failed: ${
+            e instanceof Error ? e.message : e
+          }`,
+        );
+      }
       if (outputsPath) {
         console.log(`The outputs have been written to ${outputsPath}`);
       }


### PR DESCRIPTION
### Related issue

No GitHub issue — this was reported by a user through **Sentry (CDKTN-5)** on `cdktn-cli 0.24.0`, not filed as an issue. Happy to open one retroactively if you'd prefer the paper trail.

Related: #361 — the top-level `.fail()` handler is the common exit path that turned this throw into an unhandled rejection with a stack trace. Deliberately **not** fixed here; it deserves its own PR and a regression test.

### Description

A user's `cdktn deploy` applied both stacks successfully and then crashed:

```
TypeError: Cannot convert undefined or null to object
    at Object.entries (<anonymous>)
    at renderNested (helper/format.ts:126)   <- twice, nested
    at renderOutputs (helper/format.ts:142)
    at runDeploy (ui/deploy.ts:164)
```

#### Root cause

`getConstructIdsForOutputs` maps synth metadata (`cdk.tf.json` → `"//".outputs`) onto the real
`terraform output -json` result with an unchecked lookup:

```ts
return { ...acc, [key]: outputs[value] };   // undefined when terraform didn't return it
```

An output declared in metadata but **absent** from terraform's result was retained with value `undefined`.
`isObjectEmpty` only drops a group where *every* output is missing, so a **partial** miss survived. `renderNested`
then reached that node — `isTerraformOutput(undefined)` is `false`, control fell through, and
`Object.entries(undefined)` threw.

The two nested `renderNested` frames put the bad value at `outputsByConstructId[stack][constructId]`, depth 1,
which matches. The reporter's `network` stack mixed user outputs with generated `cross-stack-output-*` entries
feeding a dependent `db` stack — a realistic way to get a partial miss (state drift, `--skip-synth`, an output
renamed or removed between applies).

#### Why the debug log looked healthy

The logged `OutputsByConstructId` appeared complete, which initially looked like it contradicted the theory. It
doesn't: those lines log via `JSON.stringify`, which silently omits `undefined`-valued keys. The poison map and a
clean map serialize **byte-identically** — verified — while `Object.keys` reveals the extra key. The defect was
structurally invisible in the logs.

#### Why it surfaced in 0.24.0

The defective data path is unchanged since before v0.23 (`git diff v0.23.4..v0.24.0` on `output.ts` is a single
unrelated zod line). What changed is #264, which removed `renderInk` — whose `try/catch` used to swallow this
throw as a one-line message and `exit(1)`. Without it the throw escapes unhandled, so a long-latent bug now
produces a stack trace, telemetry and a Sentry report. **An exposure regression, not a new defect.**

#### The fix — producer first, with defence in depth

- **`getConstructIdsForOutputs`** omits keys whose terraform output is absent, and logs which one was dropped.
  The check is an explicit `=== undefined`, *not* a truthiness test, so an output whose legitimate value is
  `""`, `0` or `false` still renders.
- **`renderNested` and `unpackTerraformOutput`** skip non-object nodes instead of recursing into
  `Object.entries`. These are deliberately defensive: with the producer fixed there is no *known* input that
  reaches them, but both walk externally-sourced data and neither should be able to take down the CLI after a
  successful deploy. `unpackTerraformOutput` is the one that runs first on the `--outputs-file` path.
- **`isTerraformOutput`** excludes `null`, which previously threw on `null.sensitive` rather than returning `false`.
- **Rendering the outputs table is now non-fatal** in `runDeploy`. The deploy has already succeeded by that
  point, so a presentation failure is logged instead of failing the deploy — restoring the safety net that
  deleting `renderInk` removed.

#### Behaviour note

`renderNested` now renders nothing for a group whose children all drop, and for a legitimately empty group,
where it previously printed a bare header.

#### Verification

The new tests were checked against the **unfixed** code, not just the fixed code: reverting the source changes
while keeping the tests reproduces the exact reported `TypeError`, with the same nested `renderNested` frames,
end-to-end through the real `runDeploy`. Assertions use `not.toHaveProperty` rather than `toEqual`, since
`toEqual` treats a missing key and an `undefined` value as equal and would pass on the buggy code.

---

#### Stacked PR

#376 builds on this branch and fixes a **separate** crash on the `--outputs-file` path found during review of
this change. It is deliberately split out — the reporter never passed `--outputs-file`, so none of it is on this
crash's path.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable — n/a, no documented behaviour changes
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
