### PR TITLE
fix(lib): retry the staging install without --prefer-offline outside CI

### DIFF
--- a/packages/cdktn/scripts/pack.mjs
+++ b/packages/cdktn/scripts/pack.mjs
@@ -127,21 +127,36 @@ function copySourceFiles(sourceFiles) {
  *   --no-package-lock:    don't pollute staging with a fresh lockfile.
  *   --prefer-offline:     use the local npm cache before the network.
  *   --ignore-scripts:     don't run install scripts of bundled deps; bundling needs the tree on disk only.
+ *
+ * A cached packument older than a dependency bump makes --prefer-offline report
+ * ETARGET ("No matching version found") for a version that exists. Outside CI we
+ * retry once with --prefer-online; in CI we let it fail, so a stale cache can
+ * never quietly change what gets packaged.
  */
 function installRuntimeDeps() {
   console.log("Installing runtime deps into staging via npm...");
-  run(
-    "npm",
-    [
-      "install",
-      "--omit=dev",
-      "--omit=optional",
-      "--no-package-lock",
-      "--prefer-offline",
-      "--ignore-scripts",
-    ],
-    { cwd: stagingDir, ...NPM_SPAWN_OPTS },
-  );
+  const args = [
+    "install",
+    "--omit=dev",
+    "--omit=optional",
+    "--no-package-lock",
+    "--ignore-scripts",
+  ];
+  try {
+    run("npm", [...args, "--prefer-offline"], {
+      cwd: stagingDir,
+      ...NPM_SPAWN_OPTS,
+    });
+  } catch (err) {
+    if (process.env.CI) throw err;
+    console.log(
+      "npm install failed with --prefer-offline; retrying with --prefer-online in case the local cache is stale...",
+    );
+    run("npm", [...args, "--prefer-online"], {
+      cwd: stagingDir,
+      ...NPM_SPAWN_OPTS,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
### Related issue

No issue — follow-up from #395, where this cost real time during the upgrade.

### Description

`packages/cdktn/scripts/pack.mjs` installs the staging dependencies with `--prefer-offline`. When the local npm cache holds a packument older than a dependency bump, npm never refreshes it and reports:

```
npm error code ETARGET
npm error notarget No matching version found for jsii-pacmak@1.140.0.
```

The version does exist — the cached index just predates it. The message blames the pin, so the natural reaction is to distrust the version rather than the cache. This happened repeatedly while upgrading jsii, on a long-lived container with a warm cache.

**Outside CI** the install is retried once with `--prefer-online`, which refreshes the metadata and succeeds.

**In CI the error is rethrown untouched.** A release build that cannot resolve a pinned version should fail rather than quietly reach for a different resolution — the fallback exists to unstick local development, not to paper over a non-reproducible build. `process.env.CI` is set by GitHub Actions.

### Verification

The happy path is unchanged (warm cache, single install, no retry).

The gate was exercised by pinning a dependency to a version that does not exist, which produces the real ETARGET:

```
CI unset   retry fired once, then failed
CI=true    no retry, failed immediately
```

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
