### PR TITLE
chore(deps): upgrade @sentry/node to 10.x with unchanged reporting behaviour

### DIFF
--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -40,7 +40,7 @@
     "@cdktn/hcl-tools": "workspace:*",
     "@cdktn/hcl2cdk": "workspace:*",
     "@cdktn/provider-schema": "workspace:*",
-    "@sentry/node": "^10.73.0",
+    "@sentry/node": "10.73.0",
     "cdktn": "workspace:*",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",

--- a/packages/@cdktn/cli-core/package.json
+++ b/packages/@cdktn/cli-core/package.json
@@ -40,7 +40,7 @@
     "@cdktn/hcl-tools": "workspace:*",
     "@cdktn/hcl2cdk": "workspace:*",
     "@cdktn/provider-schema": "workspace:*",
-    "@sentry/node": "7.120.4",
+    "@sentry/node": "^10.73.0",
     "cdktn": "workspace:*",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",

--- a/packages/@cdktn/cli-core/src/lib/error-reporting.ts
+++ b/packages/@cdktn/cli-core/src/lib/error-reporting.ts
@@ -10,6 +10,7 @@ import {
 import { logger } from "@cdktn/commons";
 import * as path from "path";
 import * as fs from "fs-extra";
+import { randomUUID } from "node:crypto";
 import ciInfo from "ci-info";
 
 export function shouldReportCrash(
@@ -82,9 +83,16 @@ export async function initializErrorReporting(
   logger.debug("Initializing error reporting");
 
   Sentry.init({
-    autoSessionTracking: true,
     dsn: process.env.SENTRY_DSN,
     release: `cdktn-cli-${DISPLAY_VERSION}`,
+    // Fixed so the SDK never falls back to the user's SENTRY_ENVIRONMENT.
+    environment: "production",
+    // Usage metrics are delivered independently of trace sampling, so no
+    // trace quota is spent.
+    tracesSampleRate: 0,
+    // Fixed constant so the machine hostname is never attached to events or
+    // metrics (v10 defaults server_name/server.address to the hostname).
+    serverName: "cdktn-cli",
     async beforeSend(event, hint) {
       if (!hint) {
         return event;
@@ -113,12 +121,17 @@ export async function initializErrorReporting(
     },
   });
 
-  Sentry.configureScope(function (scope) {
-    scope.setUser({
-      id: getUserId(),
-    });
-    scope.setTag("projectId", getProjectId());
+  const scope = Sentry.getCurrentScope();
+  // The SDK seeds the trace from SENTRY_TRACE/SENTRY_BAGGAGE; start a fresh
+  // one so nothing from the user's environment propagates.
+  scope.setPropagationContext({
+    traceId: randomUUID().replace(/-/g, ""),
+    sampleRand: Math.random(),
   });
+  scope.setUser({
+    id: getUserId(),
+  });
+  scope.setTag("projectId", getProjectId());
 
   logger.debug("Collecting environment information for error reporting");
   collectDebugInformation().then((debugOutput) => {

--- a/packages/@cdktn/cli-core/src/lib/error-reporting.ts
+++ b/packages/@cdktn/cli-core/src/lib/error-reporting.ts
@@ -93,6 +93,9 @@ export async function initializErrorReporting(
     // Fixed constant so the machine hostname is never attached to events or
     // metrics (v10 defaults server_name/server.address to the hostname).
     serverName: "cdktn-cli",
+    // Usage metrics ride on the SDK's metrics pipeline; explicit so a future
+    // SDK default flip cannot silently stop delivery.
+    enableMetrics: true,
     async beforeSend(event, hint) {
       if (!hint) {
         return event;

--- a/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
+++ b/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
@@ -99,7 +99,7 @@ describe("consent gating (initializErrorReporting)", () => {
     );
   });
 
-  it("init options pin release, tracesSampleRate 0, a fixed environment and a fixed serverName", async () => {
+  it("init options pin release, tracesSampleRate 0, a fixed environment, a fixed serverName and enableMetrics", async () => {
     fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
       sendCrashReports: true,
     });
@@ -115,6 +115,7 @@ describe("consent gating (initializErrorReporting)", () => {
       tracesSampleRate: 0,
       environment: "production",
       serverName: "cdktn-cli",
+      enableMetrics: true,
     });
   });
 });

--- a/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
+++ b/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+
+const mockScope = {
+  setUser: jest.fn(),
+  setTag: jest.fn(),
+  setTransactionName: jest.fn(),
+  setPropagationContext: jest.fn(),
+};
+jest.mock("@sentry/node", () => ({
+  init: jest.fn(),
+  getCurrentScope: jest.fn(() => mockScope),
+  setContext: jest.fn(),
+  addBreadcrumb: jest.fn(), // the commons logger records every debug line
+  flush: jest.fn().mockResolvedValue(true),
+  close: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("ci-info", () => ({ isCI: false, name: null }));
+
+jest.mock("@cdktn/commons", () => {
+  const actual = jest.requireActual("@cdktn/commons");
+  return {
+    ...actual,
+    collectDebugInformation: jest.fn().mockResolvedValue({}),
+  };
+});
+
+import * as Sentry from "@sentry/node";
+import ciInfo from "ci-info";
+import { initializErrorReporting } from "../lib/error-reporting";
+
+// the ci-info mock above replaces the module with a plain mutable object,
+// so tests can flip isCI; the published types declare it readonly
+const ciInfoMock = ciInfo as unknown as { isCI: boolean };
+
+const initOptions = () => (Sentry.init as jest.Mock).mock.calls.at(-1)![0];
+
+describe("consent gating (initializErrorReporting)", () => {
+  let workdir: string;
+  const originalCwd = process.cwd();
+  const originalEnv = {
+    CI: process.env.CI,
+    SENTRY_DSN: process.env.SENTRY_DSN,
+  };
+  const originalIsTTY = process.stdout.isTTY;
+
+  const setInteractive = (interactive: boolean) => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: interactive,
+      configurable: true,
+    });
+    if (interactive) {
+      delete process.env.CI;
+      ciInfoMock.isCI = false;
+    }
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workdir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktn-consent-"));
+    process.chdir(workdir);
+    delete process.env.CI;
+    process.env.SENTRY_DSN = "https://public@example.invalid/1";
+    ciInfoMock.isCI = false;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.removeSync(workdir);
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("starts a fresh trace so nothing seeded from SENTRY_TRACE/SENTRY_BAGGAGE propagates", async () => {
+    fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+      sendCrashReports: true,
+      sendUsageTelemetry: true,
+    });
+
+    await initializErrorReporting(jest.fn());
+
+    expect(mockScope.setPropagationContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: expect.stringMatching(/^[0-9a-f]{32}$/),
+      }),
+    );
+  });
+
+  it("init options pin release, tracesSampleRate 0, a fixed environment and a fixed serverName", async () => {
+    fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+      sendCrashReports: true,
+    });
+    setInteractive(false);
+
+    await initializErrorReporting();
+
+    // fixed values are the production-side lock that neither the hostname
+    // nor SENTRY_ENVIRONMENT reaches Sentry (the commons delivery tests set
+    // their own init options)
+    expect(initOptions()).toMatchObject({
+      release: expect.stringMatching(/^cdktn-cli-/),
+      tracesSampleRate: 0,
+      environment: "production",
+      serverName: "cdktn-cli",
+    });
+  });
+});

--- a/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
+++ b/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
@@ -39,7 +39,7 @@ const ciInfoMock = ciInfo as unknown as { isCI: boolean };
 
 const initOptions = () => (Sentry.init as jest.Mock).mock.calls.at(-1)![0];
 
-describe("consent gating (initializErrorReporting)", () => {
+describe("Sentry init hardening", () => {
   let workdir: string;
   const originalCwd = process.cwd();
   const originalEnv = {

--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MPL-2.0",
   "dependencies": {
-    "@sentry/node": "^10.73.0",
+    "@sentry/node": "10.73.0",
     "cdktn": "workspace:*",
     "ci-info": "4.4.0",
     "codemaker": "1.140.0",

--- a/packages/@cdktn/commons/package.json
+++ b/packages/@cdktn/commons/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "MPL-2.0",
   "dependencies": {
-    "@sentry/node": "7.120.4",
+    "@sentry/node": "^10.73.0",
     "cdktn": "workspace:*",
     "ci-info": "4.4.0",
     "codemaker": "1.140.0",

--- a/packages/@cdktn/commons/src/errors.ts
+++ b/packages/@cdktn/commons/src/errors.ts
@@ -53,6 +53,6 @@ export const Errors = {
   // Set the scope for all errors
   setScope(scope: string) {
     errorScope = scope;
-    Sentry.configureScope((s) => s.setTransactionName(scope));
+    Sentry.getCurrentScope().setTransactionName(scope);
   },
 };

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -74,7 +74,7 @@
     "@cdktn/provider-generator": "workspace:*",
     "@cdktn/provider-schema": "workspace:*",
     "@npmcli/ci-detect": "1.4.0",
-    "@sentry/node": "^10.73.0",
+    "@sentry/node": "10.73.0",
     "@types/fs-extra": "11.0.4",
     "@types/pidusage": "2.0.5",
     "@types/semver": "7.7.1",

--- a/packages/cdktn-cli/package.json
+++ b/packages/cdktn-cli/package.json
@@ -74,7 +74,7 @@
     "@cdktn/provider-generator": "workspace:*",
     "@cdktn/provider-schema": "workspace:*",
     "@npmcli/ci-detect": "1.4.0",
-    "@sentry/node": "7.120.4",
+    "@sentry/node": "^10.73.0",
     "@types/fs-extra": "11.0.4",
     "@types/pidusage": "2.0.5",
     "@types/semver": "7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,8 +997,8 @@ importers:
         specifier: workspace:*
         version: link:../provider-schema
       '@sentry/node':
-        specifier: 7.120.4
-        version: 7.120.4
+        specifier: ^10.73.0
+        version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       cdktn:
         specifier: workspace:*
         version: link:../../cdktn
@@ -1085,8 +1085,8 @@ importers:
   packages/@cdktn/commons:
     dependencies:
       '@sentry/node':
-        specifier: 7.120.4
-        version: 7.120.4
+        specifier: ^10.73.0
+        version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       cdktn:
         specifier: workspace:*
         version: link:../../cdktn
@@ -1441,8 +1441,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@sentry/node':
-        specifier: 7.120.4
-        version: 7.120.4
+        specifier: ^10.73.0
+        version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       '@types/fs-extra':
         specifier: 11.0.4
         version: 11.0.4
@@ -3194,6 +3194,48 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.11.0':
+    resolution: {integrity: sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.11.0':
+    resolution: {integrity: sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.11.0':
+    resolution: {integrity: sha512-H19x/TX/LZdqiYOjM7fqtSxwlplC5pgelavqbQdHbhdq0q/AI/TGkM2dfGuuynTXmJPeF2HoZVoPDu+TGoW78A==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.11.0':
+    resolution: {integrity: sha512-fFnTqGm8/G73GQVnxYi7LXa1ZVYEUvgL6XI1LpvV0bPC7WQ/ZGgKxCSl8FnlZBKto9JHHEFTO6s6CUpvvtwFrA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     resolution: {integrity: sha512-l/44caGse+VpnY9gx0yvvc5QnnG3yG1FO3KZgYvNL1GZrfK86zIwAOgGEVlxDyRymzrU/KHiblPFpevKOmJmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3529,29 +3571,50 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@sentry-internal/tracing@7.120.4':
-    resolution: {integrity: sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==}
-    engines: {node: '>=8'}
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
 
-  '@sentry/core@7.120.4':
-    resolution: {integrity: sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==}
-    engines: {node: '>=8'}
+  '@sentry/core@10.73.0':
+    resolution: {integrity: sha512-FLO1UgH19RyasVpofu612WCOgb2nEH0dZy+R72d7p65XU9i0wxlMKm3+sgfwKmiSJp1Qhilaaxs4Jg6BbiM5HA==}
+    engines: {node: '>=18'}
 
-  '@sentry/integrations@7.120.4':
-    resolution: {integrity: sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==}
-    engines: {node: '>=8'}
+  '@sentry/node-core@10.73.0':
+    resolution: {integrity: sha512-GHAGUmZPmm6FKfxfv2maVVJ/A99YAmd7oFOuKMDmITI6O/Msl6JB3vPTEpopVAHLW0LYJQBOjddL9C7o+Jt44g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
 
-  '@sentry/node@7.120.4':
-    resolution: {integrity: sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==}
-    engines: {node: '>=8'}
+  '@sentry/node@10.73.0':
+    resolution: {integrity: sha512-jiMJ6GgXDw6UMGzJY+o0c8OoeA9OfHqZ/xEpHfDqy75hn+9CEkRkbNGCIdMvsc7wW/Se1Os394hHfTpU+YEskg==}
+    engines: {node: '>=18'}
 
-  '@sentry/types@7.120.4':
-    resolution: {integrity: sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==}
-    engines: {node: '>=8'}
+  '@sentry/opentelemetry@10.73.0':
+    resolution: {integrity: sha512-fQouPQKsH0CQrw6oAn1k0Z2I+tgyochCovifr5qNS69i0OzjknLa03WJyiZ/IuzXc4AVa5jAKfOeE9slABz8Qw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
 
-  '@sentry/utils@7.120.4':
-    resolution: {integrity: sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==}
-    engines: {node: '>=8'}
+  '@sentry/server-utils@10.73.0':
+    resolution: {integrity: sha512-QskripdKFbM/+gipC6mpa2crLwL7+VbkX84IpHg2z9UlYQ1kNKd3aMT+Qk9NLRSw/zu1rSIAvlbWfx4D3rgNAA==}
+    engines: {node: '>=18'}
 
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
@@ -5172,6 +5235,9 @@ packages:
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
+  es-module-lexer@3.0.2:
+    resolution: {integrity: sha512-BuIB67FngDSyQ/dpQNOZybwdEBDUGJQvOqwWr4ha/ufYiqzuEwPkKO2zLhRAgay28tStRIHUeWmszZAJo3GCOg==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -5776,12 +5842,13 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
-  immediate@3.0.6:
-    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
-
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.5.0:
+    resolution: {integrity: sha512-O6wo8l0lhBuytKz3x8S65TvacFtoopji+gCVeEBbjCaRy75gkk4bCBQoVmY7OEZ63cbFK+yf77pDCTWaadV7hQ==}
+    engines: {node: '>=18'}
 
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
@@ -6399,9 +6466,6 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lie@3.1.1:
-    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
-
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -6428,9 +6492,6 @@ packages:
   load-json-file@4.0.0:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
-
-  localforage@1.10.0:
-    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
 
   locate-path@2.0.0:
     resolution: {integrity: sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==}
@@ -6734,6 +6795,9 @@ packages:
   modify-values@1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -7291,6 +7355,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   reserved-words@0.1.2:
     resolution: {integrity: sha512-0S5SrIUJ9LfpbVl4Yzij6VipUdafHrOTzvmfazSw/jeZrZtQK303OPZW+obtkaw7jQlTQppy0UvZWm9872PbRw==}
@@ -10315,6 +10383,49 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.5.0
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.11.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
   '@oxc-parser/binding-android-arm-eabi@0.133.0':
     optional: true
 
@@ -10514,37 +10625,52 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@sentry-internal/tracing@7.120.4':
-    dependencies:
-      '@sentry/core': 7.120.4
-      '@sentry/types': 7.120.4
-      '@sentry/utils': 7.120.4
+  '@sentry/conventions@0.16.0': {}
 
-  '@sentry/core@7.120.4':
+  '@sentry/core@10.73.0':
     dependencies:
-      '@sentry/types': 7.120.4
-      '@sentry/utils': 7.120.4
+      '@sentry/conventions': 0.16.0
 
-  '@sentry/integrations@7.120.4':
+  '@sentry/node-core@10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@sentry/core': 7.120.4
-      '@sentry/types': 7.120.4
-      '@sentry/utils': 7.120.4
-      localforage: 1.10.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.5.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
 
-  '@sentry/node@7.120.4':
+  '@sentry/node@10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@sentry-internal/tracing': 7.120.4
-      '@sentry/core': 7.120.4
-      '@sentry/integrations': 7.120.4
-      '@sentry/types': 7.120.4
-      '@sentry/utils': 7.120.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+      '@sentry/node-core': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.73.0
+      import-in-the-middle: 3.5.0
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
-  '@sentry/types@7.120.4': {}
-
-  '@sentry/utils@7.120.4':
+  '@sentry/opentelemetry@10.73.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.11.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@sentry/types': 7.120.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.11.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.11.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
+
+  '@sentry/server-utils@10.73.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.73.0
 
   '@sinclair/typebox@0.34.49': {}
 
@@ -12321,6 +12447,8 @@ snapshots:
 
   es-module-lexer@2.3.2: {}
 
+  es-module-lexer@3.0.2: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -13087,12 +13215,16 @@ snapshots:
 
   ignore@7.0.5: {}
 
-  immediate@3.0.6: {}
-
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@3.5.0:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 3.0.2
+      module-details-from-path: 1.0.4
 
   import-local@3.2.0:
     dependencies:
@@ -14186,10 +14318,6 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lie@3.1.1:
-    dependencies:
-      immediate: 3.0.6
-
   lilconfig@3.1.3: {}
 
   line-reader@0.2.4: {}
@@ -14228,10 +14356,6 @@ snapshots:
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
-
-  localforage@1.10.0:
-    dependencies:
-      lie: 3.1.1
 
   locate-path@2.0.0:
     dependencies:
@@ -14622,6 +14746,8 @@ snapshots:
     optional: true
 
   modify-values@1.0.1: {}
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.0.0:
     optional: true
@@ -15360,6 +15486,13 @@ snapshots:
 
   require-from-string@2.0.2:
     optional: true
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3(supports-color@7.2.0)
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   reserved-words@0.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -997,7 +997,7 @@ importers:
         specifier: workspace:*
         version: link:../provider-schema
       '@sentry/node':
-        specifier: ^10.73.0
+        specifier: 10.73.0
         version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       cdktn:
         specifier: workspace:*
@@ -1085,7 +1085,7 @@ importers:
   packages/@cdktn/commons:
     dependencies:
       '@sentry/node':
-        specifier: ^10.73.0
+        specifier: 10.73.0
         version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       cdktn:
         specifier: workspace:*
@@ -1441,7 +1441,7 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@sentry/node':
-        specifier: ^10.73.0
+        specifier: 10.73.0
         version: 10.73.0(@opentelemetry/core@2.11.0(@opentelemetry/api@1.9.1))
       '@types/fs-extra':
         specifier: 11.0.4


### PR DESCRIPTION
Part 1 of 6 in a stack; review order S1 → S6; base is the previous slice (this one is based on `main`).

1. `chore(deps): upgrade @sentry/node to 10.x with unchanged reporting behaviour` (this PR)
2. `fix(cli): stop the top-level error handler racing yargs`
3. `feat(cli): replace HashiCorp checkpoint telemetry with Sentry usage metrics and consent`
4. `feat(cli): report the installed binary, target versions and platform in usage metrics`
5. `feat(cli): report per-stack, per-provider and per-command usage metrics`
6. `chore(gha): run the telemetry delivery e2e on every build`

### Related issue

Part of #48

### Description

Sentry sunset the 7.x custom-metrics product server side on 2024-10-07, so on `@sentry/node` `7.120.4` any metric emission is a silent no-op. The usage metrics that replace the HashiCorp checkpoint transport (S3 onwards) therefore need the v10 metrics API. This slice is that upgrade on its own, with error and crash reporting behaviour deliberately unchanged, so the SDK bump can be reviewed and bisected apart from the telemetry work.

What changes:

- `packages/@cdktn/commons/package.json`, `packages/@cdktn/cli-core/package.json`, `packages/cdktn-cli/package.json`: `@sentry/node` moves to `^10.73.0` in all three at once, so the bundle keeps a single shared SDK instance. `pnpm-lock.yaml` is regenerated; only `@sentry/*` and its transitives move.
- `packages/@cdktn/cli-core/src/lib/error-reporting.ts`: `Sentry.configureScope` becomes `getCurrentScope()`, and the `Sentry.init` option block is rebuilt for v10. Options removed by the SDK are dropped, `tracesSampleRate: 0` is pinned (metrics deliver independently of trace sampling), `environment` is pinned to `production` so `SENTRY_ENVIRONMENT` is never read, a fresh propagation context is set so an inherited `SENTRY_TRACE` / `SENTRY_BAGGAGE` is discarded, and `serverName` is fixed to `cdktn-cli`.
- `packages/@cdktn/commons/src/errors.ts`: the same scope-API change inside `setScope`. The factories themselves are untouched here.
- `packages/@cdktn/cli-core/src/test/error-reporting.test.ts`: the init-options assertion (release, `tracesSampleRate: 0`, `serverName`, `environment`) plus the mock-factory shape it needs.

The one visible effect on today's behaviour is a privacy improvement that falls out of the fixed `serverName`: crash reports no longer carry the machine hostname, which the SDK attached by default. Nothing else about what is reported, or when, changes in this slice; there is still no usage telemetry of any kind here.

**Start with** the `Sentry.init` option block in `packages/@cdktn/cli-core/src/lib/error-reporting.ts`, then the matching assertion in `packages/@cdktn/cli-core/src/test/error-reporting.test.ts`, then the lockfile delta.

Reading order for this slice:

1. `packages/@cdktn/cli-core/src/lib/error-reporting.ts`
2. `packages/@cdktn/commons/src/errors.ts`
3. `packages/@cdktn/cli-core/src/test/error-reporting.test.ts`
4. the three `package.json` files and `pnpm-lock.yaml`

### Test plan

- [x] Unit tests green across `@cdktn/commons`, `@cdktn/cli-core` and `cdktn-cli` on this slice against `main`
- [x] Init-options assertion covers release, `tracesSampleRate: 0`, `serverName: "cdktn-cli"` and `environment: "production"`
- [x] Crash-reporting behaviour unchanged: the existing `shouldReportCrash` and `captureException` tests pass untouched
- [x] `pnpm install` lockfile delta inspected: only `@sentry/*` and its transitive dependencies move
- [x] Lint and `pnpm prettier --check .` clean

### Follow-ups (documented, not in this PR)

- `@sentry/node` is a devDependency of `cdktn-cli` (it reaches users through the bundle and through `@cdktn/commons`). Worth confirming that is intended rather than incidental.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable (follow-up in cdk-terrain-docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
