### PR TITLE
feat(cli): report the installed binary, target versions and platform in usage metrics

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/error-reporting.ts
+++ b/packages/@cdktn/cli-core/src/lib/error-reporting.ts
@@ -6,6 +6,8 @@ import {
   getProjectId,
   getUserId,
   getUsageTelemetryConsent,
+  getProjectTargetAttributes,
+  setProjectTargetAttributes,
   setUsageTelemetryEnabled,
   startCommandTelemetry,
   collectDebugInformation,
@@ -126,6 +128,7 @@ export async function initializErrorReporting(
   // directory: some commands (convert) chdir into a temporary project
   // before sendTelemetry runs and must not consult that project's flags.
   setUsageTelemetryEnabled(usageTelemetryEnabled);
+  setProjectTargetAttributes(getProjectTargetAttributes(projectPath));
 
   if (!crashReportingEnabled && !usageTelemetryEnabled) {
     logger.debug("Error reporting and usage telemetry disabled");

--- a/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
+++ b/packages/@cdktn/cli-core/src/test/error-reporting.test.ts
@@ -30,6 +30,7 @@ jest.mock("@cdktn/commons", () => {
     ...actual,
     collectDebugInformation: jest.fn().mockResolvedValue({}),
     setUsageTelemetryEnabled: jest.fn(actual.setUsageTelemetryEnabled),
+    setProjectTargetAttributes: jest.fn(actual.setProjectTargetAttributes),
   };
 });
 
@@ -39,6 +40,8 @@ import {
   Errors,
   isUsageTelemetryEnabled,
   resetCommandTelemetry,
+  seedTerraformCliProbeForTests,
+  setProjectTargetAttributes,
   setUsageTelemetryEnabled,
 } from "@cdktn/commons";
 import {
@@ -85,12 +88,16 @@ function useReportingFixture() {
     delete process.env.CHECKPOINT_DISABLE;
     process.env.SENTRY_DSN = "https://public@example.invalid/1";
     ciInfoMock.isCI = false;
+    // the start-of-command metric stamps the binary; keep it off the machine
+    seedTerraformCliProbeForTests(Promise.resolve("Terraform v1.9.0\n"));
   });
 
   afterEach(() => {
     setUsageTelemetryEnabled(undefined);
     resetCommandTelemetry();
     Errors.setScope("unknown");
+    setProjectTargetAttributes(undefined);
+    seedTerraformCliProbeForTests();
     process.chdir(originalCwd);
     fs.removeSync(workdir);
     Object.defineProperty(process.stdout, "isTTY", {
@@ -287,15 +294,22 @@ describe("consent gating (initializErrorReporting)", () => {
       expect(Sentry.init).toHaveBeenCalledTimes(1);
     },
   );
-  it("captures the usage decision while still in the user's cwd", async () => {
+  it("captures the usage decision and the project targets while still in the user's cwd", async () => {
     fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
       sendCrashReports: false,
+      targetVersions: { terraform: ">=1.9.0" },
+      validateInstalledBinary: true,
     });
     setInteractive(false);
 
     await initializErrorReporting();
 
     expect(setUsageTelemetryEnabled).toHaveBeenCalledWith(true);
+    expect(setProjectTargetAttributes).toHaveBeenCalledWith({
+      targets_declared: true,
+      validate_installed_binary: true,
+      target_terraform: ">=1.9.0",
+    });
   });
   it("reads and persists against an explicit project path, not the cwd", async () => {
     // init creates the project in a destination directory and initializes
@@ -309,6 +323,7 @@ describe("consent gating (initializErrorReporting)", () => {
     fs.writeJsonSync(path.join(destination, "cdktf.json"), {
       sendCrashReports: false,
       sendUsageTelemetry: true,
+      targetVersions: { terraform: ">=1.9.0" },
     });
     setInteractive(true);
     const crashPrompt = jest.fn();
@@ -319,6 +334,9 @@ describe("consent gating (initializErrorReporting)", () => {
     expect(crashPrompt).not.toHaveBeenCalled();
     expect(usagePrompt).not.toHaveBeenCalled();
     expect(setUsageTelemetryEnabled).toHaveBeenCalledWith(true);
+    expect(setProjectTargetAttributes).toHaveBeenCalledWith(
+      expect.objectContaining({ target_terraform: ">=1.9.0" }),
+    );
     expect(isUsageTelemetryEnabled()).toBe(true);
     // usage-only consent: the client exists but drops error events
     await expect(initOptions().beforeSend({}, undefined)).resolves.toBeNull();

--- a/packages/@cdktn/commons/src/debug.test.ts
+++ b/packages/@cdktn/commons/src/debug.test.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 jest.mock("./terraform", () => ({
-  terraformVersion: Promise.resolve("1.7.5"),
+  terraformVersion: () => Promise.resolve("1.7.5"),
 }));
 
 import { collectDebugInformation } from "./debug";

--- a/packages/@cdktn/commons/src/debug.ts
+++ b/packages/@cdktn/commons/src/debug.ts
@@ -404,7 +404,7 @@ export async function collectDebugInformation() {
     debugOutput["constructs"] = (await constructs) ?? null;
     debugOutput["jsii"] = (await jsii) ?? null;
   }
-  debugOutput["terraform"] = await terraformVersion;
+  debugOutput["terraform"] = (await terraformVersion()) ?? null;
   debugOutput["arch"] = os.arch();
   debugOutput["os"] = `${os.platform()} ${os.release()}`;
 

--- a/packages/@cdktn/commons/src/telemetry.test.ts
+++ b/packages/@cdktn/commons/src/telemetry.test.ts
@@ -10,12 +10,22 @@ import {
   startCommandTelemetry,
   resetCommandTelemetry,
   flushTelemetry,
+  getBinaryAttributes,
+  getProjectTargetAttributes,
   getUsageTelemetryConsent,
   hasCapturedUsageTelemetryDecision,
   isUsageTelemetryEnabled,
+  setProjectTargetAttributes,
   setUsageTelemetryEnabled,
 } from "./telemetry";
+import { seedTerraformCliProbeForTests } from "./terraform";
+import { DEFAULT_TARGET_VERSIONS } from "./config";
 import { Errors } from "./errors";
+
+const DEFAULT_TARGET_VERSIONS_AS_ATTRIBUTES = {
+  target_terraform: DEFAULT_TARGET_VERSIONS.terraform,
+  target_opentofu: DEFAULT_TARGET_VERSIONS.opentofu,
+};
 
 // A real client with a capturing transport proves the metric envelope
 // reaches the transport and survives a bounded flush; a mocked @sentry/node
@@ -85,11 +95,18 @@ describe("telemetry", () => {
     envelopeBodies = [];
     delete process.env.CHECKPOINT_DISABLE;
     delete process.env.SENTRY_ENVIRONMENT;
+    // the probe is process-global (see terraform.ts); a seeded output keeps
+    // the binary attributes independent of the machine running the tests
+    seedTerraformCliProbeForTests(
+      Promise.resolve("Terraform v1.9.0\non darwin_arm64\n"),
+    );
   });
 
   afterEach(async () => {
     setUsageTelemetryEnabled(undefined);
     resetCommandTelemetry();
+    setProjectTargetAttributes(undefined);
+    seedTerraformCliProbeForTests();
     await Sentry.close(1000);
     process.chdir(originalCwd);
     fs.removeSync(workdir);
@@ -106,10 +123,12 @@ describe("telemetry", () => {
   });
 
   describe("sendTelemetry delivery (real client + capturing transport)", () => {
-    it("stamps environment attributes on every command metric", async () => {
+    it("stamps environment, binary and target attributes on every command metric", async () => {
       fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
         language: "typescript",
         sendUsageTelemetry: true,
+        targetVersions: { terraform: ">=1.9.0", opentofu: ">=1.8.0" },
+        validateInstalledBinary: true,
       });
       process.env.SENTRY_ENVIRONMENT = "LEAK-ENV-SENTRY";
       initSentryWithCapturingTransport();
@@ -131,7 +150,14 @@ describe("telemetry", () => {
       for (const metric of items) {
         const values = attributeValues(metric);
         expect(values).toMatchObject({
-          command: "synth",
+          os: process.platform,
+          arch: process.arch,
+          binary: "terraform",
+          binary_version: "1.9.0",
+          target_terraform: ">=1.9.0",
+          target_opentofu: ">=1.8.0",
+          targets_declared: true,
+          validate_installed_binary: true,
           ci: ciInfo.isCI ? ciInfo.name || "unknown" : false,
           // the SDK stamps the release set in Sentry.init on every metric,
           // so the CLI version needs no attribute of its own
@@ -158,6 +184,32 @@ describe("telemetry", () => {
         language: "typescript",
       });
       expect(envelopeBodies.join("\n")).not.toContain("LEAK-ENV-SENTRY");
+    });
+
+    it("uses the target attributes captured at command start over the current cwd", async () => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        targetVersions: { terraform: ">=1.0.0" },
+      });
+      initSentryWithCapturingTransport();
+      setProjectTargetAttributes({
+        targets_declared: true,
+        validate_installed_binary: false,
+        target_opentofu: ">=1.7.0",
+      });
+
+      await startCommandTelemetry("convert");
+      await sendTelemetry("convert", {});
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      expect(items.map((i) => i.name)).toEqual([
+        "cli.command.invoked",
+        "cli.command.completed",
+      ]);
+      for (const metric of items) {
+        expect(metric.attributes.target_opentofu.value).toBe(">=1.7.0");
+        expect(metric.attributes.target_terraform).toBeUndefined();
+      }
     });
 
     it.each([
@@ -211,6 +263,60 @@ describe("telemetry", () => {
         expect(body).not.toContain(workdir);
       }
     });
+
+    it("forwards exactly the allow-listed attribute set and nothing else from the payload", async () => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        language: "typescript",
+        sendUsageTelemetry: true,
+      });
+      initSentryWithCapturingTransport();
+
+      await startCommandTelemetry("synth");
+      await sendTelemetry("synth", {
+        totalTime: 5,
+        language: "typescript",
+        stackMetadata: [{ stackName: "prod-vpc", backend: "s3" }],
+        requiredProviders: [{ aws: { source: "aws" } }],
+        stackName: "prod-vpc",
+        outdir: "/Users/x/secret",
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const invoked = items.find((i) => i.name === "cli.command.invoked")!;
+      const completed = items.find((i) => i.name === "cli.command.completed")!;
+      const keys = Object.keys(invoked.attributes);
+      // the start and end metrics carry the same base set
+      expect(Object.keys(completed.attributes).sort()).toEqual(
+        [...keys].sort(),
+      );
+      // the one place that fails when an attribute is added: extend it
+      // deliberately, together with the collected-data list in the docs
+      expect(keys.filter((key) => !key.startsWith("sentry.")).sort()).toEqual([
+        "arch",
+        "binary",
+        "binary_version",
+        "ci",
+        "command",
+        "language",
+        "os",
+        // server.address is the fixed serverName from init
+        "server.address",
+        "target_opentofu",
+        "target_terraform",
+        "targets_declared",
+        "validate_installed_binary",
+      ]);
+      // stamped by the SDK from init; a patch bump may add more of them
+      expect(keys).toEqual(
+        expect.arrayContaining(["sentry.release", "sentry.environment"]),
+      );
+      expect(invoked.attributes.binary_version.value).toBe("1.9.0");
+      expect(invoked.attributes["server.address"].value).toBe("cdktn-cli");
+      const bytes = envelopeBodies.join("\n");
+      expect(bytes).not.toContain("prod-vpc");
+      expect(bytes).not.toContain("/Users/x/secret");
+    });
   });
 
   describe("attribute validation", () => {
@@ -242,6 +348,35 @@ describe("telemetry", () => {
       )!;
       expect(invoked.attributes).not.toHaveProperty("language");
       expect(envelopeBodies.join("\n")).not.toContain("DROP TABLE");
+    });
+
+    it("sends declared targets that are not semver ranges as invalid", () => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        targetVersions: { terraform: "latest /Users/x", opentofu: ">=1.8" },
+      });
+      expect(getProjectTargetAttributes(workdir)).toMatchObject({
+        target_terraform: "invalid",
+        target_opentofu: ">=1.8.0",
+      });
+    });
+
+    it.each([
+      [">= 1.9.0", ">=1.9.0"],
+      ["~1.8", ">=1.8.0 <1.9.0-0"],
+      ["1.2.3 - 2.0.0", ">=1.2.3 <=2.0.0"],
+      [">=1.0.0 <2.0.0 || 1.2.3", ">=1.0.0 <2.0.0||1.2.3"],
+      [">= 1.0.0-LEAK-TV-PRERELEASE.corp.example.com", "invalid"],
+      ["1.2.3-acme.internal", "invalid"],
+      ["1.2.3+LEAK-TV-BUILD.johns-macbook", "invalid"],
+      [">=1.0.0 <2.0.0 || 1.2.3-LEAK-OR.host", "invalid"],
+      [">=1.0.0 " + "||1.0.0 ".repeat(10), "invalid"],
+    ])("forwards the declared target %p as %p", (range, expected) => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        targetVersions: { terraform: range },
+      });
+      expect(getProjectTargetAttributes(workdir).target_terraform).toBe(
+        expected,
+      );
     });
   });
 
@@ -359,6 +494,25 @@ describe("telemetry", () => {
         parseMetricItems(envelopeBodies).map((i) => attributeValues(i).command),
       ).toEqual(["deploy", "deploy", "get"]);
     });
+
+    it("stamps the target attributes captured by the other copy", async () => {
+      setProjectTargetAttributes({
+        targets_declared: true,
+        validate_installed_binary: true,
+        target_opentofu: ">=1.7.0",
+      });
+      await second.sendTelemetry("convert", {});
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const [completed] = parseMetricItems(envelopeBodies);
+      expect(attributeValues(completed)).toMatchObject({
+        command: "convert",
+        targets_declared: true,
+        validate_installed_binary: true,
+        target_opentofu: ">=1.7.0",
+      });
+      expect(completed.attributes.target_terraform).toBeUndefined();
+    });
   });
 
   // no DSN means no client: every emitter must stay a silent no-op rather
@@ -375,7 +529,9 @@ describe("telemetry", () => {
       expect(Sentry.getClient()).toBeUndefined();
 
       await expect(
-        sendTelemetry("deploy", { language: "typescript" }),
+        sendTelemetry("deploy", {
+          requiredProviders: [{ aws: { source: "aws" } }],
+        }),
       ).resolves.toBeUndefined();
       expect(() => Errors.Internal("boom")).not.toThrow();
       await expect(flushTelemetry(100)).resolves.toBeUndefined();
@@ -470,6 +626,79 @@ describe("telemetry", () => {
       expect(Errors.getScope()).toBe("unknown");
       Errors.setScope("provider add");
       expect(Errors.getScope()).toBe("provider add");
+    });
+  });
+
+  describe("getBinaryAttributes", () => {
+    it.each([
+      ["1.10.0-alpha20250101", "1.10.0"],
+      ["1.2.3-LEAK-WRAPPER-hostname.corp.example.com+LEAK-BUILD", "1.2.3"],
+      ["9.9.9-LEAK-UNKNOWN/Users/x/LEAK-SECRET-DIR", "9.9.9"],
+    ])(
+      "reduces the probed version %p to its release %p",
+      async (version, release) => {
+        await expect(
+          getBinaryAttributes(Promise.resolve({ name: "terraform", version })),
+        ).resolves.toEqual({ binary: "terraform", binary_version: release });
+      },
+    );
+
+    it("omits binary_version when the probed version has no release prefix", async () => {
+      await expect(
+        getBinaryAttributes(
+          Promise.resolve({ name: "opentofu", version: "v1.2" }),
+        ),
+      ).resolves.toEqual({ binary: "opentofu" });
+    });
+
+    it("sends no version for an unrecognised product: a wrapper's output has no product version line", async () => {
+      seedTerraformCliProbeForTests(
+        Promise.resolve(
+          "connected to 10.0.0.1 as LEAK-USER (wrapper 3.4.5)\nTerraform v1.9.0\n",
+        ),
+      );
+      const attributes = await getBinaryAttributes();
+      expect(attributes).toEqual({ binary: "unknown" });
+      expect(JSON.stringify(attributes)).not.toContain("10.0.0");
+    });
+
+    it("reports unknown when the probe does not settle in time", async () => {
+      // a hung or interactive `terraform version` must never delay a
+      // command; the race has a 1500 ms ceiling in production
+      const hung = new Promise<never>(() => {});
+      await expect(getBinaryAttributes(hung, 10)).resolves.toEqual({
+        binary: "unknown",
+      });
+    });
+  });
+
+  describe("getProjectTargetAttributes", () => {
+    it("reads declared targets and the validation flag", () => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        targetVersions: { opentofu: "~1.8" },
+        validateInstalledBinary: true,
+      });
+      expect(getProjectTargetAttributes(workdir)).toEqual({
+        targets_declared: true,
+        validate_installed_binary: true,
+        target_opentofu: ">=1.8.0 <1.9.0-0",
+      });
+    });
+
+    it.each([[{}], [{ targetVersions: "nope" }], [{ targetVersions: [] }]])(
+      "falls back to the defaults for %j",
+      (config) => {
+        fs.writeJsonSync(path.join(workdir, "cdktf.json"), config);
+        expect(getProjectTargetAttributes(workdir)).toEqual({
+          targets_declared: false,
+          validate_installed_binary: false,
+          ...DEFAULT_TARGET_VERSIONS_AS_ATTRIBUTES,
+        });
+      },
+    );
+
+    it("does not throw without a cdktf.json", () => {
+      expect(getProjectTargetAttributes(workdir).targets_declared).toBe(false);
     });
   });
 

--- a/packages/@cdktn/commons/src/telemetry.ts
+++ b/packages/@cdktn/commons/src/telemetry.ts
@@ -3,10 +3,12 @@
 import * as Sentry from "@sentry/node";
 import * as path from "path";
 import * as fs from "fs-extra";
+import * as semver from "semver";
 import ciInfo from "ci-info";
 import { logger } from "./logging";
-import { LANGUAGES } from "./config";
+import { DEFAULT_TARGET_VERSIONS, LANGUAGES } from "./config";
 import { processState } from "./process-state";
+import { terraformCli, TerraformCliProbe } from "./terraform";
 
 type AttributeValue = string | number | boolean;
 type Attributes = Record<string, AttributeValue>;
@@ -66,6 +68,9 @@ type CommandTelemetryState = {
   // The raw `language` of the project the run started in, so every metric of
   // the run (the error metric has no payload) carries the one `invoked` did.
   language?: unknown;
+  // Captured alongside the consent decision, for the same reason: the project
+  // the user ran the command in, not the one the command may chdir into.
+  projectTargetAttributes?: Attributes;
 };
 
 // Shared by both bundle copies: the handlers' copy captures the decision and
@@ -74,6 +79,24 @@ const state = processState<CommandTelemetryState>(
   "cdktn.commandTelemetry",
   () => ({}),
 );
+
+// Free-text payload fields are validated before they become attributes so a
+// misconfigured or hand-edited value never carries arbitrary text.
+const RELEASE_VERSION = /^\d+\.\d+\.\d+/;
+
+// MAJOR.MINOR.PATCH only: prerelease and build identifiers are free text
+// (a wrapper's version line or a locally built library can carry anything).
+function releaseVersion(value: string | undefined): string | undefined {
+  return RELEASE_VERSION.exec(value ?? "")?.[0];
+}
+
+// Normalized so spacing variants collapse into one value; a prerelease or
+// build identifier is free text and rejects the range (hyphen ranges are
+// written " - ", so a hyphen right after a digit is always a prerelease).
+function semverRangeOrInvalid(value: string): string {
+  const range = value.length <= 64 ? semver.validRange(value) : null;
+  return range && !/\d[-+]/.test(value) ? range : "invalid";
+}
 
 export function setUsageTelemetryEnabled(enabled: boolean | undefined): void {
   state.usageTelemetryEnabled = enabled;
@@ -101,6 +124,71 @@ export function isUsageTelemetryEnabled(projectPath = process.cwd()): boolean {
     return state.usageTelemetryEnabled;
   }
   return getUsageTelemetryConsent(projectPath) !== false;
+}
+
+/**
+ * The project's declared Terraform/OpenTofu targets as metric attributes.
+ * Falls back to the CLI defaults so every metric carries the ranges the
+ * command actually validated against.
+ */
+export function getProjectTargetAttributes(
+  projectPath = process.cwd(),
+): Attributes {
+  const cdktfJson = readRawCdktfJson(projectPath);
+  const declared =
+    cdktfJson.targetVersions &&
+    typeof cdktfJson.targetVersions === "object" &&
+    !Array.isArray(cdktfJson.targetVersions)
+      ? cdktfJson.targetVersions
+      : undefined;
+  const targets: Record<string, unknown> = declared ?? DEFAULT_TARGET_VERSIONS;
+  const attributes: Attributes = {
+    targets_declared: declared !== undefined,
+    validate_installed_binary: cdktfJson.validateInstalledBinary === true,
+  };
+  if (typeof targets.terraform === "string") {
+    attributes.target_terraform = semverRangeOrInvalid(targets.terraform);
+  }
+  if (typeof targets.opentofu === "string") {
+    attributes.target_opentofu = semverRangeOrInvalid(targets.opentofu);
+  }
+  return attributes;
+}
+
+export function setProjectTargetAttributes(
+  attributes: Attributes | undefined,
+): void {
+  state.projectTargetAttributes = attributes;
+}
+
+/**
+ * Binary attributes from the version probe, bounded so a hung binary never
+ * delays the command; a timed-out probe reports `binary: "unknown"`.
+ */
+export async function getBinaryAttributes(
+  probe: Promise<TerraformCliProbe> = terraformCli(),
+  timeoutMs = 1500,
+): Promise<Attributes> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<TerraformCliProbe>((resolve) => {
+    timer = setTimeout(() => resolve({ name: "unknown" }), timeoutMs);
+  });
+  try {
+    const cli = await Promise.race([probe, timeout]);
+    const attributes: Attributes = { binary: cli.name };
+    // an unrecognised product's version is the first version-like token of
+    // its output, which can be anything (a wrapper's "connected to 10.0.0.1")
+    const release =
+      cli.name === "terraform" || cli.name === "opentofu"
+        ? releaseVersion(cli.version)
+        : undefined;
+    if (release) {
+      attributes.binary_version = release;
+    }
+    return attributes;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -135,11 +223,18 @@ export async function flushTelemetry(timeoutMs = 4000): Promise<void> {
 // A run counts once as cli.command.invoked at start, then once as either
 // cli.command.completed (with the scalars known only at the end) or
 // cli.command.error; a nested operation (a deploy's synth) adds only its own.
-function commandAttributes(command: string, language: unknown): Attributes {
+async function commandAttributes(
+  command: string,
+  language: unknown,
+): Promise<Attributes> {
   const ci: string | false = ciInfo.isCI ? ciInfo.name || "unknown" : false;
   const attributes: Attributes = {
     command,
     ci: ci === false ? false : ci,
+    os: process.platform,
+    arch: process.arch,
+    ...(state.projectTargetAttributes ?? getProjectTargetAttributes()),
+    ...(await getBinaryAttributes()),
   };
   if (LANGUAGES.includes(language as any)) {
     attributes.language = language as string;
@@ -165,7 +260,7 @@ export async function startCommandTelemetry(
     if (!isUsageTelemetryEnabled()) {
       return;
     }
-    const attributes = commandAttributes(command, state.language);
+    const attributes = await commandAttributes(command, state.language);
     Sentry.metrics.count("cli.command.invoked", 1, { attributes });
   } catch (err) {
     logger.debug(`Could not send telemetry data: ${err}`);
@@ -194,7 +289,7 @@ export async function sendTelemetry(
       return;
     }
 
-    const attributes = commandAttributes(
+    const attributes = await commandAttributes(
       command,
       payload.language ?? state.language,
     );

--- a/packages/@cdktn/commons/src/terraform.test.ts
+++ b/packages/@cdktn/commons/src/terraform.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import { seedTerraformCliProbeForTests } from "./terraform";
+
+// The binary name is read at import, so every case loads a fresh module with
+// TERRAFORM_BINARY_NAME pointing at a fixture script; the probe itself is
+// cached on globalThis and reset per test.
+function loadProbe(binary: string) {
+  const original = process.env.TERRAFORM_BINARY_NAME;
+  process.env.TERRAFORM_BINARY_NAME = binary;
+  try {
+    let terraform: typeof import("./terraform");
+    let sentry: typeof import("@sentry/node");
+    jest.isolateModules(() => {
+      terraform = jest.requireActual("./terraform");
+      sentry = jest.requireActual("@sentry/node");
+    });
+    return { ...terraform!, sentry: sentry! };
+  } finally {
+    if (original === undefined) delete process.env.TERRAFORM_BINARY_NAME;
+    else process.env.TERRAFORM_BINARY_NAME = original;
+  }
+}
+
+describe("terraform binary probe", () => {
+  let fixtureDir: string;
+  const originalCheckpointDisable = process.env.CHECKPOINT_DISABLE;
+
+  // `#!/bin/sh` fixtures are POSIX-only (CI runs on ubuntu)
+  function fakeBinary(name: string, output: string): string {
+    const file = path.join(fixtureDir, name);
+    const calls = path.join(fixtureDir, `${name}.calls`);
+    fs.writeFileSync(
+      file,
+      `#!/bin/sh\necho x >> "${calls}"\nprintf '%s\\n' "${output}"\n`,
+      { mode: 0o755 },
+    );
+    return file;
+  }
+
+  function spawnCount(binary: string): number {
+    const calls = `${binary}.calls`;
+    return fs.existsSync(calls)
+      ? fs.readFileSync(calls, "utf8").trim().split("\n").length
+      : 0;
+  }
+
+  beforeEach(() => {
+    fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "cdktn-tf-probe-"));
+    seedTerraformCliProbeForTests();
+    delete process.env.CHECKPOINT_DISABLE;
+  });
+
+  afterEach(() => {
+    fs.removeSync(fixtureDir);
+    seedTerraformCliProbeForTests();
+    if (originalCheckpointDisable === undefined) {
+      delete process.env.CHECKPOINT_DISABLE;
+    } else {
+      process.env.CHECKPOINT_DISABLE = originalCheckpointDisable;
+    }
+  });
+
+  it("spawns plain `version` once per process, on first use, across module copies, and parses it", async () => {
+    const binary = fakeBinary(
+      "terraform",
+      "Terraform v1.12.6\non darwin_arm64\n\nYour version of Terraform is out of date!",
+    );
+    const first = loadProbe(binary);
+    const second = loadProbe(binary);
+    expect(spawnCount(binary)).toBe(0);
+
+    const [probe, , version] = await Promise.all([
+      first.terraformCli(),
+      second.terraformCli(),
+      first.terraformVersion(),
+      second.terraformVersion(),
+    ]);
+    expect(probe).toEqual({ name: "terraform", version: "1.12.6" });
+    expect(version).toBe("1.12.6");
+    await expect(second.terraformCli()).resolves.toEqual(probe);
+    expect(spawnCount(binary)).toBe(1);
+  });
+
+  // the probe is shared by every consumer in the process: a rejection would
+  // surface on every command, and `cdktn debug` prints the resolved value
+  it("resolves to missing (never rejects) and counts no cli.error when the binary cannot be spawned", async () => {
+    const { terraformCli, terraformVersion, sentry } = loadProbe(
+      path.join(fixtureDir, "does-not-exist"),
+    );
+    const count = jest.spyOn(sentry.metrics, "count");
+
+    await expect(terraformCli()).resolves.toEqual({ name: "missing" });
+    await expect(terraformVersion()).resolves.toMatch(
+      /^Error: Usage Error: Unknown: Error loading terraform version/,
+    );
+    expect(count).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@cdktn/commons/src/terraform.ts
+++ b/packages/@cdktn/commons/src/terraform.ts
@@ -1,7 +1,10 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { Errors } from "./errors";
 import { exec } from "./util";
+import {
+  parseTerraformCliVersion,
+  TerraformCliName,
+} from "cdktn/lib/validations";
 
 export const terraformBinaryName =
   process.env.TERRAFORM_BINARY_NAME || "terraform";
@@ -16,12 +19,60 @@ export type {
   TerraformCliName,
 } from "cdktn/lib/validations";
 
-export const terraformVersion = exec(
-  terraformBinaryName,
-  ["version", "-json"],
-  {},
-)
-  .then((versionString) => JSON.parse(versionString).terraform_version)
-  .catch((err) =>
-    Errors.Usage(`Unknown: Error loading terraform version ${err}`, err),
-  );
+/**
+ * Outcome of probing the configured Terraform-compatible binary:
+ * `missing` when it could not be spawned, `unknown` when its version output
+ * was not recognized.
+ */
+export interface TerraformCliProbe {
+  readonly name: TerraformCliName | "missing";
+  readonly version?: string;
+}
+
+// The CLI bundle carries several copies of this module (two esbuild entries
+// plus the commons build behind the external hcl2cdk); keying the probe on
+// globalThis keeps it to one `version` spawn per process, started on first use.
+const PROBE_KEY = Symbol.for("cdktn.terraformCli");
+
+/**
+ * Test seam for the process-global probe: seeds the raw `version` output the
+ * parsers see, or clears it when called without an argument.
+ */
+export function seedTerraformCliProbeForTests(output?: Promise<string>): void {
+  const globals = globalThis as { [PROBE_KEY]?: Promise<string> };
+  if (output === undefined) {
+    delete globals[PROBE_KEY];
+  } else {
+    globals[PROBE_KEY] = output;
+  }
+}
+
+function versionOutput(): Promise<string> {
+  const globals = globalThis as { [PROBE_KEY]?: Promise<string> };
+  if (!globals[PROBE_KEY]) {
+    const output = exec(terraformBinaryName, ["version"], {});
+    output.catch(() => undefined); // the consumers below handle rejection
+    globals[PROBE_KEY] = output;
+  }
+  return globals[PROBE_KEY];
+}
+
+/** Binary and version for usage telemetry; never rejects. */
+export function terraformCli(): Promise<TerraformCliProbe> {
+  return versionOutput()
+    .then((output) => parseTerraformCliVersion(output))
+    .catch(() => ({ name: "missing" as const }));
+}
+
+/**
+ * Version string for `cdktn debug`; a missing binary resolves to the error
+ * text, since an `Errors.Usage` value would count a phantom `cli.error`.
+ */
+export function terraformVersion(): Promise<string | undefined> {
+  return versionOutput()
+    .then((output) => parseTerraformCliVersion(output).version)
+    .catch(
+      (err) =>
+        `Error: Usage Error: Unknown: Error loading terraform version ${err}`,
+    );
+}


### PR DESCRIPTION
Part 4 of 6 in a stack; review order S1 → S6; base is the previous slice.

1. `chore(deps): upgrade @sentry/node to 10.x with unchanged reporting behaviour`
2. `fix(cli): stop the top-level error handler racing yargs`
3. `feat(cli): replace HashiCorp checkpoint telemetry with Sentry usage metrics and consent`
4. `feat(cli): report the installed binary, target versions and platform in usage metrics` (this PR)
5. `feat(cli): report per-stack, per-provider and per-command usage metrics`
6. `chore(gha): run the telemetry delivery e2e on every build`

### Related issue

Part of #48

### Description

S3 emits usage metrics carrying only `command`, `ci` and `language`, which does not answer the questions the metrics exist for: which Terraform or OpenTofu binary people actually run, which versions their projects declare they target, and on what platform. This slice adds that environment context to the base attribute set, so every metric from here on carries it.

What changes:

- `packages/@cdktn/commons/src/terraform.ts`: a lazy binary probe that runs at most once per process, with a 1500 ms ceiling and a timeout mapping to `unknown`, plus a seam so tests can drive it without spawning anything. The probe result is shared across copies of commons in the bundle via `globalThis`. `packages/@cdktn/commons/src/debug.ts` moves onto the same probe.
- `packages/@cdktn/commons/src/telemetry.ts`: `getBinaryAttributes` (bounded, release-only version, and a version only for a recognised product), `getProjectTargetAttributes` and `setProjectTargetAttributes`, `os` and `arch`, and `semverRangeOrInvalid`, which canonicalizes a declared range or reduces it to the literal `invalid`. The base attribute set grows accordingly.
- `packages/@cdktn/cli-core/src/lib/error-reporting.ts`: one `setProjectTargetAttributes(getProjectTargetAttributes(projectPath))` capture at init, so the target attributes are read once from the project that is actually running.

Every value here is validated before it becomes an attribute rather than forwarded: versions are reduced to `MAJOR.MINOR.PATCH` and dropped entirely for an unrecognised product, ranges are canonical or `invalid`, and nothing carries a path, a binary location or free text.

**Start with** `getBinaryAttributes` and `getProjectTargetAttributes` in `packages/@cdktn/commons/src/telemetry.ts`, then the probe in `packages/@cdktn/commons/src/terraform.ts` and its timeout handling. The exact-attribute-set test in `telemetry.test.ts` is the thing to check the result against: it pins the sorted key set of `cli.command.invoked`, so an accidental extra attribute fails.

Reading order for this slice:

1. `packages/@cdktn/commons/src/terraform.ts` (the probe and its seam)
2. `packages/@cdktn/commons/src/telemetry.ts` (the new attribute builders and the validators)
3. `packages/@cdktn/cli-core/src/lib/error-reporting.ts` (the single capture site)
4. `packages/@cdktn/commons/src/terraform.test.ts`, `debug.test.ts` and the exact-attribute-set and stamping cases in `telemetry.test.ts`

### What is collected

Added to the base attribute set of every metric (the S3 set of `command`, `ci` and `language` is unchanged and still applies). Still gated by `isUsageTelemetryEnabled()` and a Sentry DSN in the build; the never-sent list from S3 is unchanged by this slice.

| Attribute | Value | Source |
|---|---|---|
| `os`, `arch` | `process.platform` / `process.arch` | Node |
| `binary` | `terraform`, `opentofu`, `unknown`, `missing` | one lazy process-global probe, 1500 ms ceiling, timeout maps to `unknown` |
| `binary_version` | `MAJOR.MINOR.PATCH`, only when `binary` is `terraform` or `opentofu` | the probe; prerelease and build text dropped; an unrecognised product sends no version |
| `target_terraform`, `target_opentofu` | canonical semver range (for example `>=1.9.0`), else `invalid` | `targetVersions` in `cdktf.json`, else the CLI's `DEFAULT_TARGET_VERSIONS`; prerelease or build identifiers make it `invalid` |
| `targets_declared` | boolean | whether `cdktf.json` has a `targetVersions` block |
| `validate_installed_binary` | boolean | `validateInstalledBinary === true` in `cdktf.json` |

No new metrics are added in this slice.

### Test plan

- [x] Unit tests green across `@cdktn/commons`, `@cdktn/cli-core` and `cdktn-cli` on this slice against S3
- [x] Exact-attribute-set test: the sorted attribute key set of `cli.command.invoked` matches the documented set, so an extra attribute fails the build
- [x] Probe: runs at most once per process, honours the 1500 ms ceiling, a timeout yields `binary: unknown`, a missing binary yields `missing`, an unrecognised product yields no `binary_version`
- [x] Version and range validation: prerelease and build text dropped from versions; a non-canonical or prerelease range becomes `invalid`
- [x] Stamping test: the target attributes captured at init appear on metrics emitted later in the run
- [x] `targets_declared` and `validate_installed_binary` read from `cdktf.json` through the same forgiving reader as the consent flag
- [x] Lint and `pnpm prettier --check .` clean

### Review threads from #62 answered here

- ["dropped stack payload loses useful information"](https://github.com/open-constructs/cdk-terrain/pull/62#discussion_r3408182518), the target-versions half of the thread (so0k's follow-up): the declared Terraform and OpenTofu ranges are on every command metric now, alongside the installed binary and its version. The per-stack half of that thread is answered in S5.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable (follow-up in cdk-terrain-docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
