### PR TITLE
feat(tests): add per-test runtime pinning to the integration matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,9 +132,6 @@ jobs:
           echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
           mkdir -p /usr/local/share/.cache/gradle
           echo "gradle=/usr/local/share/.cache/gradle" >> $GITHUB_OUTPUT
-      # Keyed by binary, not version: OpenTofu resolves providers from
-      # registry.opentofu.org into this same directory, so a tofu run must not
-      # share a cache entry with a terraform run.
       - name: Cache terraform
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -132,13 +132,16 @@ jobs:
           echo "go=/usr/local/share/.cache/go" >> $GITHUB_OUTPUT
           mkdir -p /usr/local/share/.cache/gradle
           echo "gradle=/usr/local/share/.cache/gradle" >> $GITHUB_OUTPUT
+      # Keyed by binary, not version: OpenTofu resolves providers from
+      # registry.opentofu.org into this same directory, so a tofu run must not
+      # share a cache entry with a terraform run.
       - name: Cache terraform
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.global-cache-dir-path.outputs.terraform }}
-          key: terraform-${{ runner.os }}-${{ matrix.terraform }}-integration
+          key: terraform-${{ runner.os }}-${{ matrix.binary }}-integration
           restore-keys: |
-            terraform-${{ runner.os }}-${{ matrix.terraform }}-
+            terraform-${{ runner.os }}-${{ matrix.binary }}-
       - name: Cache go
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -173,7 +176,7 @@ jobs:
         env:
           TEST_TARGET: ${{ matrix.target }}
           TERRAFORM_CLOUD_TOKEN: ${{ secrets.TERRAFORM_CLOUD_TOKEN }}
-          TERRAFORM_BINARY_NAME: "terraform${{ matrix.terraform }}"
+          TERRAFORM_BINARY_NAME: ${{ matrix.binary }}
           NODE_OPTIONS: "--max-old-space-size=7168"
           TF_PLUGIN_CACHE_DIR: ${{ steps.global-cache-dir-path.outputs.terraform }}
           GOCACHE: ${{ steps.global-cache-dir-path.outputs.go }}
@@ -224,6 +227,10 @@ jobs:
           restore-keys: |
             go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-
             go-${{ runner.os }}-
+      # NOTE: this installs Terraform for every matrix entry, including any
+      # pinned to OpenTofu (see pinnedRuntimes in tools/build-test-matrix.mjs).
+      # Harmless while this job is disabled; re-enabling it means honouring
+      # matrix.binary here too.
       - name: HashiCorp - Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
         with:

--- a/test/typescript/provider-features/cdktf.json
+++ b/test/typescript/provider-features/cdktf.json
@@ -1,0 +1,10 @@
+{
+  "language": "typescript",
+  "app": "npx tsx main.ts",
+  "terraformProviders": ["hashicorp/time@~> 0.14"],
+  "targetVersions": {
+    "terraform": ">=1.8.0",
+    "opentofu": ">=1.8.0"
+  },
+  "context": {}
+}

--- a/test/typescript/provider-features/main.ts
+++ b/test/typescript/provider-features/main.ts
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { App, TerraformStack, TerraformOutput } from "cdktn";
+import { Construct } from "constructs";
+import { TimeProvider } from "./.gen/providers/time/provider";
+
+// Provider-defined functions are only emitted into a provider schema by
+// Terraform >= 1.8 and OpenTofu >= 1.8, so this stack can only be synthesized
+// by the runtimes this test is pinned to. See pinnedRuntimes in
+// tools/build-test-matrix.mjs.
+class ProviderFunctionsStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    const provider = new TimeProvider(this, "time");
+
+    const parsed = provider.functions.rfc3339Parse("2024-01-02T03:04:05Z");
+
+    new TerraformOutput(this, "parsed", {
+      value: parsed,
+    });
+  }
+}
+
+const app = new App();
+new ProviderFunctionsStack(app, "provider-functions");
+app.synth();

--- a/test/typescript/provider-features/test.ts
+++ b/test/typescript/provider-features/test.ts
@@ -3,9 +3,8 @@
 import { TestDriver, onlyJson } from "../../test-helper";
 
 // Runtime coverage for provider-schema features newer than the default tested
-// Terraform versions can emit. This target is pinned - in `pinnedRuntimes` in
-// tools/build-test-matrix.mjs - to current stable Terraform and OpenTofu, and
-// is the first test in this repo to run against OpenTofu at all.
+// Terraform versions can emit. Pinned to current stable Terraform and OpenTofu
+// in `pinnedRuntimes` in tools/build-test-matrix.mjs.
 describe("provider features", () => {
   let driver: TestDriver;
 
@@ -22,8 +21,7 @@ describe("provider features", () => {
         .synthesizedStack("provider-functions")
         .output("parsed");
 
-      // The generated binding renders as a Terraform/OpenTofu provider function
-      // call rather than being resolved at synth time.
+      // The generated binding renders as a provider function call.
       expect(output).toContain("provider::time::rfc3339_parse");
       expect(output).toContain("2024-01-02T03:04:05Z");
     },

--- a/test/typescript/provider-features/test.ts
+++ b/test/typescript/provider-features/test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { TestDriver, onlyJson } from "../../test-helper";
+
+// Runtime coverage for provider-schema features newer than the default tested
+// Terraform versions can emit. This target is pinned - in `pinnedRuntimes` in
+// tools/build-test-matrix.mjs - to current stable Terraform and OpenTofu, and
+// is the first test in this repo to run against OpenTofu at all.
+describe("provider features", () => {
+  let driver: TestDriver;
+
+  beforeAll(async () => {
+    driver = new TestDriver(__dirname);
+    await driver.setupTypescriptProject();
+    await driver.synth();
+  }, 500_000);
+
+  onlyJson(
+    "binds provider-defined functions into the synthesized stack",
+    () => {
+      const output = driver
+        .synthesizedStack("provider-functions")
+        .output("parsed");
+
+      // The generated binding renders as a Terraform/OpenTofu provider function
+      // call rather than being resolved at synth time.
+      expect(output).toContain("provider::time::rfc3339_parse");
+      expect(output).toContain("2024-01-02T03:04:05Z");
+    },
+  );
+});

--- a/tools/build-test-matrix.mjs
+++ b/tools/build-test-matrix.mjs
@@ -37,13 +37,7 @@ const availableVersions = {
 
 /**
  * Tests that opt out of the default `tested` Terraform cross-product and run against an explicit list of runtimes
- * instead. Keyed by path relative to `test/`.
- *
- * This is how a test gets coverage the default matrix cannot give it: a newer Terraform than `tested`, or OpenTofu,
- * without turning either on for all 60+ targets. Pinned entries reuse the whole existing integration job (container,
- * caches, `ci/skip-integration`), so a pin costs one job rather than a new workflow.
- *
- * Every pinned version must be in the matching `available` list, because those are the binaries baked into the image.
+ * instead. Keyed by path relative to `test/`. Pinned versions must be in the matching `available` list.
  *
  * @type {Record<string, Array<{ product: "terraform" | "opentofu", version: string }>>}
  */
@@ -105,10 +99,6 @@ function fileNeedsHclRun(relPath) {
 /**
  * Flattened list of matrix entries consumed by `strategy.matrix.include` in the workflow. Each entry materialises one
  * `linux_integration` job for a given test file against a given CLI in a given synth output mode.
- *
- * `binary` is the name of the version-suffixed binary in the CI image and is what `TERRAFORM_BINARY_NAME` is set to,
- * so it - not `terraform` - is what selects the CLI. `terraform` stays the bare version for cache keys and
- * `TERRAFORM_VERSION`.
  *
  * @type {Array<{ target: string, terraform: string, binary: string, hclOutput: boolean }>}
  */

--- a/tools/build-test-matrix.mjs
+++ b/tools/build-test-matrix.mjs
@@ -19,10 +19,52 @@ import { join } from "node:path";
 const repoRoot = process.cwd();
 const testDir = join(repoRoot, "test");
 
-/** Tested Terraform versions from `.terraform.versions.json`. */
-const tfVersions = JSON.parse(
+const versionsConfig = JSON.parse(
   readFileSync(join(repoRoot, ".terraform.versions.json"), "utf8"),
-).tested;
+);
+
+/** Tested Terraform versions from `.terraform.versions.json`. */
+const tfVersions = versionsConfig.tested;
+
+/** Binary name prefix per product. The CI image installs one binary per available version of each. */
+const binaryPrefix = { terraform: "terraform", opentofu: "tofu" };
+
+/** Versions of each product the CI image actually ships, used to validate pins below. */
+const availableVersions = {
+  terraform: versionsConfig.available,
+  opentofu: versionsConfig.opentofu?.available ?? [],
+};
+
+/**
+ * Tests that opt out of the default `tested` Terraform cross-product and run against an explicit list of runtimes
+ * instead. Keyed by path relative to `test/`.
+ *
+ * This is how a test gets coverage the default matrix cannot give it: a newer Terraform than `tested`, or OpenTofu,
+ * without turning either on for all 60+ targets. Pinned entries reuse the whole existing integration job (container,
+ * caches, `ci/skip-integration`), so a pin costs one job rather than a new workflow.
+ *
+ * Every pinned version must be in the matching `available` list, because those are the binaries baked into the image.
+ *
+ * @type {Record<string, Array<{ product: "terraform" | "opentofu", version: string }>>}
+ */
+const pinnedRuntimes = {
+  "typescript/provider-features/test.ts": [
+    { product: "terraform", version: "1.16.1" },
+    { product: "opentofu", version: "1.12.6" },
+  ],
+};
+
+for (const [target, runtimes] of Object.entries(pinnedRuntimes)) {
+  for (const { product, version } of runtimes) {
+    if (!availableVersions[product]?.includes(version)) {
+      throw new Error(
+        `pinnedRuntimes["${target}"] pins ${product} ${version}, which is not in ` +
+          `.terraform.versions.json ${product === "terraform" ? "available" : "opentofu.available"}, ` +
+          `so the CI image has no ${binaryPrefix[product]}${version} binary.`,
+      );
+    }
+  }
+}
 
 /**
  * Absolute paths of every integration test file, as resolved by jest's own config (including `testPathIgnorePatterns`
@@ -62,16 +104,28 @@ function fileNeedsHclRun(relPath) {
 
 /**
  * Flattened list of matrix entries consumed by `strategy.matrix.include` in the workflow. Each entry materialises one
- * `linux_integration` job for a given test file at a given Terraform version in a given synth output mode.
+ * `linux_integration` job for a given test file against a given CLI in a given synth output mode.
  *
- * @type {Array<{ target: string, terraform: string, hclOutput: boolean }>}
+ * `binary` is the name of the version-suffixed binary in the CI image and is what `TERRAFORM_BINARY_NAME` is set to,
+ * so it - not `terraform` - is what selects the CLI. `terraform` stays the bare version for cache keys and
+ * `TERRAFORM_VERSION`.
+ *
+ * @type {Array<{ target: string, terraform: string, binary: string, hclOutput: boolean }>}
  */
 const include = [];
 for (const target of targets) {
   const modes = fileNeedsHclRun(target) ? [false, true] : [false];
-  for (const terraform of tfVersions) {
+  const runtimes =
+    pinnedRuntimes[target] ??
+    tfVersions.map((version) => ({ product: "terraform", version }));
+  for (const { product, version } of runtimes) {
     for (const hclOutput of modes) {
-      include.push({ target, terraform, hclOutput });
+      include.push({
+        target,
+        terraform: version,
+        binary: `${binaryPrefix[product]}${version}`,
+        hclOutput,
+      });
     }
   }
 }


### PR DESCRIPTION
### Related issue

Implements the mechanism from #337. First step toward OpenTofu coverage.

### Description

A test can now opt out of the default `tested` Terraform cross-product and declare the runtimes it needs, via `pinnedRuntimes` in `tools/build-test-matrix.mjs`:

```js
const pinnedRuntimes = {
  "typescript/provider-features/test.ts": [
    { product: "terraform", version: "1.16.1" },
    { product: "opentofu", version: "1.12.6" },
  ],
};
```

**Why this first.** Until now the only way to run anything against OpenTofu was a full matrix leg across all 60+ targets, which needs #208, #301, #392 and #393 all resolved before a single tofu job can be green. A pin runs one target against one CLI, so each of those blockers can now be fixed and verified independently and tofu coverage grows a test at a time. It also gives an individual test a newer Terraform than `tested` without moving the floor for everything — which is what #312 needs.

To be clear about what this does and does not do: it does not fix any of the four blockers. It makes them separately fixable.

#### Mechanism

Matrix entries gain a `binary` field — the version-suffixed binary the CI image installs — and the workflow sets `TERRAFORM_BINARY_NAME` from it rather than string-concatenating `"terraform"` with a version. `terraform` stays the bare version, so `TERRAFORM_VERSION` and the cache-key semantics are unchanged for existing entries.

The plugin cache is now keyed by binary rather than version. OpenTofu resolves providers from `registry.opentofu.org` into the same `TF_PLUGIN_CACHE_DIR`, so a tofu run must not share a cache entry with a terraform run.

Pins are validated against `.terraform.versions.json` when the matrix is built, so a typo fails the `prepare-integration-tests` job with a clear message rather than a "binary not found" deep inside a test run.

#### First consumer

`test/typescript/provider-features`, pinned to Terraform 1.16.1 and OpenTofu 1.12.6 — **the first OpenTofu job in this repo's CI**. It covers the provider-defined functions binding end to end: `provider.functions.rfc3339Parse(...)` must synthesize to a `provider::time::rfc3339_parse(...)` expression rather than resolving at synth time. That needs a CLI that emits `functions` in provider schemas (Terraform/OpenTofu >= 1.8), so it could not have run at the old 1.6.5 ceiling at all.

It uses `hashicorp/time`, which is mirrored on `registry.opentofu.org` and installs cleanly under both CLIs — deliberately not `kreuzwerker/docker`, which hits the signing problem in #301.

### Testing

The matrix builder cannot run natively on Windows (pre-existing: `execFileSync("npx")` needs `.cmd`, and the `testDir` prefix strip assumes forward slashes), so I verified the pin logic against a stubbed target list:

```
entries: 8
  typescript/provider-features/test.ts   tf=1.16.1  binary=terraform1.16.1  hcl=false
  typescript/provider-features/test.ts   tf=1.12.6  binary=tofu1.12.6       hcl=false
  typescript/synth-app/test.ts           tf=1.5.7   binary=terraform1.5.7   hcl=false
  typescript/synth-app/test.ts           tf=1.16.1  binary=terraform1.16.1  hcl=false
  typescript/iterators/test.ts           tf=1.5.7   binary=terraform1.5.7   hcl=false
  typescript/iterators/test.ts           tf=1.5.7   binary=terraform1.5.7   hcl=true
  typescript/iterators/test.ts           tf=1.16.1  binary=terraform1.16.1  hcl=false
  typescript/iterators/test.ts           tf=1.16.1  binary=terraform1.16.1  hcl=true
```

The pinned target gets exactly its two entries and no default cross-product; non-pinned targets are unchanged, including the HCL doubling. Pin validation confirmed to fail fast:

```
Error: pinnedRuntimes["typescript/provider-features/test.ts"] pins opentofu 9.9.9,
which is not in .terraform.versions.json opentofu.available, so the CI image has
no tofu9.9.9 binary.
```

I could not run the new integration test locally — it needs `pnpm package` and the integration harness, and `pipenv`/`rsync` are unavailable on this machine. **This PR's own CI run is the verification for the test itself**, and it is the interesting part: the tofu job is the first of its kind here.

### Known gap

The disabled `windows_integration` job consumes the same matrix and would try to install Terraform for a tofu-pinned entry. Noted in place rather than building OpenTofu support into a job guarded by `if: false`.

### Follow-ups this unblocks

- #312 — ephemeral end-to-end can pin rather than wait on the default matrix.
- #392, #393, #208, #301 — each now fixable and verifiable on its own pinned target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
