### PR TITLE
chore(deps): move the remaining packages to TypeScript 6

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -72,7 +72,7 @@
     "nock": "^14.0.16",
     "prettier": "2.8.8",
     "tsc-files": "1.1.4",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/packages/@cdktn/cli-core/tsconfig.json
+++ b/packages/@cdktn/cli-core/tsconfig.json
@@ -24,6 +24,10 @@
     "stripInternal": true,
     "skipLibCheck": true,
     "target": "ES2018",
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": false,
     "esModuleInterop": true,
     "rootDir": "./src",

--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -51,13 +51,14 @@
     "validator": "13.15.35"
   },
   "devDependencies": {
+    "@types/node": "22.20.1",
     "@types/cross-spawn": "6.0.6",
     "@types/follow-redirects": "1.14.4",
     "@types/fs-extra": "11.0.4",
     "@types/semver": "7.7.1",
     "@types/validator": "13.15.10",
     "tsc-files": "1.1.4",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": "tsc-files ambient.d.ts --noEmit"

--- a/packages/@cdktn/commons/tsconfig.json
+++ b/packages/@cdktn/commons/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
     "experimentalDecorators": true,
@@ -25,6 +24,10 @@
     "skipLibCheck": true,
     "stripInternal": true,
     "target": "ES2018",
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": false,
     "esModuleInterop": true,
     "rootDir": "./src",

--- a/packages/@cdktn/hcl-tools/package.json
+++ b/packages/@cdktn/hcl-tools/package.json
@@ -47,6 +47,6 @@
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
     "@types/node": "22.20.1",
-    "typescript": "^5.0.0"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/@cdktn/hcl-tools/tsconfig.json
+++ b/packages/@cdktn/hcl-tools/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
     "experimentalDecorators": true,

--- a/packages/@cdktn/hcl2cdk/package.json
+++ b/packages/@cdktn/hcl2cdk/package.json
@@ -64,7 +64,7 @@
     "execa": "5.1.1",
     "fs-extra": "11.3.6",
     "tsx": "4.23.1",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   },
   "nx": {
     "tags": ["unit-test"],

--- a/packages/@cdktn/hcl2cdk/tsconfig.json
+++ b/packages/@cdktn/hcl2cdk/tsconfig.json
@@ -24,6 +24,10 @@
     "stripInternal": true,
     "skipLibCheck": true,
     "target": "ES2018",
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": true,
     "esModuleInterop": true,
     "rootDir": "./src",

--- a/packages/@cdktn/hcl2json/package.json
+++ b/packages/@cdktn/hcl2json/package.json
@@ -43,6 +43,6 @@
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
     "@types/node": "22.20.1",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/@cdktn/hcl2json/tsconfig.json
+++ b/packages/@cdktn/hcl2json/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
     "experimentalDecorators": true,

--- a/packages/@cdktn/provider-generator/package.json
+++ b/packages/@cdktn/provider-generator/package.json
@@ -50,6 +50,6 @@
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
     "@types/node": "22.20.1",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/@cdktn/provider-generator/tsconfig.json
+++ b/packages/@cdktn/provider-generator/tsconfig.json
@@ -24,6 +24,10 @@
     "stripInternal": true,
     "skipLibCheck": true,
     "target": "ES2018",
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": true,
     "esModuleInterop": true,
     "rootDir": "./src",

--- a/packages/@cdktn/provider-schema/package.json
+++ b/packages/@cdktn/provider-schema/package.json
@@ -43,11 +43,12 @@
     "semver": "7.8.5"
   },
   "devDependencies": {
+    "@types/node": "22.20.1",
     "@types/fs-extra": "11.0.4",
     "@types/semver": "7.7.1",
     "safe-stable-stringify": "2.5.0",
     "tsc-files": "1.1.4",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": "tsc-files ambient.d.ts --noEmit"

--- a/packages/@cdktn/provider-schema/tsconfig.json
+++ b/packages/@cdktn/provider-schema/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "baseUrl": ".",
     "declaration": true,
     "declarationMap": true,
     "experimentalDecorators": true,
@@ -25,6 +24,10 @@
     "skipLibCheck": true,
     "stripInternal": true,
     "target": "ES2018",
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": false,
     "esModuleInterop": true,
     "rootDir": "./src",

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -9,7 +9,7 @@
     "cdktn": "bin/cdktn"
   },
   "scripts": {
-    "compile-build-config": "tsc build.ts --outDir build-config",
+    "compile-build-config": "tsc build.ts --outDir build-config --ignoreConfig --module commonjs --target es2022",
     "prebuild": "pnpm run compile-build-config",
     "build": "tsc --noEmit",
     "postbuild": "node build-config/build.js",
@@ -93,6 +93,6 @@
     "semver": "7.8.5",
     "strip-ansi": "6.0.1",
     "tsc-files": "1.1.4",
-    "typescript": "^5.0.4"
+    "typescript": "~6.0.0"
   }
 }

--- a/packages/cdktn-cli/tsconfig.json
+++ b/packages/cdktn-cli/tsconfig.json
@@ -23,6 +23,10 @@
     "stripInternal": true,
     "skipLibCheck": true,
     "target": "ES2018",
+    "types": [
+      "node",
+      "jest"
+    ],
     "incremental": false,
     "esModuleInterop": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1077,10 +1077,10 @@ importers:
         version: 2.8.8
       tsc-files:
         specifier: 1.1.4
-        version: 1.1.4(typescript@5.4.5)
+        version: 1.1.4(typescript@6.0.3)
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/@cdktn/commons:
     dependencies:
@@ -1127,6 +1127,9 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
+      '@types/node':
+        specifier: 22.20.1
+        version: 22.20.1
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -1135,10 +1138,10 @@ importers:
         version: 13.15.10
       tsc-files:
         specifier: 1.1.4
-        version: 1.1.4(typescript@5.4.5)
+        version: 1.1.4(typescript@6.0.3)
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/@cdktn/hcl-tools:
     dependencies:
@@ -1153,8 +1156,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       typescript:
-        specifier: ^5.0.0
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/@cdktn/hcl2cdk:
     dependencies:
@@ -1244,8 +1247,8 @@ importers:
         specifier: 4.23.1
         version: 4.23.1
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/@cdktn/hcl2json:
     dependencies:
@@ -1260,8 +1263,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/@cdktn/provider-generator:
     dependencies:
@@ -1300,8 +1303,8 @@ importers:
         specifier: 22.20.1
         version: 22.20.1
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/@cdktn/provider-schema:
     dependencies:
@@ -1324,6 +1327,9 @@ importers:
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
+      '@types/node':
+        specifier: 22.20.1
+        version: 22.20.1
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
@@ -1332,10 +1338,10 @@ importers:
         version: 2.5.0
       tsc-files:
         specifier: 1.1.4
-        version: 1.1.4(typescript@5.4.5)
+        version: 1.1.4(typescript@6.0.3)
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   packages/cdktn:
     dependencies:
@@ -1490,10 +1496,10 @@ importers:
         version: 6.0.1
       tsc-files:
         specifier: 1.1.4
-        version: 1.1.4(typescript@5.4.5)
+        version: 1.1.4(typescript@6.0.3)
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
   tools/documentation-generation:
     dependencies:
@@ -1552,10 +1558,10 @@ importers:
         version: 22.20.1
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@6.0.3)
       typescript:
-        specifier: ^5.0.0
-        version: 5.4.5
+        specifier: ~6.0.0
+        version: 6.0.3
 
 packages:
 
@@ -10132,7 +10138,7 @@ snapshots:
 
   '@types/follow-redirects@1.14.4':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 22.20.1
 
   '@types/fs-extra@11.0.4':
     dependencies:
@@ -14914,9 +14920,33 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.40(@swc/helpers@0.5.21)
 
+  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.21))(@types/node@22.20.1)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.20.1
+      acorn: 8.16.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.40(@swc/helpers@0.5.21)
+
   tsc-files@1.1.4(typescript@5.4.5):
     dependencies:
       typescript: 5.4.5
+
+  tsc-files@1.1.4(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/tools/generate-function-bindings/package.json
+++ b/tools/generate-function-bindings/package.json
@@ -31,7 +31,7 @@
     "@types/babel__template": "^7.4.4",
     "@types/node": "22.20.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.0.0"
+    "typescript": "~6.0.0"
   },
   "lint-staged": {
     "scripts/**/*.ts": "tsc-files --noEmit"

--- a/tools/generate-function-bindings/tsconfig.json
+++ b/tools/generate-function-bindings/tsconfig.json
@@ -23,9 +23,11 @@
     "strictPropertyInitialization": true,
     "stripInternal": true,
     "target": "ES2018",
+    "types": [
+      "node"
+    ],
     "incremental": false,
     "esModuleInterop": true,
-    "baseUrl": ".",
     "paths": {
       "@cdktn/commons": [
         "../../packages/@cdktn/commons/src/provider-schema"


### PR DESCRIPTION
### Related issue

Completes https://github.com/open-constructs/cdk-terrain/issues/78 — #395 moved the `cdktn` library to TypeScript 6; this moves the remaining nine packages.

### Description

No source changes were needed: the codebase was already TypeScript 6 clean. This is config and dependency hygiene.

**`baseUrl` removed** from the five tsconfigs that set it, because TypeScript 6 errors on it. Only `generate-function-bindings` pairs it with `paths`, which resolves relative to the tsconfig without it.

**Explicit `types` arrays** where the compile needs them:

| package | types |
| --- | --- |
| cdktn-cli, cli-core, commons, hcl2cdk, provider-generator, provider-schema | `["node", "jest"]` |
| generate-function-bindings | `["node"]` |
| hcl-tools, hcl2json | none needed — left alone |

**`@types/node` added to `commons` and `provider-schema`.** Neither declared it; both were relying on ambient resolution. Once `types` is explicit that ends, and TypeScript reports `TS2688: Cannot find type definition file for 'node'`. This is a latent gap the migration surfaces rather than one it creates.

#### One thing worth a second look

`cdktn-cli`'s `compile-build-config` runs `tsc build.ts --outDir build-config` — a file on the command line alongside a `tsconfig.json`. TypeScript 6 reports that as:

```
TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline
```

That was already true under TypeScript 5; 6 just says so. Adding `--ignoreConfig` acknowledges it, but on its own it broke the build in a subtler way: TypeScript 6's config-less defaults emit ESM, so `build-config/build.js` was reparsed as a module and `fs.copySync` came back `undefined`. `--module commonjs --target es2022` pin what the tsconfig used to supply.

#### Not included

Root `typescript` stays at `5.4.5`. It backs `tsc-files` in the pre-commit hooks and `typescript-eslint`, neither of which needs to move for the packages to build on 6. Happy to bump it separately if you'd prefer one version across the repo.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

Locally: `pnpm build` green for all 9 projects, `pnpm lint:workspace` green for 35, knip clean, and the unit suite fully green (cdktn 43/43 suites, 525 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
