### PR TITLE
fix(cli): correct the constructs range comment in the TypeScript template hook

### DIFF
--- a/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
@@ -28,8 +28,9 @@ exports.post = (ctx) => {
     throw new Error(`missing context "npm_cdktf"`);
   }
 
-  // Mirrors the `constructs` peer dependency range declared by the cdktn
-  // package. Keep both in sync.
+  // `constructs@10` resolves to the newest 10.x, which satisfies the `^10.6.0`
+  // peer range cdktn declares; that peer range is the real constraint, so
+  // only the major here has to follow cdktn's.
   installDeps([npm_cdktf, `constructs@10`], false, silent);
   // Capped below 7.x: that is the native port, which jsii does not support yet.
   installDeps(


### PR DESCRIPTION
### Related issue

Non-blocking finding from the #396 review; the comment landed on `main` via #395.

### Description

`packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js` installs `constructs@10` and said it "mirrors the `constructs` peer dependency range declared by the cdktn package — keep both in sync". The two are not equivalent: `constructs@10` permits 10.0.0 onward, while cdktn's peer dependency is `^10.6.0`. There is no runtime defect — a fresh install resolves the newest 10.x, which satisfies the peer range — but the maintenance instruction was misleading. The comment now states the actual relationship: the peer range is the binding constraint, and only the major in the template spec has to follow cdktn's.

Comment-only change; no behaviour touched.

### Testing

`node --check` and `prettier --check` on the file; nothing else in the repo references the old text.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if applicable — n/a
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective — n/a, comment-only
- [x] New and existing unit tests pass locally with my changes — n/a, comment-only
