### PR TITLE
fix(tests): drop unused ts-jest transform from shared jest preset

### DIFF
--- a/jest.preset.js
+++ b/jest.preset.js
@@ -10,6 +10,7 @@ process.env.CHECKPOINT_DISABLE = '1';
 
 module.exports = {
   ...nxPreset,
+  transform: {},
   testEnvironment: 'node',
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   testMatch: ['**/*.test.ts', '**/*.test.tsx'],


### PR DESCRIPTION
nxPreset registers a ts-jest transform, but every project in this workspace overrides it with its own @swc/jest transform, so the entry is resolved by jest at startup yet never executed. ts-jest is not a dependency of any of these projects — it is only pulled in transitively by one example's devDependencies — so any install that does not include that example (e.g. `pnpm install --filter "cdktn-cli..."`) makes every test run fail at config load with "Module ts-jest in the transform option was not found".

Override the inherited transform with an empty map; each project supplies its own.

<!--

Unless this is a very simple 1-line-of-code change, please create a new issue describing the change you're proposing first, then link to it from this PR.

Read more about our process in our contributing guide: https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md

-->

### Related issue

Fixes #381

### Description

Make the jest.preset.js transform an empty map.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas - n/a, the change is too small to need it
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable - n/a, none needed
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable - n/a, this is tested by existing tests passing when using --filter
- [x] New and existing unit tests pass locally with my changes

<!-- If this is still a work in progress, feel free to open a draft PR until you're able to check off all the items on the list above -->
