### PR TITLE
test(tests): re-enable the Python edge integration test

### DIFF
--- a/test/python/edge/test.ts
+++ b/test/python/edge/test.ts
@@ -4,7 +4,7 @@ import { QueryableStack, TestDriver, onlyJson } from "../../test-helper";
 import * as path from "path";
 import * as fs from "fs-extra";
 
-describe.skip("full integration test", () => {
+describe("full integration test", () => {
   let driver: TestDriver;
 
   beforeAll(async () => {

--- a/test/python/edge/test.ts
+++ b/test/python/edge/test.ts
@@ -124,7 +124,7 @@ describe("full integration test", () => {
         "${list_block_resource.list.req[0].reqstr}",
       ]);
       expect(item.numList).toEqual([
-        "${element(list_block_resource.list.req, 0).reqnum)}",
+        "${element(list_block_resource.list.req, 0).reqnum}",
       ]);
     });
 
@@ -168,24 +168,16 @@ describe("full integration test", () => {
       const item = stack.byId("from_map");
 
       // Expands map references
-      expect(item.bool).toEqual(
-        '${lookup(map_resource.map.reqMap, "key1", false)}',
-      );
+      expect(item.bool).toEqual("${map_resource.map.reqMap.key1}");
       expect(item.str).toEqual(
         '${lookup(map_resource.map.optMap, "key1", "missing")}',
       );
-      expect(item.num).toEqual(
-        '${lookup(map_resource.map.computedMap, "key1", 0)}',
-      );
-      expect(item.boolList).toEqual([
-        '${lookup(map_resource.map.reqMap, "key1", false)}',
-      ]);
+      expect(item.num).toEqual("${map_resource.map.computedMap.key1}");
+      expect(item.boolList).toEqual(["${map_resource.map.reqMap.key1}"]);
       expect(item.strList).toEqual([
         '${lookup(map_resource.map.optMap, "key1", "missing")}',
       ]);
-      expect(item.numList).toEqual([
-        '${lookup(map_resource.map.computedMap, "key1", 0)}',
-      ]);
+      expect(item.numList).toEqual(["${map_resource.map.computedMap.key1}"]);
     });
 
     onlyJson("item references a full map", () => {


### PR DESCRIPTION
### Related issue

Follow-up from the review on #400, point 2. #400 is closed; this is the durable half of its regression coverage.

### Description

`test/python/edge/test.ts` has been `describe.skip`'d since 3acb935 (**1 December 2022**), waiting on [aws/jsii#3866](https://github.com/aws/jsii/pull/3866), with the stated intent to "re-add them when updating JSII". That fix shipped shortly after, and the JSII update has since landed (#395: jsii 6.0, jsii-pacmak 1.140.0) — but the skip was never lifted.

Python is the only language whose edge test does not run. TypeScript, Go, Java and C# all do.

That gap has a concrete cost: it is why #311's cross-language compile coverage never saw the broken Python provider import, which only surfaced once CI could reach Terraform >= 1.8 (#398) — and then via the `python-documentation` example rather than a test aimed at it.

`main.py` calls `edge.provider.EdgeProvider(...)`, so `beforeAll`'s synth imports the generated `edge.provider` module — exactly the module whose `__init__.py` carried the unresolvable import. A regression there fails the suite loudly, at the import.

### Two stale assertions, and why they were wrong

Re-enabling produced **18 passed / 2 failed**. The suite is substantially intact after three years dormant; both failures were expectations that had never once executed.

**1. A typo.** The `numList` expectation read `...reqnum)}` — a stray closing paren — where synth produces `...reqnum}`.

**2. A wrong assumption about `Fn.lookup`.** The map expectations assumed every `Fn.lookup(map, key, default)` renders as a Terraform `lookup()`. It does not. `Fn.lookup` (`packages/cdktn/src/terraform-functions.ts:41`) emits `lookup()` only when the default is **truthy**:

```ts
static lookup(inputMap: any, key: string, defaultValue?: any) {
  if (defaultValue) return Fn._lookup(inputMap, key, [defaultValue]);
  return asAny(propertyAccess(inputMap, [key])); // -> renders inputMap[key]
}
```

The fixture passes the same `Fn.lookup(...)` call for all six attributes, with different defaults:

| attribute | default | truthy | renders as |
| --- | --- | --- | --- |
| `reqMap` | `false` | no | `${map_resource.map.reqMap.key1}` |
| `optMap` | `"missing"` | yes | `${lookup(map_resource.map.optMap, "key1", "missing")}` |
| `computedMap` | `0` | no | `${map_resource.map.computedMap.key1}` |

So the deciding factor is the truthiness of the default, **not** whether the attribute is required, optional or computed. The corrected expectations match, and are now identical to `test/typescript/edge/test.ts`.

Only the first failing assertion in each block is reported by jest, so the rest of the map block was corrected at the same time rather than surfacing them one CI run at a time.

### These pin current behaviour, not necessarily correct behaviour (#416)

Worth flagging rather than burying: that truthiness guard looks like a bug. `Fn.lookup(map, "key", false)` reads as "return `false` if the key is missing", but the falsy default is discarded and the emitted expression becomes a bare property access — which errors on a missing key instead of returning the default. The guard should almost certainly be `defaultValue !== undefined`.

Filed as #416. I have deliberately **not** changed it here. This PR is test coverage; altering `Fn.lookup` is a behavioural change to the construct library with its own blast radius, and it would be wrong to smuggle it in. If it is fixed, these expectations move with it — and at that point the edge tests will be the thing that proves the fix, which is rather the point of un-skipping them.

Note this also means the equivalent TypeScript assertions were changed to match this behaviour in 09ac17b ("chore: fix assertions", Aug 2023) with no rationale recorded.

### Testing

CI on this branch: **257 pass, 0 fail**, 1 skip (`windows_integration`, `if: false`). Both `python/edge` jobs pass, on Terraform 1.5.7 and 1.16.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

