### PR TITLE
fix(gha): don't fail the pnpm upgrade jobs on ignored dep builds

### DIFF
--- a/.github/workflows/pnpm-upgrade.yml
+++ b/.github/workflows/pnpm-upgrade.yml
@@ -56,9 +56,16 @@ jobs:
           ncu --upgrade --reject=@types/node,@types/fs-extra,constructs,typescript,@types/prettier --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
 
-      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
+      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run).
+      #
+      # An upgrade can pull in a new transitive dependency whose build script is not in
+      # `allowBuilds`, which pnpm reports as ERR_PNPM_IGNORED_BUILDS and treats as fatal.
+      # Whether to approve that build is a judgment call for whoever reviews the resulting
+      # diff, so failing here is the wrong place for it: it drops the whole upgrade PR and
+      # hides what the upgrade would have been. Downgrade it to a warning (still visible in
+      # this job's log) and let the PR's own `pnpm ci`, which stays strict, gate the merge.
       - name: Run "pnpm install"
-        run: pnpm install --prefer-offline --no-frozen-lockfile
+        run: pnpm install --prefer-offline --no-frozen-lockfile --config.strictDepBuilds=false
 
       # Next, create and upload the changes as a patch file. This will later be downloaded to create a pull request
       # Creating a pull request requires write permissions and it's best to keep write privileges isolated.
@@ -219,9 +226,16 @@ jobs:
             --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
 
-      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
+      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run).
+      #
+      # An upgrade can pull in a new transitive dependency whose build script is not in
+      # `allowBuilds`, which pnpm reports as ERR_PNPM_IGNORED_BUILDS and treats as fatal.
+      # Whether to approve that build is a judgment call for whoever reviews the resulting
+      # diff, so failing here is the wrong place for it: it drops the whole upgrade PR and
+      # hides what the upgrade would have been. Downgrade it to a warning (still visible in
+      # this job's log) and let the PR's own `pnpm ci`, which stays strict, gate the merge.
       - name: Run "pnpm install"
-        run: pnpm install --prefer-offline --no-frozen-lockfile
+        run: pnpm install --prefer-offline --no-frozen-lockfile --config.strictDepBuilds=false
 
       - name: Mint CDKTN maintainers App token
         id: app-token
@@ -300,9 +314,16 @@ jobs:
             --filter='jsii,jsii-pacmak,jsii-rosetta,jsii-docgen,codemaker,constructs' \
             --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
-      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
+      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run).
+      #
+      # An upgrade can pull in a new transitive dependency whose build script is not in
+      # `allowBuilds`, which pnpm reports as ERR_PNPM_IGNORED_BUILDS and treats as fatal.
+      # Whether to approve that build is a judgment call for whoever reviews the resulting
+      # diff, so failing here is the wrong place for it: it drops the whole upgrade PR and
+      # hides what the upgrade would have been. Downgrade it to a warning (still visible in
+      # this job's log) and let the PR's own `pnpm ci`, which stays strict, gate the merge.
       - name: Run "pnpm install"
-        run: pnpm install --prefer-offline --no-frozen-lockfile
+        run: pnpm install --prefer-offline --no-frozen-lockfile --config.strictDepBuilds=false
 
       - name: Mint CDKTN maintainers App token
         id: app-token

--- a/.github/workflows/pnpm-upgrade.yml
+++ b/.github/workflows/pnpm-upgrade.yml
@@ -56,14 +56,8 @@ jobs:
           ncu --upgrade --reject=@types/node,@types/fs-extra,constructs,typescript,@types/prettier --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
 
-      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run).
-      #
-      # An upgrade can pull in a new transitive dependency whose build script is not in
-      # `allowBuilds`, which pnpm reports as ERR_PNPM_IGNORED_BUILDS and treats as fatal.
-      # Whether to approve that build is a judgment call for whoever reviews the resulting
-      # diff, so failing here is the wrong place for it: it drops the whole upgrade PR and
-      # hides what the upgrade would have been. Downgrade it to a warning (still visible in
-      # this job's log) and let the PR's own `pnpm ci`, which stays strict, gate the merge.
+      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
+      # strictDepBuilds is relaxed so an unapproved dep build does not kill the PR (see #399)
       - name: Run "pnpm install"
         run: pnpm install --prefer-offline --no-frozen-lockfile --config.strictDepBuilds=false
 
@@ -226,14 +220,8 @@ jobs:
             --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
 
-      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run).
-      #
-      # An upgrade can pull in a new transitive dependency whose build script is not in
-      # `allowBuilds`, which pnpm reports as ERR_PNPM_IGNORED_BUILDS and treats as fatal.
-      # Whether to approve that build is a judgment call for whoever reviews the resulting
-      # diff, so failing here is the wrong place for it: it drops the whole upgrade PR and
-      # hides what the upgrade would have been. Downgrade it to a warning (still visible in
-      # this job's log) and let the PR's own `pnpm ci`, which stays strict, gate the merge.
+      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
+      # strictDepBuilds is relaxed so an unapproved dep build does not kill the PR (see #399)
       - name: Run "pnpm install"
         run: pnpm install --prefer-offline --no-frozen-lockfile --config.strictDepBuilds=false
 
@@ -314,14 +302,8 @@ jobs:
             --filter='jsii,jsii-pacmak,jsii-rosetta,jsii-docgen,codemaker,constructs' \
             --target=minor \
             --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
-      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run).
-      #
-      # An upgrade can pull in a new transitive dependency whose build script is not in
-      # `allowBuilds`, which pnpm reports as ERR_PNPM_IGNORED_BUILDS and treats as fatal.
-      # Whether to approve that build is a judgment call for whoever reviews the resulting
-      # diff, so failing here is the wrong place for it: it drops the whole upgrade PR and
-      # hides what the upgrade would have been. Downgrade it to a warning (still visible in
-      # this job's log) and let the PR's own `pnpm ci`, which stays strict, gate the merge.
+      # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
+      # strictDepBuilds is relaxed so an unapproved dep build does not kill the PR (see #399)
       - name: Run "pnpm install"
         run: pnpm install --prefer-offline --no-frozen-lockfile --config.strictDepBuilds=false
 


### PR DESCRIPTION
## What

The weekly [Pnpm Upgrade](https://github.com/open-constructs/cdk-terrain/actions/runs/34104925567) run failed in `Pnpm Upgrade Root`, on the lockfile refresh that follows `ncu -u`:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @parcel/watcher@2.6.0
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
##[error]Process completed with exit code 1
```

`@parcel/watcher` is not in our lockfile today — it was pulled in transitively by that run's bulk upgrade. Its build script is not in `allowBuilds`, so pnpm refused to run it (correct, and unchanged by this PR) and, with `strictDepBuilds` defaulting to on in pnpm 11, turned the refusal into a hard error.

## Why not just approve the build

`strictDepBuilds` doesn't control whether the script runs — pnpm had already refused. It only controls whether we're told. That notification is worth keeping: a package that genuinely needed its build fails later, somewhere unrelated-looking, and often on only one platform. Three of the four existing `allowBuilds` entries are native-binary packages for exactly that reason.

The problem is *where* it fires. A scheduled bot job holding `contents: read`, whose only output is a patch file, can't make the approve/decline call — that needs the diff that introduced the package. Failing there costs the entire upgrade PR and all visibility into what the upgrade contained.

## What this changes

Relaxes the setting for the three post-`ncu` lockfile-refresh installs only (`upgradeRoot`, `upgradePackage`, `upgradeJSII`). Untouched:

- the first `pnpm install` in each job, which installs from the committed lockfile and stays strict
- the `pnpm ci` in `build.yml` / `quality.yml`, so the upgrade PR's own CI still gates the merge

pnpm also records the pending decision itself, writing the package into `pnpm-workspace.yaml` as `'@parcel/watcher': set this to true or false`. The patch step now picks that up, so the decision arrives as a reviewable line in the upgrade PR instead of as a dead job. That placeholder is not treated as approval — a strict install keeps ignoring the build until it's set to `true` or `false`.

## Verification

Reproduced in a throwaway project pinned to the repo's `pnpm@11.5.2`:

| | exit | behaviour |
|---|---|---|
| default | 1 | `ERR_PNPM_IGNORED_BUILDS`, same as CI |
| `--config.strictDepBuilds=false` | 0 | still prints the ignored-builds warning |
| `allowBuilds: {'@parcel/watcher': false}` | 0 | silent; per-package opt-out |
| placeholder stub, strict | 1 | confirms the stub is not an approval |

Also checked the workflow still parses as YAML with all six install steps resolving as intended, and that `prettier --check` passes.

## Follow-up

No change to `pnpm-workspace.yaml` here — `main` has no `@parcel/watcher`, so there's nothing red today. The intent is to trigger the upgrade workflow once this merges and set the entry to `false` in the PR it produces (`@parcel/watcher` ships prebuilt binaries as per-platform optional deps; its `install` script is only the build-from-source fallback, so it doesn't need to run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
