### PR TITLE
fix(provider-generator): satisfy module provider configuration aliases on get

### DIFF
--- a/packages/@cdktn/commons/src/util.ts
+++ b/packages/@cdktn/commons/src/util.ts
@@ -116,7 +116,8 @@ export async function mkdtemp(closure: (dir: string) => Promise<void>) {
  * @param command the executable to spawn
  * @param args arguments passed to the executable
  * @param options spawn options; `noColor: true` strips ANSI escapes from captured output (auto-detected from CLI flags
- *  / `FORCE_COLOR=0` when omitted)
+ *  / `FORCE_COLOR=0` when omitted); `logStderrAsDebug: true` tees stderr to `processLoggerDebug` instead, for runs
+ *  whose diagnostics are not final and would only alarm the reader
  * @param stdout optional per-chunk callback for sanitized stdout
  * @param stderr optional per-chunk callback for sanitized stderr; passing a callback suppresses default terminal echo
  * @param sendToStderr when false, suppresses both the stderr callback invocation and the default terminal echo
@@ -125,7 +126,7 @@ export async function mkdtemp(closure: (dir: string) => Promise<void>) {
 export const exec = async (
   command: string,
   args: string[],
-  options: SpawnOptions & { noColor?: boolean },
+  options: SpawnOptions & { noColor?: boolean; logStderrAsDebug?: boolean },
   stdout?: (chunk: string) => any,
   stderr?: (chunk: string | Uint8Array) => any,
   sendToStderr = true,
@@ -138,7 +139,9 @@ export const exec = async (
 
   // Drop spawn's `signal` option: the child already gets the interrupt via the process group, and a second signal
   // aborts terraform's graceful shutdown. Just wait for its own "close".
-  const { signal: _signal, ...spawnOptions } = options;
+  const { signal: _signal, logStderrAsDebug, ...spawnOptions } = options;
+
+  const logStderr = logStderrAsDebug ? processLoggerDebug : processLoggerError;
 
   return new Promise((ok, ko) => {
     const child = spawn(command, args, spawnOptions);
@@ -167,7 +170,7 @@ export const exec = async (
         const sanitizedChunk = options.noColor
           ? stripAnsi(chunk.toLocaleString())
           : chunk.toLocaleString();
-        processLoggerError(sanitizedChunk);
+        logStderr(sanitizedChunk);
         if (sendToStderr) {
           stderr(sanitizedChunk);
         }
@@ -178,7 +181,7 @@ export const exec = async (
         const sanitizedChunk = options.noColor
           ? stripAnsi(chunk.toLocaleString())
           : chunk.toLocaleString();
-        processLoggerError(sanitizedChunk);
+        logStderr(sanitizedChunk);
         if (sendToStderr) {
           process.stderr.write(sanitizedChunk);
         }

--- a/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
+++ b/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
@@ -30,6 +30,29 @@ exports[`readSchema generates a local json module 1`] = `
 }"
 `;
 
+exports[`readSchema generates a local json module that requires provider configuration aliases 1`] = `
+"{
+  "format_version": "STUBBED VERSION",
+  "local_module": {
+    "inputs": [
+      {
+        "default": "module",
+        "description": "Name of the DigitalOcean static site",
+        "name": "name",
+        "required": false,
+        "type": "any"
+      }
+    ],
+    "name": "local_module",
+    "outputs": [
+      {
+        "name": "uri"
+      }
+    ]
+  }
+}"
+`;
+
 exports[`readSchema generates a local module 1`] = `
 "{
   "format_version": "STUBBED VERSION",

--- a/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
+++ b/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
@@ -68,6 +68,29 @@ exports[`readSchema generates a local module 1`] = `
 }"
 `;
 
+exports[`readSchema generates a local module that requires provider configuration aliases 1`] = `
+"{
+  "format_version": "STUBBED VERSION",
+  "local_module": {
+    "inputs": [
+      {
+        "description": "Name of the s3 bucket. Must be unique.",
+        "name": "bucket_name",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "name": "local_module",
+    "outputs": [
+      {
+        "description": "ARN of the bucket",
+        "name": "arn"
+      }
+    ]
+  }
+}"
+`;
+
 exports[`readSchema generates a local module with inline comments in type constraints 1`] = `
 "{
   "format_version": "STUBBED VERSION",

--- a/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
+++ b/packages/@cdktn/provider-schema/src/__tests__/__snapshots__/provider-schema.test.ts.snap
@@ -91,6 +91,29 @@ exports[`readSchema generates a local module 1`] = `
 }"
 `;
 
+exports[`readSchema generates a local module that declares provider configuration aliases across .tf and .tf.json files 1`] = `
+"{
+  "format_version": "STUBBED VERSION",
+  "local_module": {
+    "inputs": [
+      {
+        "description": "Name of the s3 bucket. Must be unique.",
+        "name": "bucket_name",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "name": "local_module",
+    "outputs": [
+      {
+        "description": "ARN of the bucket",
+        "name": "arn"
+      }
+    ]
+  }
+}"
+`;
+
 exports[`readSchema generates a local module that requires provider configuration aliases 1`] = `
 "{
   "format_version": "STUBBED VERSION",

--- a/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-json-module-provider-aliases/module.tf.json
+++ b/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-json-module-provider-aliases/module.tf.json
@@ -1,0 +1,21 @@
+{
+  "terraform": {
+    "required_providers": {
+      "null": {
+        "source": "hashicorp/null",
+        "configuration_aliases": ["null.extra"]
+      }
+    }
+  },
+  "variable": {
+    "name": {
+      "default": "module",
+      "description": "Name of the DigitalOcean static site"
+    }
+  },
+  "output": {
+    "uri": {
+      "value": "${digitalocean_app.static_site}"
+    }
+  }
+}

--- a/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-mixed-module-provider-aliases/aliases.tf.json
+++ b/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-mixed-module-provider-aliases/aliases.tf.json
@@ -1,0 +1,10 @@
+{
+  "terraform": {
+    "required_providers": {
+      "null": {
+        "source": "hashicorp/null",
+        "configuration_aliases": ["null.extra"]
+      }
+    }
+  }
+}

--- a/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-mixed-module-provider-aliases/module.tf
+++ b/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-mixed-module-provider-aliases/module.tf
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# One half of a module that spreads its terraform settings across .tf and
+# .tf.json files. Terraform allows several terraform blocks but only one
+# required_providers configuration, so the provider requirements live in the
+# .tf.json half - which hcl2json merges into a shape that hides them from a
+# plain walk over the parsed terraform blocks.
+
+terraform {
+  required_version = ">= 1.0"
+}
+
+variable "bucket_name" {
+  description = "Name of the s3 bucket. Must be unique."
+  type        = string
+}
+
+output "arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.s3_bucket.arn
+}

--- a/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-module-provider-aliases/module.tf
+++ b/packages/@cdktn/provider-schema/src/__tests__/fixtures/local-module-provider-aliases/module.tf
@@ -1,0 +1,24 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# A module that expects its caller to hand it extra provider configurations,
+# the way multi-region AWS modules do.
+
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.global_region, aws.secondary_region]
+    }
+  }
+}
+
+variable "bucket_name" {
+  description = "Name of the s3 bucket. Must be unique."
+  type        = string
+}
+
+output "arn" {
+  description = "ARN of the bucket"
+  value       = aws_s3_bucket.s3_bucket.arn
+}

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
@@ -121,6 +121,21 @@ describe("readSchema", () => {
     const result = await readModuleSchema(target);
     expect(sanitizeJson(result)).toMatchSnapshot();
   }, 120000);
+
+  it("generates a local json module that requires provider configuration aliases", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(
+        __dirname,
+        "fixtures",
+        "local-json-module-provider-aliases",
+      ),
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(sanitizeJson(result)).toMatchSnapshot();
+  }, 120000);
 });
 
 describe("sanitizeProviderSchema", () => {

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
@@ -81,6 +81,36 @@ describe("readSchema", () => {
     expect(sanitizeJson(result)).toMatchSnapshot();
   }, 120000);
 
+  it("generates a local module that requires provider configuration aliases", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(
+        __dirname,
+        "fixtures",
+        "local-module-provider-aliases",
+      ),
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(sanitizeJson(result)).toMatchSnapshot();
+  }, 120000);
+
+  it("surfaces the terraform failure when a module cannot be fetched", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: "./this-module-does-not-exist",
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+
+    // the fetch is run tolerantly so a module declaring configuration_aliases
+    // gets a second chance - everything else has to keep failing loudly
+    await expect(readModuleSchema(target)).rejects.toThrow(
+      /get exited with code/,
+    );
+  }, 120000);
+
   it("generates a local json module", async () => {
     const module = new TerraformModuleConstraint({
       name: "local_module",

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.test.ts
@@ -136,6 +136,21 @@ describe("readSchema", () => {
     const result = await readModuleSchema(target);
     expect(sanitizeJson(result)).toMatchSnapshot();
   }, 120000);
+
+  it("generates a local module that declares provider configuration aliases across .tf and .tf.json files", async () => {
+    const module = new TerraformModuleConstraint({
+      name: "local_module",
+      fqn: "local_module",
+      source: path.resolve(
+        __dirname,
+        "fixtures",
+        "local-mixed-module-provider-aliases",
+      ),
+    });
+    const target = new ConstructsMakerModuleTarget(module, Language.TYPESCRIPT);
+    const result = await readModuleSchema(target);
+    expect(sanitizeJson(result)).toMatchSnapshot();
+  }, 120000);
 });
 
 describe("sanitizeProviderSchema", () => {

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
@@ -6,9 +6,18 @@ jest.mock("@cdktn/commons", () => ({
   exec: jest.fn(),
 }));
 
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
 import { exec } from "@cdktn/commons";
 import {
+  TerraformConfig,
+  applyModuleProviderAliases,
+  collectModuleProviderAliases,
+  fetchedModuleDir,
   getFetchingCliVersion,
+  packageSubdir,
   terraformInitWithRetry,
 } from "../provider-schema";
 
@@ -93,5 +102,226 @@ describe("getFetchingCliVersion", () => {
     expect(first).toEqual({ name: "terraform", version: "1.7.5" });
     expect(second).toBe(first);
     expect(execMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("collectModuleProviderAliases", () => {
+  it("returns nothing for a module without required_providers", () => {
+    expect(collectModuleProviderAliases({ variable: { foo: [{}] } })).toEqual(
+      [],
+    );
+  });
+
+  it("returns nothing for required providers without configuration aliases", () => {
+    const parsed = {
+      terraform: [
+        { required_providers: [{ aws: { source: "hashicorp/aws" } }] },
+      ],
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([]);
+  });
+
+  it("collects every alias declared across terraform blocks", () => {
+    const parsed = {
+      terraform: [
+        {
+          required_providers: [
+            {
+              aws: {
+                source: "hashicorp/aws",
+                configuration_aliases: [
+                  "${aws.global_region}",
+                  "${aws.secondary}",
+                ],
+              },
+              random: { source: "hashicorp/random" },
+            },
+          ],
+        },
+        {
+          required_providers: [
+            {
+              awsx: {
+                source: "hashicorp/aws",
+                configuration_aliases: ["${awsx.tertiary}"],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([
+      { localName: "aws", alias: "global_region", source: "hashicorp/aws" },
+      { localName: "aws", alias: "secondary", source: "hashicorp/aws" },
+      { localName: "awsx", alias: "tertiary", source: "hashicorp/aws" },
+    ]);
+  });
+
+  it("deduplicates aliases declared in more than one file", () => {
+    const declaration = {
+      aws: {
+        source: "hashicorp/aws",
+        configuration_aliases: ["${aws.global_region}"],
+      },
+    };
+    const parsed = {
+      terraform: [{ required_providers: [declaration, declaration] }],
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([
+      { localName: "aws", alias: "global_region", source: "hashicorp/aws" },
+    ]);
+  });
+
+  it("keeps aliases of providers declared without a source", () => {
+    const parsed = {
+      terraform: {
+        required_providers: {
+          aws: { configuration_aliases: ["${aws.other}"] },
+        },
+      },
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([
+      { localName: "aws", alias: "other", source: undefined },
+    ]);
+  });
+});
+
+describe("applyModuleProviderAliases", () => {
+  const configWithModule = (): TerraformConfig => ({
+    terraform: {},
+    module: { my_module: { source: "./mod" } },
+  });
+
+  it("declares the aliased providers and passes them to the module", () => {
+    const config = applyModuleProviderAliases(configWithModule(), "my_module", [
+      { localName: "aws", alias: "global_region", source: "hashicorp/aws" },
+      { localName: "aws", alias: "secondary", source: "hashicorp/aws" },
+    ]);
+
+    expect(config).toEqual({
+      terraform: { required_providers: { aws: { source: "hashicorp/aws" } } },
+      provider: { aws: [{ alias: "global_region" }, { alias: "secondary" }] },
+      module: {
+        my_module: {
+          source: "./mod",
+          providers: {
+            "aws.global_region": "aws.global_region",
+            "aws.secondary": "aws.secondary",
+          },
+        },
+      },
+    });
+  });
+
+  it("omits required_providers for aliases without a declared source", () => {
+    const config = applyModuleProviderAliases(configWithModule(), "my_module", [
+      { localName: "aws", alias: "other" },
+    ]);
+
+    expect(config.terraform.required_providers).toBeUndefined();
+    expect(config.provider).toEqual({ aws: [{ alias: "other" }] });
+  });
+
+  it("leaves the config untouched when there are no aliases", () => {
+    expect(
+      applyModuleProviderAliases(configWithModule(), "my_module", []),
+    ).toEqual(configWithModule());
+  });
+
+  it("leaves the config untouched when the module call is unknown", () => {
+    expect(
+      applyModuleProviderAliases(configWithModule(), "other_module", [
+        { localName: "aws", alias: "global_region" },
+      ]),
+    ).toEqual(configWithModule());
+  });
+});
+
+describe("packageSubdir", () => {
+  it.each([
+    ["terraform-aws-modules/iam/aws", undefined],
+    [
+      "terraform-aws-modules/iam/aws//modules/iam-account",
+      "modules/iam-account",
+    ],
+    ["git::https://github.com/org/repo.git//sub?ref=v1.2.3", "sub"],
+    ["git::ssh://git@github.com/org/repo.git", undefined],
+    ["./local/module", undefined],
+  ])("splits %s", (source, expected) => {
+    expect(packageSubdir(source as string)).toEqual(expected);
+  });
+});
+
+describe("fetchedModuleDir", () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = fs.mkdtempSync(path.join(os.tmpdir(), "fetched-module-dir-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(workdir, { recursive: true, force: true });
+  });
+
+  function writeManifest(modules: { Key: string; Dir: string }[]) {
+    const dir = path.join(workdir, ".terraform", "modules");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "modules.json"),
+      JSON.stringify({ Modules: modules }),
+    );
+  }
+
+  it("prefers the directory recorded in the module manifest", () => {
+    writeManifest([
+      { Key: "", Dir: "." },
+      { Key: "my_module", Dir: ".terraform/modules/my_module/modules/sub" },
+    ]);
+
+    expect(
+      fetchedModuleDir(workdir, "my_module", "org/name/aws//modules/sub"),
+    ).toEqual(
+      path.join(
+        workdir,
+        ".terraform",
+        "modules",
+        "my_module",
+        "modules",
+        "sub",
+      ),
+    );
+  });
+
+  it("falls back to the install path when the manifest was not written", () => {
+    expect(
+      fetchedModuleDir(workdir, "my_module", "org/name/aws//modules/sub"),
+    ).toEqual(
+      path.join(
+        workdir,
+        ".terraform",
+        "modules",
+        "my_module",
+        "modules",
+        "sub",
+      ),
+    );
+  });
+
+  it("falls back to the install path when the manifest lacks the module", () => {
+    writeManifest([{ Key: "", Dir: "." }]);
+
+    expect(fetchedModuleDir(workdir, "my_module", "org/name/aws")).toEqual(
+      path.join(workdir, ".terraform", "modules", "my_module"),
+    );
+  });
+
+  it("reads local modules where they are", () => {
+    expect(
+      fetchedModuleDir(workdir, "my_module", "../mod", "/abs/path/to/mod"),
+    ).toEqual("/abs/path/to/mod");
   });
 });

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
@@ -188,6 +188,37 @@ describe("collectModuleProviderAliases", () => {
       { localName: "aws", alias: "other", source: undefined },
     ]);
   });
+
+  it("reads the plain references a .tf.json module declares", () => {
+    // hcl2json only wraps HCL expressions in an interpolation; JSON syntax
+    // carries the reference as-is, and its blocks come through unwrapped
+    const parsed = {
+      terraform: {
+        required_providers: {
+          null: {
+            source: "hashicorp/null",
+            configuration_aliases: ["null.extra"],
+          },
+        },
+      },
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([
+      { localName: "null", alias: "extra", source: "hashicorp/null" },
+    ]);
+  });
+
+  it("ignores entries that are not provider configuration references", () => {
+    const parsed = {
+      terraform: {
+        required_providers: {
+          aws: { configuration_aliases: ["${aws}", "${var.not_an_alias.x}"] },
+        },
+      },
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([]);
+  });
 });
 
 describe("applyModuleProviderAliases", () => {

--- a/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
+++ b/packages/@cdktn/provider-schema/src/__tests__/provider-schema.unit.test.ts
@@ -208,6 +208,27 @@ describe("collectModuleProviderAliases", () => {
     ]);
   });
 
+  it("reads aliases a module spread across .tf and .tf.json files", () => {
+    // hcl2json merges a .tf.json file into the parsed HCL by recursing into
+    // the HCL block array, so the JSON half ends up as a named property on
+    // that array rather than another entry in it
+    const parsed: any = {
+      terraform: [
+        { required_providers: [{ aws: { source: "hashicorp/aws" } }] },
+      ],
+    };
+    parsed.terraform.required_providers = {
+      null: {
+        source: "hashicorp/null",
+        configuration_aliases: ["null.extra"],
+      },
+    };
+
+    expect(collectModuleProviderAliases(parsed)).toEqual([
+      { localName: "null", alias: "extra", source: "hashicorp/null" },
+    ]);
+  });
+
   it("ignores entries that are not provider configuration references", () => {
     const parsed = {
       terraform: {

--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -269,13 +269,21 @@ function joinWithAnd(items: string[]): string {
 }
 
 export interface TerraformConfig {
-  provider?: { [name: string]: Record<string, any> };
+  // a list holds several configurations of the same provider, which is how
+  // aliased provider blocks are expressed in JSON syntax
+  provider?: { [name: string]: Record<string, any> | Record<string, any>[] };
   terraform: {
     required_providers?: {
       [name: string]: { source?: string; version?: string };
     };
   };
-  module?: { [name: string]: { source: string; version?: string } };
+  module?: {
+    [name: string]: {
+      source: string;
+      version?: string;
+      providers?: { [localName: string]: string };
+    };
+  };
 }
 
 export async function readProviderSchema(
@@ -431,6 +439,205 @@ export function sanitizeProviderSchema(schema: ProviderSchema): ProviderSchema {
   return schema;
 }
 
+/**
+ * A provider configuration that a module expects to be handed by its caller,
+ * declared as `configuration_aliases` in the module's `required_providers`.
+ */
+export interface ModuleProviderAlias {
+  /** local name the module knows the provider by, e.g. `aws` */
+  localName: string;
+  /** alias part of the reference, e.g. `global_region` */
+  alias: string;
+  /** provider source the module declared for `localName`, if it declared one */
+  source?: string;
+}
+
+// hcl2json hands expressions back as interpolations, so a
+// `configuration_aliases = [aws.global_region]` entry arrives as the string
+// "${aws.global_region}".
+const CONFIGURATION_ALIAS = /^\$\{([\w-]+)\.([\w-]+)\}$/;
+
+const toArray = <T>(item: T | T[] | undefined | null): T[] => {
+  if (item === undefined || item === null) return [];
+  return Array.isArray(item) ? item : [item];
+};
+
+/**
+ * Collects the provider configurations a module requires its caller to pass
+ * in, from the hcl2json representation of the module's directory.
+ *
+ * hcl2json represents every block as an array (one entry per occurrence
+ * across the module's files), so a module may declare `required_providers` in
+ * more than one `terraform` block; all of them are considered.
+ *
+ * @internal exposed for testing
+ */
+export function collectModuleProviderAliases(
+  parsedModule: any,
+): ModuleProviderAlias[] {
+  const aliases: ModuleProviderAlias[] = [];
+  const seen = new Set<string>();
+
+  for (const terraformBlock of toArray(parsedModule?.terraform)) {
+    for (const requiredProviders of toArray(
+      terraformBlock?.required_providers,
+    )) {
+      for (const declaration of Object.values(requiredProviders || {})) {
+        const provider = unwrapIfArray(declaration as any);
+
+        for (const entry of toArray(provider?.configuration_aliases)) {
+          const match = CONFIGURATION_ALIAS.exec(String(entry));
+          if (!match) continue;
+
+          const [, localName, alias] = match;
+          const key = `${localName}.${alias}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+
+          aliases.push({ localName, alias, source: provider?.source });
+        }
+      }
+    }
+  }
+
+  return aliases;
+}
+
+/**
+ * Declares the provider configurations that `aliases` names on the synthetic
+ * root config and passes them into the module call, which is what Terraform
+ * demands of anyone calling a module with `configuration_aliases`.
+ *
+ * The alias blocks stay empty: `terraform get` only builds the configuration
+ * tree, it never configures or installs a provider. Sources are mirrored from
+ * the module's own `required_providers` so a module referring to, say,
+ * hashicorp/aws under a non-default local name still resolves to the same
+ * provider in the root.
+ *
+ * @internal exposed for testing
+ */
+export function applyModuleProviderAliases(
+  config: TerraformConfig,
+  moduleKey: string,
+  aliases: ModuleProviderAlias[],
+): TerraformConfig {
+  const moduleCall = config.module?.[moduleKey];
+  if (!moduleCall || aliases.length === 0) return config;
+
+  for (const { localName, alias, source } of aliases) {
+    if (source) {
+      config.terraform.required_providers = {
+        ...config.terraform.required_providers,
+        [localName]: { source },
+      };
+    }
+
+    config.provider = config.provider || {};
+    const blocks = toArray(config.provider[localName]);
+    if (!blocks.some((block) => block.alias === alias)) {
+      blocks.push({ alias });
+    }
+    config.provider[localName] = blocks;
+
+    moduleCall.providers = {
+      ...moduleCall.providers,
+      [`${localName}.${alias}`]: `${localName}.${alias}`,
+    };
+  }
+
+  return config;
+}
+
+/**
+ * The `//subdir` portion of a module source, if it has one, mirroring how
+ * Terraform unpacks a package into `.terraform/modules/<key>/<subdir>`.
+ *
+ * @internal exposed for testing
+ */
+export function packageSubdir(source: string): string | undefined {
+  const [withoutQuery] = source.split("?");
+  const withoutGetterPrefix = withoutQuery.replace(/^[A-Za-z0-9]+::/, "");
+  const withoutScheme = withoutGetterPrefix.replace(
+    /^[A-Za-z][A-Za-z0-9+.-]*:\/\/+/,
+    "",
+  );
+
+  const [, ...rest] = withoutScheme.split("//");
+  const subdir = rest.join("//").replace(/^\/+|\/+$/g, "");
+  return subdir || undefined;
+}
+
+/**
+ * Where the module Terraform just fetched ended up on disk.
+ *
+ * The manifest is the authority, but a `terraform get` that installed the
+ * module and then failed to validate the configuration around it leaves no
+ * manifest behind - so fall back to the locations Terraform installs into:
+ * local modules are read where they are, remote packages are unpacked into
+ * `.terraform/modules/<key>`.
+ *
+ * @internal exposed for testing
+ */
+export function fetchedModuleDir(
+  workingDirectory: string,
+  moduleKey: string,
+  source: string,
+  localSourceAbsolutePath?: string,
+): string {
+  const manifestPath = path.join(
+    workingDirectory,
+    ".terraform",
+    "modules",
+    "modules.json",
+  );
+
+  if (fs.existsSync(manifestPath)) {
+    const moduleIndex = JSON.parse(
+      fs.readFileSync(manifestPath, "utf-8"),
+    ) as ModuleIndex;
+    const record = moduleIndex.Modules.find((mod) => mod.Key === moduleKey);
+
+    if (record) {
+      return path.resolve(workingDirectory, record.Dir);
+    }
+  }
+
+  if (localSourceAbsolutePath) {
+    return localSourceAbsolutePath;
+  }
+
+  return path.join(
+    workingDirectory,
+    ".terraform",
+    "modules",
+    moduleKey,
+    packageSubdir(source) || "",
+  );
+}
+
+/**
+ * Runs `terraform get` and hands the failure back instead of throwing it.
+ *
+ * Its diagnostics are not final (see {@link readModuleSchema}), so they go to
+ * the debug log rather than the terminal; the returned error still carries
+ * them on its `stderr` for callers that end up rethrowing it.
+ */
+async function tryTerraformGet(outdir: string): Promise<Error | undefined> {
+  try {
+    await exec(
+      terraformBinaryName,
+      ["get"],
+      { cwd: outdir, logStderrAsDebug: true },
+      undefined,
+      undefined,
+      false,
+    );
+    return undefined;
+  } catch (error: any) {
+    return error;
+  }
+}
+
 export async function readModuleSchema(target: ConstructsMakerModuleTarget) {
   let moduleSchema: Record<string, ModuleSchema> = {};
 
@@ -458,7 +665,38 @@ export async function readModuleSchema(target: ConstructsMakerModuleTarget) {
     const filePath = path.join(outdir, "main.tf.json");
     await fs.writeFile(filePath, JSON.stringify(config));
 
-    await exec(terraformBinaryName, ["get"], { cwd: outdir });
+    // `terraform get` is both our downloader and a full validation of the
+    // synthetic root config wrapped around the module. A module declaring
+    // `configuration_aliases` cannot validate until the root passes those
+    // configurations in, and their names are only knowable once the module is
+    // on disk - so this first run is a fetch we defer judgement on. Terraform
+    // installs the module either way; since 1.15 it just stops short of
+    // writing the module manifest when validation fails (terraform#38217
+    // dropped the error-to-warning downgrade that `terraform get` used to
+    // apply), which is what the second run below restores.
+    const fetchError = await tryTerraformGet(outdir);
+
+    const moduleDir = fetchedModuleDir(
+      outdir,
+      target.moduleKey,
+      source,
+      localSource,
+    );
+    const aliases = fs.existsSync(moduleDir)
+      ? collectModuleProviderAliases(await convertFiles(moduleDir))
+      : [];
+
+    if (aliases.length > 0) {
+      applyModuleProviderAliases(config, target.moduleKey, aliases);
+      await fs.writeFile(filePath, JSON.stringify(config));
+      await exec(terraformBinaryName, ["get"], { cwd: outdir });
+    } else if (fetchError) {
+      // nothing here was salvageable after all, so report the diagnostics that
+      // were held back while the fetch still had a second chance
+      logger.error((fetchError as any).stderr || String(fetchError));
+      throw fetchError;
+    }
+
     if (config.module) {
       moduleSchema = await harvestModuleSchema(
         outdir,

--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -452,10 +452,14 @@ export interface ModuleProviderAlias {
   source?: string;
 }
 
-// hcl2json hands expressions back as interpolations, so a
+const CONFIGURATION_ALIAS = /^([\w-]+)\.([\w-]+)$/;
+
+// hcl2json hands HCL expressions back as interpolations, so a
 // `configuration_aliases = [aws.global_region]` entry arrives as the string
-// "${aws.global_region}".
-const CONFIGURATION_ALIAS = /^\$\{([\w-]+)\.([\w-]+)\}$/;
+// "${aws.global_region}". A .tf.json module writes the same reference as a
+// plain string, which hcl2json passes through untouched.
+const unwrapInterpolation = (value: string) =>
+  value.startsWith("${") && value.endsWith("}") ? value.slice(2, -1) : value;
 
 const toArray = <T>(item: T | T[] | undefined | null): T[] => {
   if (item === undefined || item === null) return [];
@@ -466,9 +470,11 @@ const toArray = <T>(item: T | T[] | undefined | null): T[] => {
  * Collects the provider configurations a module requires its caller to pass
  * in, from the hcl2json representation of the module's directory.
  *
- * hcl2json represents every block as an array (one entry per occurrence
+ * hcl2json represents every HCL block as an array (one entry per occurrence
  * across the module's files), so a module may declare `required_providers` in
- * more than one `terraform` block; all of them are considered.
+ * more than one `terraform` block; all of them are considered. Blocks read
+ * from a .tf.json module arrive unwrapped instead, and both shapes are
+ * handled here.
  *
  * @internal exposed for testing
  */
@@ -486,7 +492,9 @@ export function collectModuleProviderAliases(
         const provider = unwrapIfArray(declaration as any);
 
         for (const entry of toArray(provider?.configuration_aliases)) {
-          const match = CONFIGURATION_ALIAS.exec(String(entry));
+          const match = CONFIGURATION_ALIAS.exec(
+            unwrapInterpolation(String(entry)),
+          );
           if (!match) continue;
 
           const [, localName, alias] = match;

--- a/packages/@cdktn/provider-schema/src/provider-schema.ts
+++ b/packages/@cdktn/provider-schema/src/provider-schema.ts
@@ -467,14 +467,34 @@ const toArray = <T>(item: T | T[] | undefined | null): T[] => {
 };
 
 /**
+ * Every occurrence of a block that hcl2json produced under one key.
+ *
+ * HCL blocks come back as an array with an entry per occurrence, a .tf.json
+ * block as a plain object. A module mixing both syntaxes gets a third shape:
+ * hcl2json merges the JSON file into the parsed HCL, and its deepMerge
+ * recurses into the HCL array instead of appending to it, leaving the JSON
+ * contribution hanging off the array as named properties. Those properties
+ * are an occurrence of their own - and one that neither iterating the array
+ * nor JSON.stringify would ever show.
+ */
+const blockOccurrences = (block: any): any[] => {
+  if (block === undefined || block === null) return [];
+  if (!Array.isArray(block)) return [block];
+
+  const merged = Object.fromEntries(
+    Object.entries(block).filter(([key]) => !/^\d+$/.test(key)),
+  );
+
+  return Object.keys(merged).length > 0 ? [...block, merged] : [...block];
+};
+
+/**
  * Collects the provider configurations a module requires its caller to pass
  * in, from the hcl2json representation of the module's directory.
  *
- * hcl2json represents every HCL block as an array (one entry per occurrence
- * across the module's files), so a module may declare `required_providers` in
- * more than one `terraform` block; all of them are considered. Blocks read
- * from a .tf.json module arrive unwrapped instead, and both shapes are
- * handled here.
+ * A module may declare `required_providers` in more than one `terraform`
+ * block, and may spread them across .tf and .tf.json files; every occurrence
+ * hcl2json reports is considered (see {@link blockOccurrences}).
  *
  * @internal exposed for testing
  */
@@ -484,8 +504,8 @@ export function collectModuleProviderAliases(
   const aliases: ModuleProviderAlias[] = [];
   const seen = new Set<string>();
 
-  for (const terraformBlock of toArray(parsedModule?.terraform)) {
-    for (const requiredProviders of toArray(
+  for (const terraformBlock of blockOccurrences(parsedModule?.terraform)) {
+    for (const requiredProviders of blockOccurrences(
       terraformBlock?.required_providers,
     )) {
       for (const declaration of Object.values(requiredProviders || {})) {


### PR DESCRIPTION
Fixes #379

`cdktn get` fetches a module schema by writing a synthetic root config that calls the module and running `terraform get` in it. A module declaring `configuration_aliases` in its `required_providers` makes that root config invalid — Terraform demands the caller pass those configurations in — and `terraform get` used to downgrade the resulting error to a warning and write the module manifest anyway, which is what the fetch relied on.

Terraform 1.15 routed init and get through the graph-based install workflow ([hashicorp/terraform#38217](https://github.com/hashicorp/terraform/pull/38217)), which never reaches that downgrade (`installErrsOnly` no longer has any effect for `get`) and returns before writing the manifest. From 1.15.7 on, `cdktn get` therefore fails with "Missing required provider configuration" for any such module, and `.terraform/modules/modules.json` is never written, so the failure cannot simply be tolerated. OpenTofu still has the downgrade in both of its install paths and is unaffected.

## Approach

Read what the module actually declares rather than guessing up front or parsing the error text:

1. The first `terraform get` is treated as a fetch whose diagnostics are deferred. Terraform installs the module either way — it just skips the manifest.
2. The module's own `required_providers` block (parsed with the `hcl2json` call the harvest step already makes) says which aliased configurations are required.
3. Those are declared in the root config and passed to the module call, and a second `terraform get` produces the manifest.

Modules without `configuration_aliases` are unaffected, and a fetch that fails for any other reason still reports its original error.

Alternatives considered and rejected: parsing alias names out of the error prose (English-prose-dependent); reading them from the Terraform Registry API before fetching (`provider_dependencies` does not expose `configuration_aliases`, and it would not cover git or local sources); `terraform init -from-module` (skips validation entirely but takes no version argument, so registry modules cannot be pinned); version-gating on Terraform >= 1.15 (no benefit — the declaration-driven flow is version-agnostic and also silences the pre-1.15 warning).

`exec` gains a `logStderrAsDebug` option so the deferred fetch does not print an `[ERROR]` block that a following success contradicts. When the fetch turns out not to be salvageable, the held-back diagnostics are re-logged at error level before rethrowing, so that output is unchanged.

## Testing

- New `local-module-provider-aliases` fixture and snapshot test, a test that a genuinely unfetchable module still fails loudly, and unit tests for the new helpers.
- Full `@cdktn/provider-schema` suite passes against both Terraform 1.14.3 (which only warned) and 1.15.8 (which errors); the same suite fails on 1.15.8 without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
