### PR TITLE
fix(cli): stop the top-level error handler racing yargs

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts
+++ b/packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts
@@ -455,7 +455,12 @@ export class TerraformCli implements Terraform {
       exitCode !== 0 &&
       !snapshot.context.cancelled // don't fail if we cancelled the run
     ) {
-      throw `Invoking Terraform CLI failed with exit code ${exitCode}`;
+      // A plain Error, not Errors.External: a non-zero terraform exit is
+      // exactly what the entrypoint's debug collection exists for, and only
+      // untyped errors trigger it.
+      throw new Error(
+        `Invoking Terraform CLI failed with exit code ${exitCode}`,
+      );
     }
 
     return { cancelled: Boolean(snapshot.context.cancelled) };

--- a/packages/@cdktn/cli-core/src/lib/watch.ts
+++ b/packages/@cdktn/cli-core/src/lib/watch.ts
@@ -149,10 +149,18 @@ export async function watch(
     }
   }
 
-  abortSignal.addEventListener("abort", () => {
-    logger.debug("Abort signal received, stopping watch");
-    watcher.close();
-    changeState({ type: "stopped" });
+  // The session ends only on abort: the CLI exits as soon as its handler
+  // returns, so resolving earlier would end `cdktn watch` after the first run.
+  const stopped = new Promise<void>((resolve) => {
+    abortSignal.addEventListener("abort", async () => {
+      logger.debug("Abort signal received, stopping watch");
+      const inFlight = state.type === "running" ? state.currentRun : undefined;
+      await watcher.close();
+      changeState({ type: "stopped" });
+      // hardAbort rejects the in-flight deploy; that ends the run, not the process
+      await inFlight?.catch(() => undefined);
+      resolve();
+    });
   });
 
   const onFileChange = () => {
@@ -178,4 +186,5 @@ export async function watch(
   onFileChange();
 
   await sendTelemetry("watch", { event: "start" });
+  await stopped;
 }

--- a/packages/@cdktn/cli-core/src/test/lib/cdktf-project.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/cdktf-project.test.ts
@@ -421,7 +421,7 @@ describeIfDistExists(__dirname)("CdktfProject", () => {
         throw new Error("This error should not be thrown");
       } catch (e) {
         expect(e).toMatchInlineSnapshot(
-          `"Invoking Terraform CLI failed with exit code 1"`
+          `[Error: Invoking Terraform CLI failed with exit code 1]`
         );
       }
 

--- a/packages/@cdktn/cli-core/src/test/lib/watch.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/watch.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { EventEmitter } from "events";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+const watcher = Object.assign(new EventEmitter(), {
+  close: jest.fn().mockResolvedValue(undefined),
+});
+jest.mock("chokidar", () => ({ watch: () => watcher }));
+
+// A deploy that runs until the project is hard-aborted, like a real one
+// waiting on terraform.
+let currentDeploy: { reject: (e: Error) => void } | undefined;
+jest.mock("../../lib/cdktf-project", () => ({
+  CdktfProject: class {
+    public stacksToRun = [];
+    public hardAbort = () => {
+      const e = new Error("aborted");
+      e.name = "AbortError";
+      currentDeploy?.reject(e);
+    };
+    public deploy = () =>
+      new Promise<void>((_resolve, reject) => {
+        currentDeploy = { reject };
+      });
+  },
+}));
+
+import { watch, State } from "../../lib/watch";
+
+const settled = (p: Promise<unknown>) =>
+  Promise.race([
+    p.then(() => true),
+    new Promise<boolean>((r) => setTimeout(() => r(false), 50)),
+  ]);
+
+describe("watch", () => {
+  const originalCwd = process.cwd();
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cdktn-watch-"));
+    fs.writeFileSync(
+      path.join(tmp, "cdktf.json"),
+      JSON.stringify({ language: "typescript", watchPattern: ["./**/*.ts"] }),
+    );
+    process.chdir(tmp);
+    watcher.close.mockClear();
+    currentDeploy = undefined;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // the CLI exits as soon as the handler returns, so an early resolution
+  // would end `cdktn watch` right after its first deploy started
+  it("stays pending until aborted, then stops the watcher and settles the in-flight run", async () => {
+    const ac = new AbortController();
+    const states: State["type"][] = [];
+    const session = watch(
+      { synthCommand: "true", outDir: "out", onUpdate: () => {} },
+      { autoApprove: true },
+      ac.signal,
+      (state) => states.push(state.type),
+    );
+
+    expect(await settled(session)).toBe(false);
+    expect(states).toEqual(["running"]);
+    expect(watcher.close).not.toHaveBeenCalled();
+
+    ac.abort();
+
+    await session;
+    expect(watcher.close).toHaveBeenCalledTimes(1);
+    expect(states[states.length - 1]).toBe("stopped");
+  });
+});

--- a/packages/@cdktn/cli-core/src/test/models/terraform-cli.test.ts
+++ b/packages/@cdktn/cli-core/src/test/models/terraform-cli.test.ts
@@ -59,7 +59,7 @@ describe("terraform-cli", () => {
       // The exit code is produced as the machine's final-state output and read off the settled snapshot.
       jest.mocked(spawnInteractive).mockImplementation(silentPty(3));
 
-      await expect(makeCli().deploy({}, () => {})).rejects.toMatch(
+      await expect(makeCli().deploy({}, () => {})).rejects.toThrow(
         /exit code 3/,
       );
     });

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
@@ -41,8 +41,29 @@ function fixtureSource(errorHandlingPath: string): string {
     });
   }
 
+  // cdktn.ts' completion function, minus the manifest: answers for "diff"
+  // only after a turn of the event loop
+  const customCompletion = function (_current, argv, completionsFilter, done) {
+    if (argv._.includes("diff")) {
+      completionsFilter(async (_err, defaults) => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        done([...defaults, 'alpha:target stack "alpha"']);
+      });
+    } else {
+      completionsFilter();
+    }
+  };
+
   const cli = yargs(process.argv.slice(2).filter((a) => a !== "--with-listener"))
     .exitProcess(false)
+    .completion("completion", customCompletion)
+    .command(
+      "diff [stack]",
+      "diffs a stack",
+      (cmdYargs) =>
+        cmdYargs.positional("stack", { type: "string", desc: "the stack" }),
+      () => {},
+    )
     .command(
       "rawboom",
       "throws an async raw string",
@@ -293,6 +314,21 @@ describe("runCli child-process smoke test", () => {
     expect(exitCode).toBe(0);
     expect(stderr).not.toContain("EPIPE");
     expectNoRuntimeNoise(stderr);
+  }, 15000);
+
+  it("prints the completions of an asynchronous completion function", async () => {
+    // `cdktn diff <TAB>`: yargs does not await the completion callback, so
+    // parseAsync resolves before an async completion function has printed
+    const result = await execa(
+      process.execPath,
+      [bundlePath, "--get-yargs-completions", "fixture", "diff", ""],
+      { reject: false },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('alpha:target stack "alpha"');
+    expect(result.stdout).toContain("--help");
+    expectNoRuntimeNoise(`${result.stdout}\n${result.stderr}`);
   }, 15000);
 
   it("exits 1 within the flush bound when the ingest endpoint never answers on the failure path", async () => {

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
@@ -4,6 +4,7 @@
 // Bundles a tiny fixture with esbuild and runs it as a separate Node process,
 // so runCli() meets the runtime's real unhandled-rejection behaviour. Not
 // dist-gated: no prebuilt CLI, terraform or network is needed.
+import { spawn } from "child_process";
 import * as fs from "fs";
 import * as http from "http";
 import type { AddressInfo } from "net";
@@ -65,6 +66,20 @@ function fixtureSource(errorHandlingPath: string): string {
       async () => {
         Sentry.captureMessage("empirical-success-message");
         console.log("capturedok-done");
+      },
+    )
+    .command(
+      "pipedok",
+      "prints one line, then waits for stdin to end before returning",
+      () => {},
+      async () => {
+        console.log("pipedok-first-line");
+        // lets the test close its end of the stdout pipe before the success
+        // path drains stdio
+        await new Promise((resolve) => {
+          process.stdin.once("end", resolve);
+          process.stdin.resume();
+        });
       },
     );
 
@@ -252,6 +267,32 @@ describe("runCli child-process smoke test", () => {
     } finally {
       await sink.close();
     }
+  }, 15000);
+
+  it("exits 0 when the stdout reader closes before the success path drains stdio", async () => {
+    // `cdktn --help | head -1`: the reader is gone by the time the drain
+    // writes, so that write gets EPIPE and Node emits 'error' on stdout
+    const child = spawn(process.execPath, [bundlePath, "pipedok"], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => (stderr += chunk));
+    const firstChunk = await new Promise<string>((resolve) => {
+      child.stdout.setEncoding("utf8");
+      child.stdout.once("data", resolve);
+    });
+    child.stdout.destroy(); // closes the read end: every later write is EPIPE
+    child.stdin.end(); // only now may the handler return and the drain run
+    const [exitCode] = await new Promise<[number | null, string | null]>(
+      (resolve) =>
+        child.once("close", (code, signal) => resolve([code, signal])),
+    );
+
+    expect(firstChunk).toContain("pipedok-first-line");
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("EPIPE");
+    expectNoRuntimeNoise(stderr);
   }, 15000);
 
   it("exits 1 within the flush bound when the ingest endpoint never answers on the failure path", async () => {

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+//
+// Bundles a tiny fixture with esbuild and runs it as a separate Node process,
+// so runCli() meets the runtime's real unhandled-rejection behaviour. Not
+// dist-gated: no prebuilt CLI, terraform or network is needed.
+import * as fs from "fs";
+import * as http from "http";
+import type { AddressInfo } from "net";
+import * as os from "os";
+import * as path from "path";
+import * as zlib from "zlib";
+import * as esbuild from "esbuild";
+import execa from "execa";
+
+function fixtureSource(errorHandlingPath: string): string {
+  return `
+  import yargs from "yargs";
+  import * as Sentry from "@sentry/node";
+  import { runCli } from ${JSON.stringify(errorHandlingPath)};
+
+  if (process.argv.includes("--with-listener")) {
+    // stands in for Sentry's OnUnhandledRejection integration: if runCli()
+    // ever orphans a rejection, this would be the thing that catches it.
+    process.on("unhandledRejection", (reason) => {
+      console.error("stub-sentry-caught:", reason);
+    });
+  }
+
+  // Points the SDK at a local sink instead of sentry.io, standing in for
+  // the initializErrorReporting() call every real command handler makes
+  // (see cli-core's error-reporting.ts) before runCli() can ever report.
+  if (process.env.TEST_SENTRY_DSN) {
+    Sentry.init({
+      dsn: process.env.TEST_SENTRY_DSN,
+      release: "cdktn-cli-test",
+      environment: "production",
+      tracesSampleRate: 0,
+      serverName: "cdktn-cli",
+    });
+  }
+
+  const cli = yargs(process.argv.slice(2).filter((a) => a !== "--with-listener"))
+    .exitProcess(false)
+    .command(
+      "rawboom",
+      "throws an async raw string",
+      () => {},
+      async () => {
+        throw "raw-string-message";
+      },
+    )
+    .command(
+      "capturedboom",
+      "throws an async Error that should reach Sentry",
+      () => {},
+      async () => {
+        throw new Error("empirical-sentry-message");
+      },
+    );
+
+  void runCli(cli);
+`;
+}
+
+// A minimal stand-in for Sentry's ingest endpoint: records every request it
+// receives so the test can assert an actual envelope was delivered over the
+// wire, not just that some in-process function was called.
+function startSentrySink(): Promise<{
+  port: number;
+  requests: () => { url: string; body: string }[];
+  close: () => Promise<void>;
+}> {
+  const requests: { url: string; body: string }[] = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        let body = Buffer.concat(chunks);
+        if (req.headers["content-encoding"] === "gzip") {
+          body = zlib.gunzipSync(body);
+        }
+        requests.push({ url: req.url || "", body: body.toString("utf8") });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        port,
+        requests: () => requests,
+        close: () => new Promise((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+describe("runCli child-process smoke test", () => {
+  let bundlePath: string;
+
+  beforeAll(async () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "cdktn-error-handling-fixture-"),
+    );
+    const fixturePath = path.join(tmpDir, "fixture.ts");
+    bundlePath = path.join(tmpDir, "fixture.bundle.js");
+
+    const errorHandlingPath = path
+      .resolve(__dirname, "../error-handling.ts")
+      .replace(/\.ts$/, "");
+    fs.writeFileSync(fixturePath, fixtureSource(errorHandlingPath));
+
+    // The fixture sits under os.tmpdir() with no node_modules ancestry, so its
+    // bare imports are aliased to the workspace copies error-handling.ts itself
+    // resolves: one Sentry client.
+    await esbuild.build({
+      entryPoints: [fixturePath],
+      bundle: true,
+      platform: "node",
+      format: "cjs",
+      outfile: bundlePath,
+      alias: {
+        yargs: require.resolve("yargs"),
+        "@sentry/node": require.resolve("@sentry/node"),
+      },
+    });
+  }, 60000);
+
+  it("prints a raw-string handler rejection exactly once and never crashes the process", async () => {
+    const result = await execa(process.execPath, [bundlePath, "rawboom"], {
+      reject: false,
+    });
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(1);
+    expect(output.split("raw-string-message").length - 1).toBe(1);
+    expect(output).not.toContain("ERR_UNHANDLED_REJECTION");
+    expect(output).not.toContain("UnhandledPromiseRejection");
+    expect(output).not.toContain("PromiseRejectionHandledWarning");
+    expect(output).not.toContain("Node.js v");
+  });
+
+  it("still orphans nothing when a Sentry-style unhandledRejection listener is installed", async () => {
+    const result = await execa(
+      process.execPath,
+      [bundlePath, "rawboom", "--with-listener"],
+      { reject: false },
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.exitCode).toBe(1);
+    expect(output.split("raw-string-message").length - 1).toBe(1);
+    expect(output).not.toContain("stub-sentry-caught");
+    expect(output).not.toContain("ERR_UNHANDLED_REJECTION");
+    expect(output).not.toContain("UnhandledPromiseRejection");
+    expect(output).not.toContain("PromiseRejectionHandledWarning");
+    expect(output).not.toContain("Node.js v");
+  });
+
+  it("delivers the crash to Sentry before the process exits", async () => {
+    const sink = await startSentrySink();
+    try {
+      const dsn = `http://public@127.0.0.1:${sink.port}/1`;
+      const result = await execa(
+        process.execPath,
+        [bundlePath, "capturedboom"],
+        { env: { ...process.env, TEST_SENTRY_DSN: dsn }, reject: false },
+      );
+
+      // the process exits only after reportFailure awaited the flush, so
+      // everything it delivered has already reached the sink
+      expect(result.exitCode).toBe(1);
+      const bodies = sink
+        .requests()
+        .filter((r) => r.url.includes("/envelope/"))
+        .map((r) => r.body);
+      expect(bodies.length).toBeGreaterThan(0);
+      expect(bodies.some((b) => b.includes("empirical-sentry-message"))).toBe(
+        true,
+      );
+    } finally {
+      await sink.close();
+    }
+  }, 15000);
+});

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.integration.test.ts
@@ -57,6 +57,15 @@ function fixtureSource(errorHandlingPath: string): string {
       async () => {
         throw new Error("empirical-sentry-message");
       },
+    )
+    .command(
+      "capturedok",
+      "succeeds after queueing an event, like a usage metric would",
+      () => {},
+      async () => {
+        Sentry.captureMessage("empirical-success-message");
+        console.log("capturedok-done");
+      },
     );
 
   void runCli(cli);
@@ -95,6 +104,42 @@ function startSentrySink(): Promise<{
       });
     });
   });
+}
+
+// A sink that accepts the envelope connection and never answers: the
+// transport's request then keeps the event loop alive until something exits
+// the process explicitly.
+function startSilentSentrySink(): Promise<{
+  port: number;
+  connections: () => number;
+  close: () => Promise<void>;
+}> {
+  let connections = 0;
+  return new Promise((resolve) => {
+    const server = http.createServer(() => {
+      connections += 1;
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        port,
+        connections: () => connections,
+        close: () =>
+          new Promise((res) => {
+            server.closeAllConnections();
+            server.close(() => res());
+          }),
+      });
+    });
+  });
+}
+
+function expectNoRuntimeNoise(output: string) {
+  expect(output).not.toContain("ERR_UNHANDLED_REJECTION");
+  expect(output).not.toContain("UnhandledPromiseRejection");
+  expect(output).not.toContain("PromiseRejectionHandledWarning");
+  expect(output).not.toContain("Warning:");
+  expect(output).not.toContain("Node.js v");
 }
 
 describe("runCli child-process smoke test", () => {
@@ -180,6 +225,53 @@ describe("runCli child-process smoke test", () => {
       expect(bodies.some((b) => b.includes("empirical-sentry-message"))).toBe(
         true,
       );
+    } finally {
+      await sink.close();
+    }
+  }, 15000);
+
+  it("exits 0 within the flush bound when the ingest endpoint never answers on the success path", async () => {
+    const sink = await startSilentSentrySink();
+    try {
+      const dsn = `http://public@127.0.0.1:${sink.port}/1`;
+      const started = Date.now();
+      const result = await execa(process.execPath, [bundlePath, "capturedok"], {
+        env: { ...process.env, TEST_SENTRY_DSN: dsn },
+        reject: false,
+      });
+      const elapsedMs = Date.now() - started;
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      // the hung request would keep the loop alive forever; the bounded
+      // flush (4 s) plus the explicit exit is what ends the process
+      expect(result.exitCode).toBe(0);
+      expect(elapsedMs).toBeLessThan(8000);
+      expect(sink.connections()).toBeGreaterThan(0);
+      expect(result.stdout).toContain("capturedok-done");
+      expectNoRuntimeNoise(output);
+    } finally {
+      await sink.close();
+    }
+  }, 15000);
+
+  it("exits 1 within the flush bound when the ingest endpoint never answers on the failure path", async () => {
+    const sink = await startSilentSentrySink();
+    try {
+      const dsn = `http://public@127.0.0.1:${sink.port}/1`;
+      const started = Date.now();
+      const result = await execa(
+        process.execPath,
+        [bundlePath, "capturedboom"],
+        { env: { ...process.env, TEST_SENTRY_DSN: dsn }, reject: false },
+      );
+      const elapsedMs = Date.now() - started;
+      const output = `${result.stdout}\n${result.stderr}`;
+
+      expect(result.exitCode).toBe(1);
+      expect(elapsedMs).toBeLessThan(8000);
+      expect(sink.connections()).toBeGreaterThan(0);
+      expect(output).toContain("empirical-sentry-message");
+      expectNoRuntimeNoise(output);
     } finally {
       await sink.close();
     }

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
@@ -437,4 +437,33 @@ describe("runCli", () => {
     expect(exitCallCount).toBe(1);
     expect(exitCode).toBe(0);
   });
+
+  it("still exits 0 when the stdout reader closed early and the drain write gets EPIPE", async () => {
+    // What Node does for `cdktn --help | head -1`: the write callback gets
+    // EPIPE, then 'error' is emitted on the stream; unhandled, that throws.
+    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    const errorListeners = process.stdout.listenerCount("error");
+    const writeSpy = jest.spyOn(process.stdout, "write").mockImplementation(((
+      ...args: unknown[]
+    ) => {
+      const cb = args.find((a) => typeof a === "function") as
+        ((err?: Error) => void) | undefined;
+      cb?.(epipe);
+      process.nextTick(() => process.stdout.emit("error", epipe));
+      return false;
+    }) as never);
+    try {
+      const deps = makeDeps();
+      const { exitCode, exitCallCount, unhandledRejections } =
+        await runAndCapture(["ok"], deps);
+
+      expect(unhandledRejections).toEqual([]);
+      expect(exitCallCount).toBe(1);
+      expect(exitCode).toBe(0);
+    } finally {
+      writeSpy.mockRestore();
+    }
+    // the drain's one-shot listener was consumed by the emitted 'error'
+    expect(process.stdout.listenerCount("error")).toBe(errorListeners);
+  });
 });

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
@@ -1,0 +1,388 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import yargs, { Argv } from "yargs";
+import { Errors } from "@cdktn/commons";
+import {
+  describeError,
+  reportFailure,
+  runCli,
+  SENTRY_FLUSH_TIMEOUT_MS,
+  FailureReporterDeps,
+} from "../error-handling";
+
+// Node reports an orphaned rejection at the end of the tick that orphaned it;
+// two setImmediate turns land strictly after that, making "was anything
+// orphaned" a deterministic check.
+async function flushMicroAndMacrotasks() {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+function allLoggedText(deps: FailureReporterDeps): string[] {
+  const log = deps.log as jest.Mock;
+  const logError = deps.logError as jest.Mock;
+  return [...log.mock.calls, ...logError.mock.calls].map((args) => args[0]);
+}
+
+function makeDeps(): FailureReporterDeps {
+  return {
+    log: jest.fn(),
+    logError: jest.fn(),
+    collectDebugInformation: jest
+      .fn()
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => setImmediate(() => resolve({ node: "24" }))),
+      ),
+    captureException: jest.fn(),
+    flushTelemetry: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+// `yargs(args)` builds a fresh instance per test, so commands and `.fail()`
+// handlers never leak between cases.
+function makeCli(args: string[], handlers: { ok?: jest.Mock } = {}) {
+  return yargs(args)
+    .exitProcess(false)
+    .command(
+      "boom",
+      "throws an async Error",
+      () => {},
+      async () => {
+        throw new Error("boom-message");
+      },
+    )
+    .command(
+      "rawboom",
+      "throws an async raw string",
+      () => {},
+      async () => {
+        throw "raw-string-message";
+      },
+    )
+    .command(
+      "syncboom",
+      "throws synchronously",
+      () => {},
+      () => {
+        throw new Error("sync-boom-message");
+      },
+    )
+    .command(
+      "usageboom",
+      "throws a Usage error",
+      () => {},
+      // async like real handlers, so this takes the handler-rejection path
+      // rather than the yargs-validation path (`choice` below)
+      async () => {
+        throw Errors.Usage("bad-usage-message");
+      },
+    )
+    .command(
+      "externalboom",
+      "throws an External error",
+      () => {},
+      async () => {
+        throw Errors.External("bad-external-message");
+      },
+    )
+    .command(
+      "ok",
+      "succeeds",
+      () => {},
+      () => {
+        handlers.ok?.();
+      },
+    )
+    .command(
+      "choice",
+      "has an invalid-choice option",
+      (cmdYargs: Argv) =>
+        cmdYargs.option("language", {
+          type: "string",
+          choices: ["typescript", "python"],
+        }),
+      () => {
+        handlers.ok?.();
+      },
+    );
+}
+
+async function runAndCapture(
+  args: string[],
+  deps: FailureReporterDeps,
+  handlers: { ok?: jest.Mock } = {},
+) {
+  const cli = makeCli(args, handlers);
+  const exitSpy = jest
+    .spyOn(process, "exit")
+    .mockImplementation((() => undefined) as never);
+  const unhandledRejections: unknown[] = [];
+  const onUnhandled = (reason: unknown) => unhandledRejections.push(reason);
+  process.on("unhandledRejection", onUnhandled);
+
+  try {
+    await runCli(cli, deps);
+  } finally {
+    await flushMicroAndMacrotasks();
+    process.off("unhandledRejection", onUnhandled);
+  }
+
+  // read the calls before mockRestore(), which also resets them
+  const exitCallCount = exitSpy.mock.calls.length;
+  const lastCall = exitSpy.mock.calls[exitCallCount - 1];
+  const exitCode = lastCall ? (lastCall[0] as number | undefined) : undefined;
+  exitSpy.mockRestore();
+  return { exitCode, exitCallCount, unhandledRejections };
+}
+
+describe("describeError", () => {
+  it("handles a real Error", () => {
+    const e = new Error("oops");
+    const { message, stack } = describeError(e);
+    expect(message).toBe("oops");
+    expect(stack).toBe(e.stack);
+  });
+
+  it("handles a raw string throw", () => {
+    expect(describeError("just a string")).toEqual({
+      message: "just a string",
+    });
+  });
+
+  it("handles an error-shaped plain object", () => {
+    expect(describeError({ message: "shaped", stack: "at x" })).toEqual({
+      message: "shaped",
+      stack: "at x",
+    });
+  });
+
+  it("handles an unrelated plain object", () => {
+    const { message, stack } = describeError({ foo: "bar" });
+    expect(message).toContain('{"foo":"bar"}');
+    expect(stack).toBeUndefined();
+  });
+
+  it("handles a circular object without throwing", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const { message } = describeError(circular);
+    expect(typeof message).toBe("string");
+    expect(message).toContain("Unexpected non-Error value thrown");
+  });
+});
+
+describe("reportFailure", () => {
+  it("prints Usage errors as a single line with no debug info, and never reports them to Sentry", async () => {
+    const deps = makeDeps();
+    const error = Errors.Usage("bad-usage-message");
+    const code = await reportFailure({ message: null, error }, deps);
+
+    expect(code).toBe(1);
+    expect(deps.collectDebugInformation).not.toHaveBeenCalled();
+    expect(allLoggedText(deps)).toEqual(["Usage Error: bad-usage-message"]);
+    // beforeSend (cli-core's error-reporting.ts) drops "Usage Error" anyway;
+    // don't even try to capture one.
+    expect(deps.captureException).not.toHaveBeenCalled();
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+  });
+
+  it("prints External errors as a single line with no debug info, but does report them to Sentry", async () => {
+    const deps = makeDeps();
+    const error = Errors.External("bad-external-message");
+    const code = await reportFailure({ message: null, error }, deps);
+
+    expect(code).toBe(1);
+    expect(deps.collectDebugInformation).not.toHaveBeenCalled();
+    expect(allLoggedText(deps)).toEqual([
+      "External Error: bad-external-message",
+    ]);
+    expect(deps.captureException).toHaveBeenCalledWith(error);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+  });
+
+  it("reports a message + Error with message, stack, then debug info, and captures it for Sentry before flushing", async () => {
+    const deps = makeDeps();
+    const error = new Error("boom-message");
+    const captureOrder: string[] = [];
+    (deps.captureException as jest.Mock).mockImplementation(() =>
+      captureOrder.push("capture"),
+    );
+    (deps.flushTelemetry as jest.Mock).mockImplementation(async () => {
+      captureOrder.push("flush");
+    });
+    const code = await reportFailure({ message: null, error }, deps);
+
+    expect(code).toBe(1);
+    const texts = allLoggedText(deps);
+    expect(texts.filter((t) => t === "boom-message").length).toBe(1);
+    expect(texts).toContain(error.stack);
+    expect(texts).toContain("Collecting Debug Information...");
+    expect(texts).toContain("Debug Information:");
+    expect(deps.captureException).toHaveBeenCalledWith(error);
+    // the capture must happen before the flush, or the flush has nothing
+    // queued to send.
+    expect(captureOrder).toEqual(["capture", "flush"]);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+  });
+
+  it("never prints the literal 'undefined' for a raw-string throw, and still captures it for Sentry", async () => {
+    const deps = makeDeps();
+    const code = await reportFailure(
+      { message: null, error: "raw-string-message" },
+      deps,
+    );
+
+    expect(code).toBe(1);
+    const texts = allLoggedText(deps);
+    expect(texts).toContain("raw-string-message");
+    expect(texts).not.toContain("undefined");
+    expect(deps.captureException).toHaveBeenCalledWith("raw-string-message");
+  });
+
+  it("reports a debug-collection failure without masking the original error", async () => {
+    const deps = makeDeps();
+    (deps.collectDebugInformation as jest.Mock).mockRejectedValue(
+      new Error("debug collection exploded"),
+    );
+    const code = await reportFailure(
+      { message: null, error: new Error("boom-message") },
+      deps,
+    );
+
+    expect(code).toBe(1);
+    const texts = allLoggedText(deps);
+    expect(texts).toContain("boom-message");
+    expect(
+      texts.some((t) => t.includes("Could not collect debug information")),
+    ).toBe(true);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+  });
+
+  it("still flushes Sentry even if captureException itself throws", async () => {
+    const deps = makeDeps();
+    (deps.captureException as jest.Mock).mockImplementation(() => {
+      throw new Error("sentry client exploded");
+    });
+    const code = await reportFailure(
+      { message: null, error: new Error("boom-message") },
+      deps,
+    );
+
+    expect(code).toBe(1);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+  });
+});
+
+describe("runCli", () => {
+  it("reports an async Error thrown by a command handler exactly once, with no orphaned rejection", async () => {
+    const deps = makeDeps();
+    const { exitCode, exitCallCount, unhandledRejections } =
+      await runAndCapture(["boom"], deps);
+
+    expect(unhandledRejections).toEqual([]);
+    expect(exitCode).toBe(1);
+    expect(exitCallCount).toBe(1);
+    const texts = allLoggedText(deps);
+    expect(texts.filter((t) => t === "boom-message").length).toBe(1);
+    expect(texts).toContain("Collecting Debug Information...");
+    expect(texts).toContain("Debug Information:");
+    expect(deps.captureException).toHaveBeenCalledTimes(1);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+  });
+
+  it("reports an async raw-string throw without ever printing 'undefined'", async () => {
+    const deps = makeDeps();
+    const { exitCode, unhandledRejections } = await runAndCapture(
+      ["rawboom"],
+      deps,
+    );
+
+    expect(unhandledRejections).toEqual([]);
+    expect(exitCode).toBe(1);
+    const texts = allLoggedText(deps);
+    expect(texts).toContain("raw-string-message");
+    expect(texts).not.toContain("undefined");
+    expect(deps.captureException).toHaveBeenCalledWith("raw-string-message");
+  });
+
+  it("reports a synchronous handler throw", async () => {
+    const deps = makeDeps();
+    const { exitCode } = await runAndCapture(["syncboom"], deps);
+
+    expect(exitCode).toBe(1);
+    expect(allLoggedText(deps)).toContain("sync-boom-message");
+    expect(deps.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("prints Usage errors as one line, skips debug collection, and orphans no rejection", async () => {
+    const deps = makeDeps();
+    const { exitCode, unhandledRejections } = await runAndCapture(
+      ["usageboom"],
+      deps,
+    );
+
+    expect(unhandledRejections).toEqual([]);
+    expect(exitCode).toBe(1);
+    expect(deps.collectDebugInformation).not.toHaveBeenCalled();
+    expect(deps.captureException).not.toHaveBeenCalled();
+  });
+
+  it("prints External errors as one line, skips debug collection, and orphans no rejection, but does report to Sentry", async () => {
+    const deps = makeDeps();
+    const { exitCode, exitCallCount, unhandledRejections } =
+      await runAndCapture(["externalboom"], deps);
+
+    expect(unhandledRejections).toEqual([]);
+    expect(exitCode).toBe(1);
+    expect(exitCallCount).toBe(1);
+    expect(deps.collectDebugInformation).not.toHaveBeenCalled();
+    expect(deps.captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an invalid choice before the command handler runs", async () => {
+    const deps = makeDeps();
+    const handler = jest.fn();
+    const { exitCode } = await runAndCapture(
+      ["choice", "--language=nope"],
+      deps,
+      { ok: handler },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(handler).not.toHaveBeenCalled();
+    expect(allLoggedText(deps).some((t) => t.includes("Invalid values"))).toBe(
+      true,
+    );
+    // a yargs validation failure carries a message but no error, so there is
+    // nothing to capture
+    expect(deps.captureException).not.toHaveBeenCalled();
+  });
+
+  it("does not report a failure or exit on success", async () => {
+    const deps = makeDeps();
+    const handler = jest.fn();
+    const { exitCode, exitCallCount, unhandledRejections } =
+      await runAndCapture(["ok"], deps, { ok: handler });
+
+    expect(handler).toHaveBeenCalled();
+    expect(unhandledRejections).toEqual([]);
+    expect(exitCallCount).toBe(0);
+    expect(exitCode).toBeUndefined();
+    expect(deps.log).not.toHaveBeenCalled();
+    expect(deps.logError).not.toHaveBeenCalled();
+  });
+
+  it("does not report a failure or exit on --help", async () => {
+    const deps = makeDeps();
+    const { exitCallCount, unhandledRejections } = await runAndCapture(
+      ["--help"],
+      deps,
+    );
+
+    expect(unhandledRejections).toEqual([]);
+    expect(exitCallCount).toBe(0);
+    expect(deps.log).not.toHaveBeenCalled();
+    expect(deps.logError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
@@ -95,6 +95,14 @@ function makeCli(args: string[], handlers: { ok?: jest.Mock } = {}) {
       },
     )
     .command(
+      "setcode",
+      "succeeds after setting a non-zero exit code",
+      () => {},
+      () => {
+        process.exitCode = 3;
+      },
+    )
+    .command(
       "choice",
       "has an invalid-choice option",
       (cmdYargs: Argv) =>
@@ -111,12 +119,12 @@ function makeCli(args: string[], handlers: { ok?: jest.Mock } = {}) {
 async function runAndCapture(
   args: string[],
   deps: FailureReporterDeps,
-  handlers: { ok?: jest.Mock } = {},
+  handlers: { ok?: jest.Mock; onExit?: () => void } = {},
 ) {
   const cli = makeCli(args, handlers);
   const exitSpy = jest
     .spyOn(process, "exit")
-    .mockImplementation((() => undefined) as never);
+    .mockImplementation((() => handlers.onExit?.()) as never);
   const unhandledRejections: unknown[] = [];
   const onUnhandled = (reason: unknown) => unhandledRejections.push(reason);
   process.on("unhandledRejection", onUnhandled);
@@ -359,30 +367,74 @@ describe("runCli", () => {
     expect(deps.captureException).not.toHaveBeenCalled();
   });
 
-  it("does not report a failure or exit on success", async () => {
+  it("reports nothing on success, but flushes once (bounded) and then exits 0", async () => {
     const deps = makeDeps();
     const handler = jest.fn();
+    const order: string[] = [];
+    (deps.flushTelemetry as jest.Mock).mockImplementation(async () => {
+      order.push("flush");
+    });
     const { exitCode, exitCallCount, unhandledRejections } =
-      await runAndCapture(["ok"], deps, { ok: handler });
+      await runAndCapture(["ok"], deps, {
+        ok: handler,
+        onExit: () => order.push("exit"),
+      });
 
     expect(handler).toHaveBeenCalled();
     expect(unhandledRejections).toEqual([]);
-    expect(exitCallCount).toBe(0);
-    expect(exitCode).toBeUndefined();
     expect(deps.log).not.toHaveBeenCalled();
     expect(deps.logError).not.toHaveBeenCalled();
+    expect(deps.captureException).not.toHaveBeenCalled();
+    expect(deps.flushTelemetry).toHaveBeenCalledTimes(1);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+    // the explicit exit is what bounds an unresponsive ingest endpoint, so it
+    // must come after the flush, never instead of it
+    expect(order).toEqual(["flush", "exit"]);
+    expect(exitCallCount).toBe(1);
+    expect(exitCode).toBe(0);
   });
 
-  it("does not report a failure or exit on --help", async () => {
+  it("keeps the exit code a handler already set", async () => {
     const deps = makeDeps();
-    const { exitCallCount, unhandledRejections } = await runAndCapture(
-      ["--help"],
-      deps,
+    const originalExitCode = process.exitCode;
+    try {
+      const { exitCode, exitCallCount } = await runAndCapture(
+        ["setcode"],
+        deps,
+      );
+
+      expect(exitCallCount).toBe(1);
+      expect(exitCode).toBe(3);
+      expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+    } finally {
+      process.exitCode = originalExitCode;
+    }
+  });
+
+  it("still exits 0 when the flush itself rejects", async () => {
+    const deps = makeDeps();
+    (deps.flushTelemetry as jest.Mock).mockRejectedValue(
+      new Error("transport exploded"),
     );
+    const { exitCode, exitCallCount, unhandledRejections } =
+      await runAndCapture(["ok"], deps);
 
     expect(unhandledRejections).toEqual([]);
-    expect(exitCallCount).toBe(0);
+    expect(exitCallCount).toBe(1);
+    expect(exitCode).toBe(0);
+  });
+
+  it("treats --help like success: no report, one flush, exit 0", async () => {
+    const deps = makeDeps();
+    const { exitCode, exitCallCount, unhandledRejections } =
+      await runAndCapture(["--help"], deps);
+
+    expect(unhandledRejections).toEqual([]);
     expect(deps.log).not.toHaveBeenCalled();
     expect(deps.logError).not.toHaveBeenCalled();
+    expect(deps.flushTelemetry).toHaveBeenCalledTimes(1);
+    expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+    expect(exitCallCount).toBe(1);
+    expect(exitCode).toBe(0);
   });
 });

--- a/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
+++ b/packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts
@@ -116,6 +116,38 @@ function makeCli(args: string[], handlers: { ok?: jest.Mock } = {}) {
     );
 }
 
+// The shape cdktn.ts registers: a fallback completion function that
+// answers asynchronously (there: after reading the manifest) for `diff`.
+function makeCompletingCli(args: string[]) {
+  const customCompletion = function (
+    _current: string,
+    argv: { _: (string | number)[] },
+    completionsFilter: (
+      done?: (err: unknown, defaultCompletions: string[]) => void,
+    ) => void,
+    done: (completions: string[]) => void,
+  ) {
+    if (argv._.includes("diff")) {
+      completionsFilter(async (_err, defaults) => {
+        await new Promise((r) => setImmediate(r));
+        done([...defaults, 'alpha:target stack "alpha"']);
+      });
+    } else {
+      completionsFilter();
+    }
+  } as unknown as yargs.AsyncCompletionFunction;
+  return yargs(args)
+    .exitProcess(false)
+    .command(
+      "diff [stack]",
+      "diffs a stack",
+      (cmdYargs: Argv) =>
+        cmdYargs.positional("stack", { type: "string", desc: "the stack" }),
+      () => {},
+    )
+    .completion("completion", customCompletion);
+}
+
 async function runAndCapture(
   args: string[],
   deps: FailureReporterDeps,
@@ -436,6 +468,42 @@ describe("runCli", () => {
     expect(deps.flushTelemetry).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
     expect(exitCallCount).toBe(1);
     expect(exitCode).toBe(0);
+  });
+
+  it("lets an asynchronous completion function print before the process ends", async () => {
+    // yargs never awaits the completion callback, so parseAsync resolves
+    // before an async completion function has printed anything; an explicit
+    // exit at that point would swallow `cdktn diff <TAB>` entirely.
+    const deps = makeDeps();
+    const printed: string[] = [];
+    const logSpy = jest
+      .spyOn(console, "log")
+      .mockImplementation((line: string) => {
+        printed.push(line);
+      });
+    try {
+      const exitSpy = jest
+        .spyOn(process, "exit")
+        .mockImplementation((() => {}) as never);
+      try {
+        await runCli(
+          makeCompletingCli(["--get-yargs-completions", "cdktn", "diff", ""]),
+          deps,
+        );
+        const printedWhenRunCliResolved = printed.length;
+        await flushMicroAndMacrotasks();
+
+        expect(printedWhenRunCliResolved).toBe(0);
+        expect(printed).toContain('alpha:target stack "alpha"');
+        expect(exitSpy).not.toHaveBeenCalled();
+      } finally {
+        exitSpy.mockRestore();
+      }
+    } finally {
+      logSpy.mockRestore();
+    }
+    expect(deps.flushTelemetry).not.toHaveBeenCalled();
+    expect(deps.logError).not.toHaveBeenCalled();
   });
 
   it("still exits 0 when the stdout reader closed early and the drain write gets EPIPE", async () => {

--- a/packages/cdktn-cli/src/bin/cdktn.ts
+++ b/packages/cdktn-cli/src/bin/cdktn.ts
@@ -6,13 +6,11 @@ import * as yargs from "yargs";
 import * as path from "path";
 import * as os from "os";
 import * as fs from "fs-extra";
-import * as Sentry from "@sentry/node";
 import {
   readCDKTFManifest,
-  IsErrorType,
-  collectDebugInformation,
   CDKTF_DISABLE_PLUGIN_CACHE_ENV,
 } from "@cdktn/commons";
+import { runCli } from "./error-handling";
 import initCmd from "./cmds/init";
 import getCmd from "./cmds/get";
 import convertCmd from "./cmds/convert";
@@ -83,8 +81,7 @@ const customCompletion = function (
 // for the possible overload (which supports falling back to default completions)
 // https://github.com/yargs/yargs/blob/d33e9972291406490cd8fdad0b3589be234e0f12/lib/completion.ts#L202
 
-// eslint-disable-next-line @typescript-eslint/no-unused-expressions
-yargs
+const cli = yargs
   .command(initCmd)
   .command(getCmd)
   .command(convertCmd)
@@ -155,32 +152,6 @@ yargs
       yargs.showHelp();
       process.exit(1);
     },
-  })
-  .fail(async (message, error) => {
-    // will not stop the process, but stops further execution of the handler function
-    // this is called first because yargs is not waiting for this async function
-    yargs.exit(1, error);
+  });
 
-    // set if e.g. the validation of command arguments failed
-    if (message) {
-      console.log(message);
-    }
-
-    // set if e.g. an handler threw an error while being invoked
-    if (IsErrorType(error, "Usage") || IsErrorType(error, "External")) {
-      console.error(error.message);
-    } else if (error) {
-      console.error(error.message);
-      console.error(error.stack);
-      console.error("Collecting Debug Information...");
-      const debugOutput = await collectDebugInformation();
-
-      console.error("Debug Information:");
-      Object.entries(debugOutput).forEach(([key, value]) => {
-        console.log(`${key}: ${value === null ? "null" : value}`);
-      });
-    }
-
-    await Sentry.close(4000);
-    process.exit(1);
-  }).argv;
+void runCli(cli);

--- a/packages/cdktn-cli/src/bin/error-handling.ts
+++ b/packages/cdktn-cli/src/bin/error-handling.ts
@@ -98,6 +98,18 @@ export async function reportFailure(
   return 1;
 }
 
+// process.exit drops stdio writes still queued behind a slow pipe reader (a
+// full 64 KiB pipe truncates `cdktn convert | less` on macOS); a zero-length
+// write's callback runs only once everything queued before it has gone out.
+async function drainStdio(): Promise<void> {
+  await Promise.all(
+    [process.stdout, process.stderr].map(
+      (stream) =>
+        new Promise<void>((resolve) => stream.write("", () => resolve())),
+    ),
+  );
+}
+
 export function runCli(
   y: yargs.Argv,
   deps: FailureReporterDeps = defaultDeps,
@@ -121,8 +133,20 @@ export function runCli(
       // place that catches those.
       if (!failure) failure = { message: null, error };
     }
-    if (!failure) return; // success / --help / --version
-    process.exit(await reportFailure(failure, deps));
+    if (failure) {
+      process.exit(await reportFailure(failure, deps));
+    } else {
+      // success / --help / --version: Sentry buffers asynchronously, so flush
+      // (bounded) and exit explicitly, or an unresponsive ingest endpoint
+      // keeps the transport socket and the process alive.
+      try {
+        await deps.flushTelemetry(SENTRY_FLUSH_TIMEOUT_MS);
+      } catch {
+        /* never block the exit */
+      }
+      await drainStdio();
+      process.exit(process.exitCode ?? 0);
+    }
   })().catch((e) => {
     // belt-and-braces: runCli itself must never reject
     console.error(

--- a/packages/cdktn-cli/src/bin/error-handling.ts
+++ b/packages/cdktn-cli/src/bin/error-handling.ts
@@ -105,7 +105,17 @@ async function drainStdio(): Promise<void> {
   await Promise.all(
     [process.stdout, process.stderr].map(
       (stream) =>
-        new Promise<void>((resolve) => stream.write("", () => resolve())),
+        new Promise<void>((resolve) => {
+          // A reader that already closed (`cdktn --help | head -1`) reports
+          // EPIPE to the callback and then emits 'error'; console.log swallows
+          // it, this listener does the same (kept only while an error is due).
+          const onError = () => resolve();
+          stream.once("error", onError);
+          stream.write("", (err) => {
+            if (!err) stream.off("error", onError);
+            resolve();
+          });
+        }),
     ),
   );
 }

--- a/packages/cdktn-cli/src/bin/error-handling.ts
+++ b/packages/cdktn-cli/src/bin/error-handling.ts
@@ -1,0 +1,133 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import * as yargs from "yargs";
+import * as Sentry from "@sentry/node";
+import { IsErrorType, collectDebugInformation } from "@cdktn/commons";
+
+export type CliFailure = { message?: string | null; error?: unknown };
+
+export interface FailureReporterDeps {
+  log(msg: string): void; // default: console.log
+  logError(msg: string): void; // default: console.error
+  collectDebugInformation(): Promise<Record<string, unknown>>;
+  captureException(error: unknown): void; // default: Sentry.captureException
+  flushTelemetry(timeoutMs: number): Promise<void>; // default: Sentry.flush
+}
+
+export const SENTRY_FLUSH_TIMEOUT_MS = 4000;
+
+// Non-Error tolerant: a raw string or object throw still prints a message,
+// never the literal `undefined`.
+export function describeError(e: unknown): { message: string; stack?: string } {
+  if (e instanceof Error) return { message: e.message, stack: e.stack };
+  if (typeof e === "string") return { message: e };
+  const o = e as { message?: unknown; stack?: unknown } | null;
+  if (o && typeof o.message === "string") {
+    return {
+      message: o.message,
+      stack: typeof o.stack === "string" ? o.stack : undefined,
+    };
+  }
+  let rendered: string;
+  try {
+    rendered = JSON.stringify(e);
+  } catch {
+    rendered = String(e);
+  }
+  return {
+    message: `Unexpected non-Error value thrown: ${rendered ?? String(e)}`,
+  };
+}
+
+export const defaultDeps: FailureReporterDeps = {
+  log: (msg) => console.log(msg),
+  logError: (msg) => console.error(msg),
+  collectDebugInformation,
+  captureException: (error) => {
+    Sentry.captureException(error);
+  },
+  flushTelemetry: async (timeoutMs) => {
+    await Sentry.flush(timeoutMs);
+  },
+};
+
+export async function reportFailure(
+  f: CliFailure,
+  deps: FailureReporterDeps,
+): Promise<number> {
+  const { message, error } = f;
+  try {
+    if (message) deps.log(message); // yargs validation text
+
+    if (IsErrorType(error, "Usage")) {
+      // not captured: cli-core's `beforeSend` drops "Usage Error" events
+      // anyway (a user mistake, not a crash)
+      deps.logError((error as Error).message); // one line, NO debug info
+    } else if (IsErrorType(error, "External")) {
+      // one clean line for the user, but still captured: `beforeSend`
+      // keeps External errors
+      deps.logError((error as Error).message); // one line, NO debug info
+      deps.captureException(error);
+    } else if (error !== undefined && error !== null) {
+      const { message: m, stack } = describeError(error);
+      deps.logError(m);
+      if (stack) deps.logError(stack);
+      deps.captureException(error);
+      deps.logError("Collecting Debug Information...");
+      try {
+        const debugOutput = await deps.collectDebugInformation();
+        deps.logError("Debug Information:");
+        Object.entries(debugOutput).forEach(([key, value]) =>
+          deps.log(`${key}: ${value === null ? "null" : value}`),
+        );
+      } catch (e) {
+        deps.logError(
+          `Could not collect debug information: ${describeError(e).message}`,
+        );
+      }
+    }
+  } catch (e) {
+    deps.logError(`Error while reporting failure: ${describeError(e).message}`);
+  }
+
+  try {
+    await deps.flushTelemetry(SENTRY_FLUSH_TIMEOUT_MS);
+  } catch {
+    /* never mask the original error */
+  }
+  return 1;
+}
+
+export function runCli(
+  y: yargs.Argv,
+  deps: FailureReporterDeps = defaultDeps,
+): Promise<void> {
+  let failure: CliFailure | undefined;
+
+  y.fail((message, error) => {
+    // Must stay synchronous: yargs discards the return value, so an await here
+    // races Node's unhandled-rejection reporter. y.exit does not exit under
+    // .exitProcess(false); it sets hasOutput, which stops the handler running.
+    y.exit(1, error as Error);
+    if (!failure) failure = { message, error };
+  });
+
+  return (async () => {
+    try {
+      await y.parseAsync();
+    } catch (error) {
+      // Async handler rejections land here after .fail already recorded them;
+      // synchronous handler throws bypass .fail entirely, so this is the only
+      // place that catches those.
+      if (!failure) failure = { message: null, error };
+    }
+    if (!failure) return; // success / --help / --version
+    process.exit(await reportFailure(failure, deps));
+  })().catch((e) => {
+    // belt-and-braces: runCli itself must never reject
+    console.error(
+      `Fatal error in cdktn error handling: ${describeError(e).message}`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/cdktn-cli/src/bin/error-handling.ts
+++ b/packages/cdktn-cli/src/bin/error-handling.ts
@@ -16,6 +16,11 @@ export interface FailureReporterDeps {
 
 export const SENTRY_FLUSH_TIMEOUT_MS = 4000;
 
+// yargs' hard-coded flag for a shell completion request (`cdktn diff <TAB>`
+// runs `cdktn --get-yargs-completions cdktn diff ""`); its parsed value is
+// whatever word follows it, so only presence counts (as yargs itself checks).
+const YARGS_COMPLETION_KEY = "get-yargs-completions";
+
 // Non-Error tolerant: a raw string or object throw still prints a message,
 // never the literal `undefined`.
 export function describeError(e: unknown): { message: string; stack?: string } {
@@ -135,8 +140,10 @@ export function runCli(
   });
 
   return (async () => {
+    let completionRequest = false;
     try {
-      await y.parseAsync();
+      const argv = await y.parseAsync();
+      completionRequest = YARGS_COMPLETION_KEY in argv;
     } catch (error) {
       // Async handler rejections land here after .fail already recorded them;
       // synchronous handler throws bypass .fail entirely, so this is the only
@@ -145,6 +152,12 @@ export function runCli(
     }
     if (failure) {
       process.exit(await reportFailure(failure, deps));
+    } else if (completionRequest) {
+      // yargs does not await the completion callback, so an asynchronous
+      // completion function (cdktn.ts reads the manifest) prints only after
+      // parseAsync resolved; no handler ran, so there is nothing to flush and
+      // the loop drains on its own.
+      return;
     } else {
       // success / --help / --version: Sentry buffers asynchronously, so flush
       // (bounded) and exit explicitly, or an unresponsive ingest endpoint


### PR DESCRIPTION
Part 2 of 6 in a stack; review order S1 → S6; base is the previous slice.

1. `chore(deps): upgrade @sentry/node to 10.x with unchanged reporting behaviour`
2. `fix(cli): stop the top-level error handler racing yargs` (this PR)
3. `feat(cli): replace HashiCorp checkpoint telemetry with Sentry usage metrics and consent`
4. `feat(cli): report the installed binary, target versions and platform in usage metrics`
5. `feat(cli): report per-stack, per-provider and per-command usage metrics`
6. `chore(gha): run the telemetry delivery e2e on every build`

### Related issue

Fixes #360, fixes #361

### Description

This is the former PR #378, landed inside this stack because it rewrites the same yargs `.fail()` lines the telemetry work needs, and because the failure metric added in S3 belongs on the seam this slice creates. Rebasing one file through two separate PRs was the alternative. The commit keeps its original author and the adaptation is a separate commit.

The defect: `.fail()` was registered `async` (yargs does not await it, as the code's own comment said) and called `yargs.exit(1, error)` as its first statement. The error printed once from the handler and again from Node's unhandled-rejection path.

Reproduced against a build of the base before any change, deterministically rather than by timing:

| Trigger | Before |
|---|---|
| Unexpected internal error (corrupt `cdk.tf.json` with `--skip-synth`) | message and stack printed twice, and the `Debug Information:` label never reached because the awaited collection never completed |
| Terraform failure (`TerraformOutput` referencing an undeclared resource) | `undefined` / `undefined`, then a hard `ERR_UNHANDLED_REJECTION` abort |

The `undefined` / `undefined` signature had a second cause: `packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts` threw a raw string, so `error.message` and `error.stack` were both undefined. It throws an `Error` now.

The fix: the handler moves to `packages/cdktn-cli/src/bin/error-handling.ts`, `.fail()` becomes synchronous and only records the failure (it still calls `yargs.exit(1, error)` for its load-bearing `hasOutput` side effect), and `runCli` in `packages/cdktn-cli/src/bin/cdktn.ts` awaits `parseAsync()` with `.exitProcess(false)`, reports once through one awaited `reportFailure`, and makes the single `process.exit()` call. That `try/catch` also catches synchronous handler throws, which yargs 17 never routes to `.fail()` at all. `packages/cdktn-cli/src/bin/exit-flush.ts` extracts the `beforeExit` flush so the success path is testable too.

**Crash reporting needed care and is the part worth reviewing closely.** Nothing in the old handler reported to Sentry; what did report was the orphaned rejection from the un-awaited `.argv` promise, picked up by the global unhandled-rejection integration. Handling the rejection properly removes that channel, so `reportFailure` captures explicitly before flushing, for unexpected and `External` errors but not for `Usage`, which cli-core's `beforeSend` already drops. Exit codes are unchanged, measured per failure class before and after.

Scoping note for the stack: `reportFailure` here takes deps `{log, logError, collectDebugInformation, captureException, flushTelemetry}` and the flush dep calls `Sentry.flush` directly, because the bounded `flushTelemetry()` helper in commons does not exist yet. S3 reroutes it onto that helper and adds the `cli.command.error` metric on top. There is no usage telemetry in this slice.

Two behaviour changes worth knowing, both deliberate:

- **More crash events than before.** The old handler called `Sentry.close(4000)` but never captured the error, so unexpected errors reaching the entrypoint were not reported; what did reach Sentry was the orphaned rejection, picked up by the global unhandled-rejection integration. Handling the rejection removes that channel, so `reportFailure` now calls `captureException` for both `External` and unexpected errors (never for `Usage`). It stays consent-gated: Sentry is only initialised after consent, so the capture is inert otherwise.
- **The success path flushes and exits explicitly at the end of `runCli`.** An earlier revision hooked `process.on("beforeExit")`, which cannot fire while a pending Sentry request keeps the event loop alive, so the 4000 ms bound was never armed in exactly the case it exists for. `runCli` now awaits the bounded flush after `parseAsync()` resolves without a failure and then calls `process.exit(process.exitCode ?? 0)`; `--help` and `--version` take the same path. A child-process test points the fixture at a sink that accepts the connection and never answers, and asserts the process still exits 0 within the bound. `watch` is unaffected because its handler promise resolves only on graceful shutdown. Commands that call `process.exit()` directly (the `*` default handler, the self-exiting synth paths) bypass this; nothing emits metrics on those paths in this slice, and S3 flushes explicitly before each of them.

Three consequences of the explicit exit, each found by running the built bundle and each covered by a unit test and a child-process test:

- **Stdio is drained before the exit.** `process.exit` right after a large write into a pipe with a slow reader truncated stdout at 64 KiB on macOS (`cdktn convert | less`, `cdktn output --json | jq`), something the old natural loop drain never hit. `runCli` now waits for a zero-length write on stdout and stderr to complete before exiting, and tolerates a reader that closed early (`cdktn --help | head -1` exits 0 instead of dying on EPIPE).
- **Shell completion still prints.** yargs does not await an asynchronous completion callback before `parseAsync` resolves, so the explicit exit cut `cdktn deploy <TAB>` off with no output. On a completion request `runCli` returns early and lets the loop drain naturally; no handler runs there, so there is nothing to flush.
- **`watch` stays alive until its session is aborted.** `watch()` in cli-core resolved right after kicking off the first run, which was harmless while the process lived on the event loop but would have ended the session under an explicit exit. It now stays pending until its abort signal fires, with a test.

**Start with** `packages/cdktn-cli/src/bin/error-handling.ts` and the `runCli` wiring in `packages/cdktn-cli/src/bin/cdktn.ts`; those two files are the whole change, everything else is a consequence.

Reading order for this slice:

1. `packages/cdktn-cli/src/bin/error-handling.ts`
2. `packages/cdktn-cli/src/bin/cdktn.ts` and `packages/cdktn-cli/src/bin/exit-flush.ts`
3. `packages/@cdktn/cli-core/src/lib/models/terraform-cli.ts`
4. `packages/cdktn-cli/src/bin/__tests__/error-handling.test.ts`, `error-handling.integration.test.ts` and `exit-flush.test.ts`

### Test plan

- [x] Unit tests green across `@cdktn/commons`, `@cdktn/cli-core` and `cdktn-cli` on this slice against S1
- [x] #360 / #361 reproductions: the corrupt-`cdk.tf.json` trigger reaches `Debug Information:` and prints once; the undeclared-resource trigger prints a real message and stack with no `ERR_UNHANDLED_REJECTION` and no `PromiseRejectionHandledWarning`
- [x] Regression guards: the `.fail` handler is asserted synchronous, `reportFailure` is asserted to run exactly once, and there is exactly one `process.exit` call
- [x] Child-process integration test points a real Sentry client at a local sink and asserts the crash envelope arrives before exit
- [x] Child-process test against a sink that never responds: the success path still exits 0 within the flush bound, with no unhandled-rejection output
- [x] `terraform-cli` throws an `Error`, covered by `terraform-cli.test.ts` and the `cdktf-project.test.ts` snapshot line
- [x] Exit codes measured per failure class before and after, unchanged
- [x] Lint and `pnpm prettier --check .` clean

### Follow-ups (documented, not in this PR)

- `packages/cdktn-cli/src/bin/cmds/get.ts` calls `readConfigSync()` at module import, so an invalid `cdktf.json` crashes before the failure reporter runs. Pre-existing, and out of scope here.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable (follow-up in cdk-terrain-docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
