### PR TITLE
chore(lib): stop publishing build state in the cdktn package

### DIFF
--- a/packages/cdktn/.npmignore
+++ b/packages/cdktn/.npmignore
@@ -14,3 +14,8 @@ coverage
 # full nested node_modules; if `npm pack` descends into it, npm aborts with
 # "Exit handler never called!" and the build fails.
 .pack-staging
+# Build state: jsii regenerates tsconfig.json, .tsbuildinfo embeds build-machine
+# paths.
+tsconfig.json
+tsconfig.test.json
+*.tsbuildinfo


### PR DESCRIPTION
### Related issue

No issue — noticed while investigating #373. Independent of #395/#396; based on `main`.

### Description

The published `cdktn` tarball carries three files that are build output rather than package content:

| file | why it should not ship |
| --- | --- |
| `tsconfig.json` | Generated by jsii on every build, and `.gitignore`'d for exactly that reason. Publishing it asserts compiler settings consumers should not adopt, and it tracks whichever jsii major built the release. |
| `tsconfig.test.json` | Extends the above and points at test sources the tarball does not ship, so it is dangling by construction. |
| `lib/tsconfig.tsbuildinfo` | Incremental-build state. Embeds absolute paths from the build machine, which also makes the tarball differ between builds of identical sources. |

`packages/cdktn/.npmignore` already excluded `*.ts`, `dist` and `coverage` — it simply had no entry for these. Worth noting for anyone tracing this: npm ignores `.gitignore` entirely once an `.npmignore` exists, which is why the `tsconfig.json` entry already present in `packages/cdktn/.gitignore` had no effect on packaging.

### Why this is safe

Nothing resolves a dependency's shipped tsconfig. jsii derives symbol ids from `jsii.tsc` in `package.json` and from the assembly metadata (`jsii/lib/common/symbol-id.js`), never from a tsconfig in the tarball — which is what made constructs 10.8.0 break when it dropped `jsii.tsc.outDir` from its `package.json`. A grep across `packages/`, `tools/` and `test/` finds no reader of a dependency's tsconfig.

Verified against the real packaging path (`scripts/pack.mjs`, not just `npm pack --dry-run`):

```
before: 269 files   offenders: lib/tsconfig.tsbuildinfo, tsconfig.json, tsconfig.test.json
after:  266 files   offenders: (none)
        lib/index.js ✓   lib/index.d.ts ✓   .jsii ✓
```

### Scope

Only `cdktn` is changed. The other published packages were checked:

- `@cdktn/cli-core` ships `templates/typescript/tsconfig.json`, which is the init template's config and **must** keep shipping.
- `@cdktn/hcl2cdk` and `@cdktn/provider-generator` ship their own checked-in `tsconfig.json`. Those are real source files, accurate for those packages, and neither has an `.npmignore` — adding one would override the `.gitignore` fallback and change what ships. Left alone deliberately.
- Every other package already excludes these.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
