### PR TITLE
feat(cli): report per-stack, per-provider and per-command usage metrics

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/cdktf-project.ts
+++ b/packages/@cdktn/cli-core/src/lib/cdktf-project.ts
@@ -418,29 +418,38 @@ export class CdktfProject {
         e,
       );
     }
-    if (stack.error) {
-      throw Errors.External(
-        `Stack failed to plan: ${stack.stack.name}. Please check the logs for more information.`,
-        new Error(stack.error),
-      );
-    }
+    await this.finishStackRun(
+      "diff",
+      stacks,
+      stack.error ? [stack.stack.name] : [],
+      () =>
+        Errors.External(
+          `Stack failed to plan: ${stack.stack.name}. Please check the logs for more information.`,
+          new Error(stack.error),
+        ),
+    );
+  }
 
+  /**
+   * Emits the stack metrics, with the failed-stack count, before the failure
+   * is thrown; the failed run itself is counted by the entrypoint's reporter.
+   */
+  private async finishStackRun(
+    command: "diff" | "deploy" | "destroy",
+    stacks: SynthesizedStack[],
+    failedStacks: string[],
+    failure: (failedStacks: string[]) => Error,
+  ): Promise<void> {
     try {
-      await this.projectTelemetry("diff", {
-        stackMetadata: stacks.map((stack) =>
-          JSON.parse(stack.content)["//"]
-            ? JSON.parse(stack.content)["//"].metadata
-            : {},
-        ),
-        errors: stack.error,
-        requiredProviders: stacks.map((stack: any) =>
-          JSON.parse(stack.content)["terraform"]
-            ? JSON.parse(stack.content)["terraform"].required_providers
-            : {},
-        ),
+      await this.projectTelemetry(command, {
+        ...SynthStack.telemetryPayload(stacks),
+        failedStackCount: failedStacks.length,
       });
     } catch (e) {
       logger.debug("Failed to send telemetry", e);
+    }
+    if (failedStacks.length > 0) {
+      throw failure(failedStacks);
     }
   }
 
@@ -531,34 +540,17 @@ export class CdktfProject {
 
     await this.execute("deploy", next, opts);
 
-    const unprocessedStacks = this.stacksToRun.filter(
-      (executor) => executor.isPending,
+    await this.finishStackRun(
+      "deploy",
+      stacksToRun,
+      this.stacksToRun
+        .filter((executor) => executor.isPending)
+        .map((executor) => executor.stack.name),
+      (failedStacks) =>
+        Errors.External(
+          `Some stacks failed to deploy: ${failedStacks.join(", ")}. Please check the logs for more information.`,
+        ),
     );
-    if (unprocessedStacks.length > 0) {
-      throw Errors.External(
-        `Some stacks failed to deploy: ${unprocessedStacks
-          .map((s) => s.stack.name)
-          .join(", ")}. Please check the logs for more information.`,
-      );
-    }
-
-    try {
-      await this.projectTelemetry("deploy", {
-        stackMetadata: stacksToRun.map((stack) =>
-          JSON.parse(stack.content)["//"]
-            ? JSON.parse(stack.content)["//"].metadata
-            : {},
-        ),
-        failedStacks: unprocessedStacks.map((stack) => stack.error),
-        requiredProviders: stacksToRun.map((stack: any) =>
-          JSON.parse(stack.content)["terraform"]
-            ? JSON.parse(stack.content)["terraform"].required_providers
-            : {},
-        ),
-      });
-    } catch (e) {
-      logger.debug("Failed to send telemetry", e);
-    }
   }
 
   public async destroy(opts: MutationOptions = {}) {
@@ -610,34 +602,17 @@ export class CdktfProject {
 
     await this.execute("destroy", next, opts);
 
-    const unprocessedStacks = this.stacksToRun.filter(
-      (executor) => executor.isPending,
+    await this.finishStackRun(
+      "destroy",
+      stacksToRun,
+      this.stacksToRun
+        .filter((executor) => executor.isPending)
+        .map((executor) => executor.stack.name),
+      (failedStacks) =>
+        Errors.External(
+          `Some stacks failed to destroy: ${failedStacks.join(", ")}. Please check the logs for more information.`,
+        ),
     );
-    if (unprocessedStacks.length > 0) {
-      throw Errors.External(
-        `Some stacks failed to destroy: ${unprocessedStacks
-          .map((s) => s.stack.name)
-          .join(", ")}. Please check the logs for more information.`,
-      );
-    }
-
-    try {
-      await this.projectTelemetry("destroy", {
-        stackMetadata: stacksToRun.map((stack) =>
-          JSON.parse(stack.content)["//"]
-            ? JSON.parse(stack.content)["//"].metadata
-            : {},
-        ),
-        failedStacks: unprocessedStacks.map((stack) => stack.error),
-        requiredProviders: stacksToRun.map((stack: any) =>
-          JSON.parse(stack.content)["terraform"]
-            ? JSON.parse(stack.content)["terraform"].required_providers
-            : {},
-        ),
-      });
-    } catch (e) {
-      logger.debug("Failed to send telemetry", e);
-    }
   }
 
   public async projectTelemetry(command: string, payload: any): Promise<void> {

--- a/packages/@cdktn/cli-core/src/lib/synth-stack.ts
+++ b/packages/@cdktn/cli-core/src/lib/synth-stack.ts
@@ -282,6 +282,30 @@ Command output on stdout:
     return stacks;
   }
 
+  /**
+   * The telemetry-relevant slice of the synthesized stacks: the metadata
+   * block and `required_providers`, one entry per stack. Resource config
+   * and outputs stay out of the payload.
+   */
+  public static telemetryPayload(stacks: SynthesizedStack[]): {
+    stackMetadata: unknown[];
+    requiredProviders: unknown[];
+  } {
+    const contents = stacks.map((stack) => {
+      try {
+        return JSON.parse(stack.content);
+      } catch {
+        return {};
+      }
+    });
+    return {
+      stackMetadata: contents.map((c) => c?.["//"]?.metadata ?? {}),
+      requiredProviders: contents.map(
+        (c) => c?.terraform?.required_providers ?? {},
+      ),
+    };
+  }
+
   public static async synthTelemetry(
     totalTime: number,
     stacks: SynthesizedStack[],
@@ -293,13 +317,7 @@ Command output on stdout:
       totalTime: totalTime,
       language: config.language,
       synthOrigin,
-      stackMetadata: stacks.map(
-        (stack) => JSON.parse(stack.content)["//"].metadata,
-      ),
-      requiredProviders: stacks.map(
-        (stack: any) =>
-          JSON.parse(stack.content)["terraform"].required_providers,
-      ),
+      ...SynthStack.telemetryPayload(stacks),
     });
   }
 

--- a/packages/@cdktn/cli-core/src/test/lib/cdktf-project-telemetry.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/cdktf-project-telemetry.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { IsErrorType } from "@cdktn/commons";
+import { CdktfProject } from "../../lib/cdktf-project";
+import { SynthesizedStack } from "../../lib/synth-stack";
+
+jest.mock("@cdktn/commons", () => ({
+  ...jest.requireActual("@cdktn/commons"),
+  sendTelemetry: jest.fn().mockResolvedValue(undefined),
+}));
+
+const metadata = {
+  version: "0.21.0",
+  stackName: "pending-stack",
+  backend: "s3",
+};
+const stack: SynthesizedStack = {
+  name: "pending-stack",
+  dependencies: [],
+  annotations: [],
+  content: JSON.stringify({ "//": { metadata, outputs: {} } }),
+  constructPath: ".",
+  synthesizedStackPath: ".",
+  workingDirectory: ".",
+  stackMetadataPath: ".",
+};
+
+describe("CdktfProject stack telemetry on failure", () => {
+  const commons = jest.requireMock("@cdktn/commons") as {
+    sendTelemetry: jest.Mock;
+  };
+
+  beforeEach(() => {
+    commons.sendTelemetry.mockClear();
+  });
+
+  // A pending executor after `execute` returns is a stack that never ran
+  // (its dependency failed); the stack metrics go out before the throw.
+  it.each(["deploy", "destroy"] as const)(
+    "%s with a pending stack counts it as failed and still throws",
+    async (method) => {
+      const project = new CdktfProject({
+        synthCommand: "unused",
+        outDir: "unused",
+        onUpdate: () => {},
+      });
+      jest
+        .spyOn(project as any, "readSynthesizedStacks")
+        .mockResolvedValue([stack]);
+      jest
+        .spyOn(project, "getStackExecutor")
+        .mockReturnValue({ isPending: true, stack } as any);
+      jest.spyOn(project as any, "execute").mockResolvedValue(undefined);
+
+      let thrown: unknown;
+      await project[method]({ skipSynth: true, autoApprove: true }).catch(
+        (e) => (thrown = e),
+      );
+
+      expect(IsErrorType(thrown, "External")).toBe(true);
+      expect((thrown as Error).message).toContain(
+        `Some stacks failed to ${method}: pending-stack`,
+      );
+      expect(commons.sendTelemetry).toHaveBeenCalledTimes(1);
+      expect(commons.sendTelemetry).toHaveBeenCalledWith(
+        method,
+        expect.objectContaining({
+          stackMetadata: [metadata],
+          failedStackCount: 1,
+        }),
+      );
+    },
+  );
+});

--- a/packages/@cdktn/cli-core/src/test/lib/synth-stack.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/synth-stack.test.ts
@@ -4,13 +4,68 @@ import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
 import { Errors } from "@cdktn/commons";
-import { SynthStack } from "../../lib/synth-stack";
+import { SynthStack, SynthesizedStack } from "../../lib/synth-stack";
 
 jest.mock("@cdktn/commons", () => ({
   ...jest.requireActual("@cdktn/commons"),
   sendTelemetry: jest.fn().mockResolvedValue(undefined),
   flushTelemetry: jest.fn().mockResolvedValue(undefined),
 }));
+
+function stack(content: string): SynthesizedStack {
+  return {
+    name: "stack",
+    dependencies: [],
+    annotations: [],
+    content,
+    constructPath: ".",
+    synthesizedStackPath: ".",
+    workingDirectory: ".",
+    stackMetadataPath: ".",
+  };
+}
+
+describe("SynthStack.telemetryPayload", () => {
+  // not the privacy boundary: the payload still carries the stack name and
+  // the ids inside imports/moved; sendStackTelemetry reduces it to counts
+  it("extracts the metadata block and required providers per stack", () => {
+    const metadata = {
+      version: "0.21.0",
+      stackName: "prod-vpc",
+      backend: "local",
+    };
+    const requiredProviders = { aws: { source: "aws", version: "~> 5.0" } };
+    const payload = SynthStack.telemetryPayload([
+      stack(
+        JSON.stringify({
+          "//": { metadata, outputs: {} },
+          terraform: { required_providers: requiredProviders },
+          resource: { aws_s3_bucket: { bucket: { bucket: "name" } } },
+        }),
+      ),
+      // HCL output: the content is the metadata file, without a terraform block
+      stack(JSON.stringify({ "//": { metadata, outputs: {} } })),
+    ]);
+
+    expect(payload).toEqual({
+      stackMetadata: [metadata, metadata],
+      requiredProviders: [requiredProviders, {}],
+    });
+    expect(payload.stackMetadata[0]).toHaveProperty("stackName");
+    expect(JSON.stringify(payload)).not.toContain("aws_s3_bucket");
+  });
+
+  // content is read from disk on the failure path before the throw; it must
+  // degrade to {} rather than take down deploy
+  it("yields empty entries for content without metadata or unparsable content", () => {
+    expect(
+      SynthStack.telemetryPayload([stack("{}"), stack("not json")]),
+    ).toEqual({
+      stackMetadata: [{}, {}],
+      requiredProviders: [{}, {}],
+    });
+  });
+});
 
 describe("SynthStack.synth failure paths count the run before exiting", () => {
   const commons = jest.requireMock("@cdktn/commons") as {

--- a/packages/@cdktn/commons/src/construct-maker-target.test.ts
+++ b/packages/@cdktn/commons/src/construct-maker-target.test.ts
@@ -3,8 +3,15 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import { Language, TerraformModuleConstraint } from "./config";
-import { ConstructsMakerModuleTarget } from "./construct-maker-target";
+import {
+  Language,
+  TerraformModuleConstraint,
+  TerraformProviderConstraint,
+} from "./config";
+import {
+  ConstructsMakerModuleTarget,
+  ConstructsMakerProviderTarget,
+} from "./construct-maker-target";
 
 describe("ConstructsMakerModuleTarget", () => {
   describe.each([
@@ -76,5 +83,37 @@ describe("ConstructsMakerModuleTarget", () => {
         expect(target.srcMakName).toBe(name);
       },
     );
+  });
+});
+
+// `trackingPayload` is read by the `get` telemetry in cdktn-cli (`type` and
+// `source`): a rename here silently drops the per-binding metrics.
+describe("trackingPayload", () => {
+  it("names a module target by its registry source", () => {
+    const target = new ConstructsMakerModuleTarget(
+      new TerraformModuleConstraint("terraform-aws-modules/vpc/aws@5.0.0"),
+      Language.TYPESCRIPT,
+    );
+    expect(target.trackingPayload).toEqual({
+      name: "vpc",
+      fullName: "terraform-aws-modules/vpc/aws",
+      source: "terraform-aws-modules/vpc/aws",
+      version: "5.0.0",
+      type: "module",
+    });
+  });
+
+  it("names a provider target by its source", () => {
+    const target = new ConstructsMakerProviderTarget(
+      new TerraformProviderConstraint("hashicorp/aws@~> 5.0"),
+      Language.TYPESCRIPT,
+    );
+    expect(target.trackingPayload).toEqual({
+      name: "aws",
+      fullName: "hashicorp/aws",
+      source: "hashicorp/aws",
+      version: "~> 5.0",
+      type: "provider",
+    });
   });
 });

--- a/packages/@cdktn/commons/src/construct-maker-target.ts
+++ b/packages/@cdktn/commons/src/construct-maker-target.ts
@@ -97,6 +97,7 @@ export class ConstructsMakerModuleTarget extends ConstructsMakerTarget {
     return {
       name: this.name,
       fullName: this.fqn,
+      source: this.source,
       version: this.version,
       type: "module",
     };
@@ -149,6 +150,7 @@ export class ConstructsMakerProviderTarget extends ConstructsMakerTarget {
     return {
       name: this.name,
       fullName: this.source,
+      source: this.source,
       version: this.version,
       type: "provider",
     };

--- a/packages/@cdktn/commons/src/telemetry.test.ts
+++ b/packages/@cdktn/commons/src/telemetry.test.ts
@@ -10,6 +10,12 @@ import {
   startCommandTelemetry,
   resetCommandTelemetry,
   flushTelemetry,
+  normalizeBackendKind,
+  normalizeProviderConstraint,
+  classifyModuleSource,
+  classifyProviderBinding,
+  getGeneratedProviderSources,
+  normalizeProviderSource,
   getBinaryAttributes,
   getProjectTargetAttributes,
   getUsageTelemetryConsent,
@@ -135,7 +141,7 @@ describe("telemetry", () => {
 
       await startCommandTelemetry("synth");
       await sendTelemetry("synth", { totalTime: 1234, language: "typescript" });
-      await sendTelemetry("synth", { error: true });
+      await sendTelemetry("synth", { error: true, synthOrigin: "watch" });
       expect(await Sentry.flush(2000)).toBe(true);
 
       const items = parseMetricItems(envelopeBodies);
@@ -182,6 +188,7 @@ describe("telemetry", () => {
       expect(attributeValues(error)).toMatchObject({
         error_type: "unexpected",
         language: "typescript",
+        synth_origin: "watch",
       });
       expect(envelopeBodies.join("\n")).not.toContain("LEAK-ENV-SENTRY");
     });
@@ -275,6 +282,7 @@ describe("telemetry", () => {
       await sendTelemetry("synth", {
         totalTime: 5,
         language: "typescript",
+        synthOrigin: "watch",
         stackMetadata: [{ stackName: "prod-vpc", backend: "s3" }],
         requiredProviders: [{ aws: { source: "aws" } }],
         stackName: "prod-vpc",
@@ -285,10 +293,11 @@ describe("telemetry", () => {
       const items = parseMetricItems(envelopeBodies);
       const invoked = items.find((i) => i.name === "cli.command.invoked")!;
       const completed = items.find((i) => i.name === "cli.command.completed")!;
-      const keys = Object.keys(invoked.attributes);
-      // the start and end metrics carry the same base set
-      expect(Object.keys(completed.attributes).sort()).toEqual(
-        [...keys].sort(),
+      const keys = Object.keys(completed.attributes);
+      // the start metric carries the base set; the end-of-run scalars ride
+      // on completed only
+      expect(Object.keys(invoked.attributes).sort()).toEqual(
+        keys.filter((key) => key !== "synth_origin").sort(),
       );
       // the one place that fails when an attribute is added: extend it
       // deliberately, together with the collected-data list in the docs
@@ -302,6 +311,7 @@ describe("telemetry", () => {
         "os",
         // server.address is the fixed serverName from init
         "server.address",
+        "synth_origin",
         "target_opentofu",
         "target_terraform",
         "targets_declared",
@@ -311,12 +321,381 @@ describe("telemetry", () => {
       expect(keys).toEqual(
         expect.arrayContaining(["sentry.release", "sentry.environment"]),
       );
-      expect(invoked.attributes.binary_version.value).toBe("1.9.0");
-      expect(invoked.attributes["server.address"].value).toBe("cdktn-cli");
+      expect(completed.attributes.binary_version.value).toBe("1.9.0");
+      expect(completed.attributes["server.address"].value).toBe("cdktn-cli");
       const bytes = envelopeBodies.join("\n");
       expect(bytes).not.toContain("prod-vpc");
       expect(bytes).not.toContain("/Users/x/secret");
     });
+  });
+
+  describe("sendTelemetry payload mapping", () => {
+    beforeEach(() => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        sendUsageTelemetry: true,
+      });
+      initSentryWithCapturingTransport();
+    });
+
+    it.each([
+      [
+        "convert",
+        { numberOfProviders: 2, numberOfModules: 1, convertedLines: 42 },
+        { provider_count: 2, module_count: 1, converted_lines: 42 },
+      ],
+      [
+        "init",
+        { template: "go", isRemote: false },
+        { template: "go", is_remote: false },
+      ],
+      ["synth", { synthOrigin: "watch" }, { synth_origin: "watch" }],
+    ])(
+      "maps the %s scalars %j to the attributes %j of cli.command.completed",
+      async (command, payload, expected) => {
+        await sendTelemetry(command, payload);
+        expect(await Sentry.flush(2000)).toBe(true);
+
+        const completed = parseMetricItems(envelopeBodies).find(
+          (i) => i.name === "cli.command.completed",
+        )!;
+        expect(attributeValues(completed)).toMatchObject(expected);
+      },
+    );
+
+    it("forwards only allow-listed scalars: an unknown object-valued key is never serialized", async () => {
+      await sendTelemetry("convert", {
+        language: "python",
+        convertedLines: 42,
+        resources: { aws: { s3_bucket: 3 } },
+        data: { aws: { caller_identity: 1 } },
+        somethingElse: "not listed",
+        error: false,
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const completed = parseMetricItems(envelopeBodies).find(
+        (i) => i.name === "cli.command.completed",
+      )!;
+      const values = attributeValues(completed);
+      expect(values).toMatchObject({ language: "python", converted_lines: 42 });
+      expect(values).not.toHaveProperty("resources");
+      expect(values).not.toHaveProperty("data");
+      expect(values).not.toHaveProperty("somethingElse");
+      expect(values).not.toHaveProperty("error");
+      expect(JSON.stringify(values)).not.toContain("s3_bucket");
+    });
+
+    it("counts get targets per provider/module and puts only totals on the command metric", async () => {
+      await sendTelemetry("get", {
+        language: "typescript",
+        targets: [
+          { type: "provider", source: "registry.terraform.io/hashicorp/aws" },
+          { type: "provider", source: "Kreuzwerker/Docker" },
+          { type: "module", source: "terraform-aws-modules/vpc/aws" },
+          { type: "module", source: "./modules/secret-name" },
+        ],
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const completed = items.find((i) => i.name === "cli.command.completed")!;
+      expect(attributeValues(completed)).toMatchObject({
+        provider_count: 2,
+        module_count: 2,
+      });
+      expect(completed.attributes).not.toHaveProperty("targets");
+
+      const providers = items
+        .filter((i) => i.name === "cli.get.provider")
+        .map((i) => attributeValues(i).provider);
+      expect(providers).toEqual(["hashicorp/aws", "kreuzwerker/docker"]);
+
+      const modules = items
+        .filter((i) => i.name === "cli.get.module")
+        .map((i) => attributeValues(i).module);
+      expect(modules).toEqual(["terraform-aws-modules/vpc/aws", "local"]);
+      expect(JSON.stringify(items)).not.toContain("secret-name");
+    });
+
+    it("counts init providers per provider and puts only the total on the command metric", async () => {
+      await sendTelemetry("init", {
+        language: "go",
+        projectId: "should-not-be-sent",
+        addedProviders: ["aws@~>5.0", "hashicorp/random"],
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const completed = items.find((i) => i.name === "cli.command.completed")!;
+      expect(attributeValues(completed).provider_count).toBe(2);
+      expect(completed.attributes).not.toHaveProperty("projectId");
+      expect(
+        items
+          .filter((i) => i.name === "cli.init.provider")
+          .map((i) => attributeValues(i).provider),
+      ).toEqual(["hashicorp/aws", "hashicorp/random"]);
+    });
+  });
+
+  describe("stack metrics", () => {
+    // one JSON-synthesized stack the way the library writes it: metadata
+    // carries the stack name and resource ids (imports/moved), overrides
+    // are keyed by schema type, module overrides by source
+    const stackMetadata = [
+      {
+        version: "0.21.0",
+        stackName: "SECRET-STACK-NAME",
+        backend: "s3",
+        overrides: {
+          stack: ["terraform.required_version"],
+          aws_s3_bucket: ["tags", "region"],
+          "module.../secret-path/vpc": ["providers"],
+        },
+        imports: { aws_s3_bucket: ["secret-resource-id"] },
+        moved: {
+          aws_s3_bucket: ["secret-resource-id"],
+          aws_iam_role: ["secret-resource-id"],
+        },
+      },
+      {
+        version: "0.21.0",
+        stackName: "SECRET-STACK-NAME-2",
+        backend: "remote",
+        cloud: "tfc",
+      },
+    ];
+    const requiredProviders = [
+      {
+        aws: { source: "aws", version: "~> 5.0" },
+        docker: {
+          source: "registry.terraform.io/kreuzwerker/docker",
+          version: "3.0.2",
+        },
+        google: { source: "hashicorp/google", version: "x".repeat(100) },
+      },
+      {
+        random: { source: "hashicorp/random" },
+        vault: {
+          source: "tfe.corp.example.com/acme-org/vault",
+          version: "~> 3.0",
+        },
+      },
+    ];
+
+    beforeEach(() => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        sendUsageTelemetry: true,
+        terraformProviders: [
+          "aws@~>5.0",
+          { name: "docker", source: "kreuzwerker/docker", version: "3.0.2" },
+        ],
+      });
+      initSentryWithCapturingTransport();
+    });
+
+    it("counts one cli.stack per stack with backend, cloud, library version and group sizes", async () => {
+      await sendTelemetry("deploy", {
+        language: "typescript",
+        stackMetadata,
+        requiredProviders,
+        failedStackCount: 0,
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const stacks = items
+        .filter((i) => i.name === "cli.stack")
+        .map(attributeValues);
+      expect(stacks).toHaveLength(2);
+      expect(stacks[0]).toMatchObject({
+        command: "deploy",
+        language: "typescript",
+        backend: "s3",
+        cloud: false,
+        library_version: "0.21.0",
+        override_count: 4,
+        import_count: 1,
+        moved_count: 2,
+        os: process.platform,
+        "sentry.release": "cdktn-cli-test",
+      });
+      expect(stacks[1]).toMatchObject({
+        backend: "remote",
+        cloud: true,
+        override_count: 0,
+        import_count: 0,
+        moved_count: 0,
+      });
+      expect(items.some((i) => i.name === "cli.stack.failed")).toBe(false);
+      expect(items.some((i) => i.name === "cli.command.completed")).toBe(true);
+    });
+
+    it("counts overrides per resource type, reducing module sources to their kind", async () => {
+      await sendTelemetry("synth", { stackMetadata, requiredProviders });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const overrides = parseMetricItems(envelopeBodies)
+        .filter((i) => i.name === "cli.stack.override")
+        .map((i) => {
+          const { resource_type, override_count } = attributeValues(i);
+          return [resource_type, override_count];
+        });
+      expect(overrides).toEqual([
+        ["stack", 1],
+        ["aws_s3_bucket", 2],
+        ["module.local", 1],
+      ]);
+    });
+
+    it("counts required providers with normalized source, validated constraint and binding", async () => {
+      await sendTelemetry("diff", { stackMetadata, requiredProviders });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const providers = parseMetricItems(envelopeBodies)
+        .filter((i) => i.name === "cli.stack.provider")
+        .map(attributeValues);
+      expect(providers.map((p) => p.provider)).toEqual([
+        "hashicorp/aws",
+        "kreuzwerker/docker",
+        "hashicorp/google",
+        "hashicorp/random",
+        "private-registry",
+      ]);
+      expect(providers.map((p) => p.binding)).toEqual([
+        "generated",
+        "generated",
+        "prebuilt",
+        "prebuilt",
+        "prebuilt",
+      ]);
+      expect(providers[0].version_constraint).toBe("~> 5.0");
+      expect(providers[2].version_constraint).toBe("invalid");
+      expect(providers[3]).not.toHaveProperty("version_constraint");
+    });
+
+    it("counts failed stacks and never serializes their failure messages", async () => {
+      await sendTelemetry("destroy", {
+        stackMetadata,
+        requiredProviders,
+        failedStackCount: 2,
+        failedStacks: ["failed to destroy SECRET-STACK-NAME: /Users/x/state"],
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const failed = items.find((i) => i.name === "cli.stack.failed")!;
+      expect(failed.value).toBe(2);
+      expect(failed.attributes.command.value).toBe("destroy");
+      // the failure thrown next is counted as cli.command.error, not here
+      expect(items.some((i) => i.name === "cli.command.completed")).toBe(false);
+      expect(envelopeBodies.join("\n")).not.toContain("failed to destroy");
+      expect(envelopeBodies.join("\n")).not.toContain("/Users/x");
+    });
+
+    it("never serializes stack names, resource ids or module paths", async () => {
+      await sendTelemetry("deploy", {
+        language: "typescript",
+        stackMetadata,
+        requiredProviders,
+        failedStackCount: 1,
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const overrideCount = Object.keys(stackMetadata[0].overrides!).length;
+      const providerCount = requiredProviders.reduce(
+        (total, providers) => total + Object.keys(providers).length,
+        0,
+      );
+      // one cli.stack per stack, one override / provider metric per entry,
+      // plus the single cli.stack.failed count
+      expect(items.filter((i) => i.name.startsWith("cli.stack")).length).toBe(
+        stackMetadata.length + overrideCount + providerCount + 1,
+      );
+      for (const item of items) {
+        for (const forbidden of [
+          "stackName",
+          "stack_name",
+          "imports",
+          "moved",
+        ]) {
+          expect(item.attributes).not.toHaveProperty(forbidden);
+        }
+      }
+      const bytes = envelopeBodies.join("\n");
+      expect(bytes).not.toContain("SECRET-STACK-NAME");
+      expect(bytes).not.toContain("secret-resource-id");
+      expect(bytes).not.toContain("secret-path");
+      expect(bytes).not.toContain("tfe.corp.example.com");
+      expect(bytes).not.toContain("acme-org");
+    });
+
+    it("emits no cli.stack.* metric when usage telemetry is off", async () => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        sendUsageTelemetry: false,
+      });
+
+      await sendTelemetry("deploy", {
+        stackMetadata,
+        requiredProviders,
+        failedStackCount: 1,
+      });
+      await Sentry.flush(2000);
+
+      expect(parseMetricItems(envelopeBodies)).toHaveLength(0);
+    });
+
+    // a throw inside a payload handler is swallowed by sendTelemetry's catch
+    // and would skip the command metric for the whole run
+    it("tolerates malformed metadata entries and counts only the real stacks", async () => {
+      await sendTelemetry("synth", {
+        stackMetadata: [null, "nope", { overrides: "nope", imports: [] }],
+        requiredProviders: [undefined, undefined, { aws: "nope" }],
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      // only the one object entry is a stack
+      expect(items.filter((i) => i.name === "cli.stack")).toHaveLength(1);
+      expect(items.filter((i) => i.name === "cli.stack.override")).toHaveLength(
+        0,
+      );
+      const provider = items.find((i) => i.name === "cli.stack.provider")!;
+      expect(attributeValues(provider)).toMatchObject({
+        provider: "hashicorp/aws",
+        binding: "generated",
+      });
+      expect(items.some((i) => i.name === "cli.command.completed")).toBe(true);
+    });
+
+    it.each([
+      ["init", { addedProviders: [null, 42, "aws"] }, "cli.init.provider"],
+      [
+        "get",
+        {
+          targets: [{ type: "provider" }, null, { type: "module", source: 7 }],
+        },
+        "cli.get.provider",
+      ],
+    ])(
+      "still counts the %s command with malformed %j entries",
+      async (command, payload, metric) => {
+        await sendTelemetry(command, payload);
+        expect(await Sentry.flush(2000)).toBe(true);
+
+        const items = parseMetricItems(envelopeBodies);
+        const completed = items.find(
+          (i) => i.name === "cli.command.completed",
+        )!;
+        expect(completed).toBeDefined();
+        expect(items.filter((i) => i.name === metric)).toHaveLength(
+          command === "init" ? 1 : 0,
+        );
+        expect(attributeValues(completed).provider_count).toBe(
+          command === "init" ? 1 : 0,
+        );
+      },
+    );
   });
 
   describe("attribute validation", () => {
@@ -350,6 +729,33 @@ describe("telemetry", () => {
       expect(envelopeBodies.join("\n")).not.toContain("DROP TABLE");
     });
 
+    it.each([
+      ["synth", { synthOrigin: "watch" }, "synth_origin", "watch"],
+      ["synth", { synthOrigin: "/Users/x" }, "synth_origin", undefined],
+      ["init", { isRemote: true }, "is_remote", true],
+      ["init", { isRemote: "true" }, "is_remote", undefined],
+      ["init", { template: "go" }, "template", "go"],
+      ["init", { template: 7 }, "template", undefined],
+      ["convert", { convertedLines: 42 }, "converted_lines", 42],
+      ["convert", { convertedLines: "42" }, "converted_lines", undefined],
+      ["convert", { convertedLines: NaN }, "converted_lines", undefined],
+    ])(
+      "%s: %j forwards %s as %j",
+      async (command, payload, attribute, expected) => {
+        await sendTelemetry(command, payload);
+        expect(await Sentry.flush(2000)).toBe(true);
+
+        const completed = parseMetricItems(envelopeBodies).find(
+          (i) => i.name === "cli.command.completed",
+        )!;
+        if (expected === undefined) {
+          expect(completed.attributes).not.toHaveProperty(attribute);
+        } else {
+          expect(attributeValues(completed)[attribute]).toBe(expected);
+        }
+      },
+    );
+
     it("sends declared targets that are not semver ranges as invalid", () => {
       fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
         targetVersions: { terraform: "latest /Users/x", opentofu: ">=1.8" },
@@ -377,6 +783,223 @@ describe("telemetry", () => {
       expect(getProjectTargetAttributes(workdir).target_terraform).toBe(
         expected,
       );
+    });
+
+    it.each([
+      ["~> 5.0", "~> 5.0"],
+      ["latest /Users/x", "invalid"],
+    ])(
+      "delivers the provider constraint %p as %p",
+      async (version, expected) => {
+        await sendTelemetry("synth", {
+          stackMetadata: [{}],
+          requiredProviders: [{ aws: { source: "aws", version } }],
+        });
+        expect(await Sentry.flush(2000)).toBe(true);
+
+        const provider = parseMetricItems(envelopeBodies).find(
+          (i) => i.name === "cli.stack.provider",
+        )!;
+        expect(attributeValues(provider).version_constraint).toBe(expected);
+      },
+    );
+
+    it("reduces a backend outside the built-in kinds and override keys outside the type grammar to other", async () => {
+      await sendTelemetry("synth", {
+        stackMetadata: [
+          {
+            version: "0.21.0+build." + "x".repeat(40),
+            backend: "s3 bucket=/Users/x/state",
+            overrides: {
+              aws_s3_bucket: ["tags"],
+              terraform_remote_state: ["backend"],
+              "module.terraform-aws-modules/vpc/aws": ["providers"],
+              "resource with spaces /Users/x": ["tags"],
+              AWS_S3_Bucket: ["tags"],
+              ["aws_" + "x".repeat(70)]: ["tags"],
+            },
+          },
+          { version: "dev-/Users/x", backend: "S3" },
+        ],
+      });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      const items = parseMetricItems(envelopeBodies);
+      const stacks = items
+        .filter((i) => i.name === "cli.stack")
+        .map(attributeValues);
+      // build metadata is stripped like binary_version; a version without a
+      // MAJOR.MINOR.PATCH prefix yields no attribute at all
+      expect(stacks[0]).toMatchObject({
+        backend: "other",
+        library_version: "0.21.0",
+      });
+      expect(stacks[1]).toMatchObject({ backend: "other" });
+      expect(stacks[1]).not.toHaveProperty("library_version");
+      expect(
+        items
+          .filter((i) => i.name === "cli.stack.override")
+          .map((i) => attributeValues(i).resource_type),
+      ).toEqual([
+        "aws_s3_bucket",
+        "terraform_remote_state",
+        "module.terraform-aws-modules/vpc/aws",
+        "other",
+        "other",
+        "other",
+      ]);
+      expect(envelopeBodies.join("\n")).not.toContain("/Users/x");
+    });
+
+    it("delivers a built-in backend kind as-is", async () => {
+      await sendTelemetry("synth", { stackMetadata: [{ backend: "gcs" }] });
+      expect(await Sentry.flush(2000)).toBe(true);
+
+      expect(
+        attributeValues(
+          parseMetricItems(envelopeBodies).find((i) => i.name === "cli.stack")!,
+        ).backend,
+      ).toBe("gcs");
+    });
+  });
+
+  describe("provider binding classification", () => {
+    it("reads string and object terraformProviders entries as identities", () => {
+      fs.writeJsonSync(path.join(workdir, "cdktf.json"), {
+        terraformProviders: [
+          "aws@~>5.0",
+          "hashicorp/random@3.6.0",
+          "registry.terraform.io/kreuzwerker/docker",
+          { name: "google", source: "hashicorp/google", version: "~> 5.0" },
+          { name: "azurerm" },
+          { version: "1.0.0" },
+          42,
+          "TFE.corp.example.com/acme-org/vault@~>3.0",
+        ],
+      });
+      expect(getGeneratedProviderSources(workdir)).toEqual([
+        "hashicorp/aws",
+        "hashicorp/random",
+        "kreuzwerker/docker",
+        "hashicorp/google",
+        "hashicorp/azurerm",
+        "tfe.corp.example.com/acme-org/vault",
+      ]);
+    });
+
+    it.each([[{}], [{ terraformProviders: "aws" }]])(
+      "returns no sources for %j",
+      (config) => {
+        fs.writeJsonSync(path.join(workdir, "cdktf.json"), config);
+        expect(getGeneratedProviderSources(workdir)).toEqual([]);
+      },
+    );
+
+    it("returns no sources without a cdktf.json", () => {
+      expect(getGeneratedProviderSources(workdir)).toEqual([]);
+    });
+
+    it.each([
+      ["aws", "generated"],
+      ["registry.terraform.io/hashicorp/aws", "generated"],
+      ["Hashicorp/AWS", "generated"],
+      ["kreuzwerker/docker", "generated"],
+      ["hashicorp/google", "prebuilt"],
+      ["tfe.corp.example.com/acme-org/vault", "generated"],
+      // another private source is not the generated one, even though both
+      // reach the metric as "private-registry"
+      ["tfe.corp.example.com/other-org/vault", "prebuilt"],
+      ["./leak-provider", "prebuilt"],
+    ])("classifies %s as %s", (source, expected) => {
+      const generated = [
+        "hashicorp/aws",
+        "kreuzwerker/docker",
+        "tfe.corp.example.com/acme-org/vault",
+      ];
+      expect(classifyProviderBinding(source, generated)).toBe(expected);
+    });
+  });
+
+  describe("source normalization", () => {
+    it.each([
+      ["aws", "hashicorp/aws"],
+      ["aws@~>5.0", "hashicorp/aws"],
+      ["Hashicorp/AWS@5.1.0", "hashicorp/aws"],
+      ["registry.terraform.io/hashicorp/aws", "hashicorp/aws"],
+      ["registry.opentofu.org/hashicorp/aws", "hashicorp/aws"],
+      ["kreuzwerker/docker", "kreuzwerker/docker"],
+      ["tfe.corp.example.com/acme-org/aws", "private-registry"],
+      ["registry.acme.internal/platform/vault@~>3.0", "private-registry"],
+      ["localhost:8080/acme/aws", "private-registry"],
+      ["./leak-provider", "other"],
+      ["../leak/provider", "other"],
+      ["/abs/leak/provider", "other"],
+      ["a/b/c", "other"],
+      ["", "other"],
+      ["registry.terraform.io/hashicorp", "other"],
+      [`${"n".repeat(65)}/aws`, "other"],
+      [`${"n".repeat(64)}/aws`, `${"n".repeat(64)}/aws`],
+      [`${"n".repeat(64)}/${"t".repeat(64)}`, "other"],
+    ])("normalizeProviderSource(%s) -> %s", (input, expected) => {
+      expect(normalizeProviderSource(input)).toBe(expected);
+    });
+
+    it.each([
+      ["terraform-aws-modules/vpc/aws", "terraform-aws-modules/vpc/aws"],
+      ["Terraform-AWS-Modules/VPC/aws", "terraform-aws-modules/vpc/aws"],
+      // one row per fallthrough: everything the grammar rejects is "other"
+      ["Terraform-AWS-Modules/VPC/aws?ref=v5.0.0", "other"],
+      ["app.terraform.io/my-org/vpc/aws", "private-registry"],
+      ["./modules/vpc", "local"],
+      ["../shared/vpc", "local"],
+      ["/abs/path/vpc", "local"],
+      ["git::https://github.com/org/repo.git", "git"],
+      ["git@github.com:org/repo.git", "git"],
+      ["github.com/org/repo", "git"],
+      ["https://example.com/vpc.zip", "git"],
+      ["s3::https://s3-eu-west-1.amazonaws.com/leak-bucket/vpc.zip", "git"],
+      ["s3-eu-west-1.amazonaws.com/leak-bucket/vpc.zip", "git"],
+      ["leak-bucket.s3.amazonaws.com/leak-dir/vpc.zip", "git"],
+      ["gcs::https://www.googleapis.com/storage/v1/leak-bucket/vpc", "git"],
+      ["www.googleapis.com/storage/v1/leak-bucket/vpc", "git"],
+      ["hg::http://example.com/leak-repo", "git"],
+    ])("classifyModuleSource(%s) -> %s", (input, expected) => {
+      expect(classifyModuleSource(input)).toBe(expected);
+    });
+
+    it.each([
+      ["local", "local"],
+      ["remote", "remote"],
+      ["cloud", "cloud"],
+      ["s3", "s3"],
+      ["gcs", "gcs"],
+      ["azurerm", "azurerm"],
+      ["kubernetes", "kubernetes"],
+      ["S3", "other"],
+      ["s3 bucket=/Users/x/state", "other"],
+      [undefined, "unknown"],
+    ])("normalizeBackendKind(%p) -> %p", (input, expected) => {
+      expect(normalizeBackendKind(input)).toBe(expected);
+    });
+
+    it.each([
+      [">= 1.2, < 2.0", ">= 1.2, < 2.0"],
+      ["~> 5.0", "~> 5.0"],
+      ["= 1.0", "= 1.0"],
+      ["!= 1.2.3", "!= 1.2.3"],
+      ["1.2.3", "1.2.3"],
+      ["  >= 1.0 ,  < 2.0  ", ">= 1.0, < 2.0"],
+      ["~>5.0,!=5.1.0", "~> 5.0, != 5.1.0"],
+      ["1.0.0-beta.1", "invalid"],
+      [">= 1.0.0-LEAK-CONSTRAINT-PRERELEASE.corp", "invalid"],
+      ["1.2.3-acme.internal", "invalid"],
+      ["1.2.3+build.host", "invalid"],
+      ["latest", "invalid"],
+      [">= 1.2 || < 2.0", "invalid"],
+      ["~> 5.0 # /Users/x", "invalid"],
+      ["1." + "1.".repeat(40), "invalid"],
+    ])("normalizeProviderConstraint(%p) -> %p", (input, expected) => {
+      expect(normalizeProviderConstraint(input)).toBe(expected);
     });
   });
 
@@ -530,6 +1153,8 @@ describe("telemetry", () => {
 
       await expect(
         sendTelemetry("deploy", {
+          language: "typescript",
+          stackMetadata: [{ backend: "s3" }],
           requiredProviders: [{ aws: { source: "aws" } }],
         }),
       ).resolves.toBeUndefined();

--- a/packages/@cdktn/commons/src/telemetry.ts
+++ b/packages/@cdktn/commons/src/telemetry.ts
@@ -6,8 +6,9 @@ import * as fs from "fs-extra";
 import * as semver from "semver";
 import ciInfo from "ci-info";
 import { logger } from "./logging";
-import { DEFAULT_TARGET_VERSIONS, LANGUAGES } from "./config";
+import { DEFAULT_TARGET_VERSIONS, LANGUAGES, isLocalModule } from "./config";
 import { processState } from "./process-state";
+import { isRegistryModule } from "./terraform-module";
 import { terraformCli, TerraformCliProbe } from "./terraform";
 
 type AttributeValue = string | number | boolean;
@@ -82,7 +83,41 @@ const state = processState<CommandTelemetryState>(
 
 // Free-text payload fields are validated before they become attributes so a
 // misconfigured or hand-edited value never carries arbitrary text.
+const CONSTRAINT_PART = /^(=|!=|>=|<=|>|<|~>)?\s*(\d+(?:\.\d+){0,2})$/;
 const RELEASE_VERSION = /^\d+\.\d+\.\d+/;
+
+// Terraform's built-in backend kinds; anything else (a typo, a hand-edited
+// value) is reduced to "other".
+const BACKEND_KINDS = [
+  "local",
+  "remote",
+  "cloud",
+  "s3",
+  "gcs",
+  "azurerm",
+  "http",
+  "consul",
+  "kubernetes",
+  "pg",
+  "oss",
+  "cos",
+  "etcdv3",
+  "artifactory",
+  "swift",
+  "manta",
+];
+
+/** Backend kind for metrics: a built-in kind as-is, anything else "other". */
+export function normalizeBackendKind(backend: unknown): string {
+  if (typeof backend !== "string") {
+    return "unknown";
+  }
+  return BACKEND_KINDS.includes(backend) ? backend : "other";
+}
+
+// Terraform resource type grammar; the stack-level override keys (stack,
+// backend, output, local, terraform_remote_state) are identifiers too.
+const RESOURCE_TYPE = /^[a-z][a-z0-9_]*$/;
 
 // MAJOR.MINOR.PATCH only: prerelease and build identifiers are free text
 // (a wrapper's version line or a locally built library can carry anything).
@@ -96,6 +131,28 @@ function releaseVersion(value: string | undefined): string | undefined {
 function semverRangeOrInvalid(value: string): string {
   const range = value.length <= 64 ? semver.validRange(value) : null;
   return range && !/\d[-+]/.test(value) ? range : "invalid";
+}
+
+/**
+ * Terraform provider constraint: comma-separated operators over versions,
+ * re-joined as "~> 5.0, != 5.1.0" so spacing variants collapse into one
+ * value. Constraints are user-authored free text in cdktf.json, so a
+ * prerelease identifier or an over-long value rejects the whole constraint.
+ */
+export function normalizeProviderConstraint(value: string): string {
+  if (value.length > 64) {
+    return "invalid";
+  }
+  const parts: string[] = [];
+  for (const part of value.split(",")) {
+    const match = CONSTRAINT_PART.exec(part.trim());
+    if (!match) {
+      return "invalid";
+    }
+    const [, operator, version] = match;
+    parts.push(operator ? `${operator} ${version}` : version);
+  }
+  return parts.join(", ");
 }
 
 export function setUsageTelemetryEnabled(enabled: boolean | undefined): void {
@@ -220,6 +277,310 @@ export async function flushTelemetry(timeoutMs = 4000): Promise<void> {
   }
 }
 
+const PUBLIC_PROVIDER_REGISTRIES = [
+  "registry.terraform.io",
+  "registry.opentofu.org",
+];
+const PROVIDER_SEGMENT = /^[a-z0-9][a-z0-9_-]*$/;
+const PROVIDER_HOST = /^(localhost|[a-z0-9-]+(\.[a-z0-9-]+)+)(:\d+)?$/;
+
+// Registry identities are bounded so an over-long hand-written source cannot
+// carry free text through the segment grammar.
+function withinIdentityLimits(segments: string[]): boolean {
+  return (
+    segments.every((segment) => segment.length <= 64) &&
+    segments.join("/").length <= 128
+  );
+}
+
+/**
+ * Provider identity for metrics: only public-registry `namespace/type` is sent
+ * (`aws`, `hashicorp/aws@~>5`, `registry.terraform.io/hashicorp/aws` are one);
+ * other hosts become "private-registry", paths and malformed input "other".
+ */
+export function normalizeProviderSource(source: string): string {
+  const segments = source.trim().toLowerCase().split("@")[0].split("/");
+  if (segments.length === 3) {
+    const host = segments.shift()!;
+    if (!PUBLIC_PROVIDER_REGISTRIES.includes(host)) {
+      return PROVIDER_HOST.test(host) ? "private-registry" : "other";
+    }
+  }
+  if (segments.length === 1) {
+    segments.unshift("hashicorp");
+  }
+  return segments.length === 2 &&
+    segments.every((s) => PROVIDER_SEGMENT.test(s)) &&
+    withinIdentityLimits(segments)
+    ? segments.join("/")
+    : "other";
+}
+
+// Comparison key for generated-vs-prebuilt, never sent: public sources
+// normalize, anything else stays raw so two unrelated private sources (both
+// "private-registry" on the metric) never match each other.
+function providerIdentity(source: string): string {
+  const normalized = normalizeProviderSource(source);
+  return normalized === "private-registry" || normalized === "other"
+    ? source.trim().toLowerCase().split("@")[0]
+    : normalized;
+}
+
+/**
+ * Identities of the providers a project generates bindings for
+ * (`terraformProviders` in `cdktf.json`, as `"aws@~>5.0"` strings or
+ * `{ name, source }` objects); anything else in a stack is prebuilt.
+ */
+export function getGeneratedProviderSources(
+  projectPath = process.cwd(),
+): string[] {
+  const entries = readRawCdktfJson(projectPath).terraformProviders;
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries.flatMap((entry) => {
+    if (typeof entry === "string") {
+      return [providerIdentity(entry)];
+    }
+    const source = entry?.source ?? entry?.name;
+    return typeof source === "string" ? [providerIdentity(source)] : [];
+  });
+}
+
+export function classifyProviderBinding(
+  source: string,
+  generatedSources: string[],
+): "generated" | "prebuilt" {
+  return generatedSources.includes(providerIdentity(source))
+    ? "generated"
+    : "prebuilt";
+}
+
+// Public registry addresses are `namespace/name/provider` with plain segments;
+// a dot, colon or `~` in a segment marks a hostname, bucket or home path that
+// go-getter would resolve instead.
+const REGISTRY_SEGMENT = /^[a-z0-9][a-z0-9_-]*$/;
+
+// Forced getters, URLs and well-known object-store or forge hosts.
+const REMOTE_SOURCE =
+  /^(?:git|hg|s3|gcs)::|^git@|:\/\/|^github\.com\/|^bitbucket\.org\/|amazonaws\.com\/|googleapis\.com\//i;
+
+/**
+ * Module identity for metrics. Only public registry sources are sent as-is;
+ * anything else could carry a path, hostname, bucket or organization and is
+ * reduced to its kind.
+ */
+export function classifyModuleSource(source: string): string {
+  const trimmed = source.trim();
+  if (isLocalModule(trimmed) || path.isAbsolute(trimmed)) {
+    return "local";
+  }
+  if (REMOTE_SOURCE.test(trimmed)) {
+    return "git";
+  }
+  if (!isRegistryModule(trimmed)) {
+    return "other";
+  }
+  const segments = trimmed.toLowerCase().split("/");
+  if (segments.length === 4) {
+    return "private-registry";
+  }
+  return segments.every((segment) => REGISTRY_SEGMENT.test(segment)) &&
+    withinIdentityLimits(segments)
+    ? segments.join("/")
+    : "other";
+}
+
+// The synth origins the CLI passes through; see SynthOrigin in cli-core.
+const SYNTH_ORIGINS = ["watch"];
+
+type ScalarAttribute = {
+  attribute: string;
+  type: "string" | "number" | "boolean";
+  /** Enumerated values; a value outside the set is dropped. */
+  values?: string[];
+};
+
+// Scalar payload fields forwarded as attributes, per command, each with the
+// type (and where enumerable, the values) it must have. Anything not listed
+// here, of the wrong type or off the value set stays out of the metric.
+const SCALAR_ATTRIBUTES: Record<string, Record<string, ScalarAttribute>> = {
+  synth: {
+    synthOrigin: {
+      attribute: "synth_origin",
+      type: "string",
+      values: SYNTH_ORIGINS,
+    },
+  },
+  init: {
+    // reduced to a built-in template name or "remote" by templateTelemetryName
+    template: { attribute: "template", type: "string" },
+    isRemote: { attribute: "is_remote", type: "boolean" },
+  },
+  convert: {
+    numberOfModules: { attribute: "module_count", type: "number" },
+    numberOfProviders: { attribute: "provider_count", type: "number" },
+    convertedLines: { attribute: "converted_lines", type: "number" },
+  },
+};
+
+function scalarAttributeValue(
+  value: unknown,
+  spec: ScalarAttribute,
+): AttributeValue | undefined {
+  if (typeof value !== spec.type) {
+    return undefined;
+  }
+  if (spec.type === "number" && !Number.isFinite(value)) {
+    return undefined;
+  }
+  if (spec.values && !spec.values.includes(value as string)) {
+    return undefined;
+  }
+  return value as AttributeValue;
+}
+
+// Number of entries per key of a metadata group such as
+// `overrides: { aws_s3_bucket: ["tags", "region"] }`.
+function groupSizes(group: unknown): Record<string, number> {
+  const sizes: Record<string, number> = {};
+  if (group && typeof group === "object" && !Array.isArray(group)) {
+    for (const [key, entries] of Object.entries(group)) {
+      sizes[key] = Array.isArray(entries) ? entries.length : 0;
+    }
+  }
+  return sizes;
+}
+
+function sum(sizes: Record<string, number>): number {
+  return Object.values(sizes).reduce((total, size) => total + size, 0);
+}
+
+// Override keys are provider schema names, except module overrides which
+// carry the module source and are reduced to its kind.
+function overrideResourceType(key: string): string {
+  const resourceType = key.startsWith("module.")
+    ? `module.${classifyModuleSource(key.slice("module.".length))}`
+    : key;
+  return resourceType.length <= 64 &&
+    (RESOURCE_TYPE.test(resourceType) || resourceType.startsWith("module."))
+    ? resourceType
+    : "other";
+}
+
+/**
+ * Per-stack metrics for synth/diff/deploy/destroy from the stack metadata
+ * block and `required_providers`: backend and library version, override /
+ * import / moved counts and the providers used, never names or ids.
+ */
+function sendStackTelemetry(
+  stackMetadata: unknown[],
+  requiredProviders: unknown[],
+  attributes: Attributes,
+): void {
+  const generatedSources = getGeneratedProviderSources();
+  stackMetadata.forEach((entry, index) => {
+    // a null or non-object entry is not a stack: counting one would inflate
+    // the stack count with metadata the library never wrote
+    if (!entry || typeof entry !== "object") {
+      return;
+    }
+    const metadata = entry as Record<string, any>;
+    const overrides = groupSizes(metadata.overrides);
+    const stackAttributes: Attributes = {
+      ...attributes,
+      backend: normalizeBackendKind(metadata.backend),
+      cloud: typeof metadata.cloud === "string",
+      override_count: sum(overrides),
+      import_count: sum(groupSizes(metadata.imports)),
+      moved_count: sum(groupSizes(metadata.moved)),
+    };
+    const libraryVersion = releaseVersion(metadata.version);
+    if (libraryVersion) {
+      stackAttributes.library_version = libraryVersion;
+    }
+    Sentry.metrics.count("cli.stack", 1, { attributes: stackAttributes });
+
+    for (const [key, count] of Object.entries(overrides)) {
+      Sentry.metrics.count("cli.stack.override", 1, {
+        attributes: {
+          ...attributes,
+          resource_type: overrideResourceType(key),
+          override_count: count,
+        },
+      });
+    }
+
+    const providers = requiredProviders[index];
+    if (!providers || typeof providers !== "object") {
+      return;
+    }
+    for (const [type, constraint] of Object.entries(
+      providers as Record<string, any>,
+    )) {
+      const source =
+        typeof constraint?.source === "string" ? constraint.source : type;
+      const providerAttributes: Attributes = {
+        ...attributes,
+        provider: normalizeProviderSource(source),
+        binding: classifyProviderBinding(source, generatedSources),
+      };
+      if (typeof constraint?.version === "string") {
+        providerAttributes.version_constraint = normalizeProviderConstraint(
+          constraint.version,
+        );
+      }
+      Sentry.metrics.count("cli.stack.provider", 1, {
+        attributes: providerAttributes,
+      });
+    }
+  });
+}
+
+// Payload entries are validated one by one: a throw here would be swallowed
+// by sendTelemetry's catch and skip the command metric for the whole run.
+function sourceOf(entry: unknown): string | undefined {
+  return typeof entry === "string" ? entry : undefined;
+}
+
+// `get` payload: one entry per generated binding, counted per provider and
+// module; only the totals land on the command metric.
+function sendGetTelemetry(targets: unknown[], attributes: Attributes): void {
+  const byType = (type: string) =>
+    targets.flatMap((target: any) => {
+      const source = sourceOf(target?.source);
+      return target?.type === type && source !== undefined ? [source] : [];
+    });
+  const providers = byType("provider");
+  const modules = byType("module");
+  attributes.provider_count = providers.length;
+  attributes.module_count = modules.length;
+  for (const source of providers) {
+    Sentry.metrics.count("cli.get.provider", 1, {
+      attributes: { ...attributes, provider: normalizeProviderSource(source) },
+    });
+  }
+  for (const source of modules) {
+    Sentry.metrics.count("cli.get.module", 1, {
+      attributes: { ...attributes, module: classifyModuleSource(source) },
+    });
+  }
+}
+
+// `init` payload: the providers the new project was created with.
+function sendInitTelemetry(entries: unknown[], attributes: Attributes): void {
+  const providers = entries.flatMap((entry) => sourceOf(entry) ?? []);
+  attributes.provider_count = providers.length;
+  for (const provider of providers) {
+    Sentry.metrics.count("cli.init.provider", 1, {
+      attributes: {
+        ...attributes,
+        provider: normalizeProviderSource(provider),
+      },
+    });
+  }
+}
+
 // A run counts once as cli.command.invoked at start, then once as either
 // cli.command.completed (with the scalars known only at the end) or
 // cli.command.error; a nested operation (a deploy's synth) adds only its own.
@@ -293,6 +654,14 @@ export async function sendTelemetry(
       command,
       payload.language ?? state.language,
     );
+    for (const [key, spec] of Object.entries(
+      SCALAR_ATTRIBUTES[command] ?? {},
+    )) {
+      const value = scalarAttributeValue(payload[key], spec);
+      if (value !== undefined) {
+        attributes[spec.attribute] = value;
+      }
+    }
 
     if (payload.error) {
       attributes.error_type = COMMAND_ERROR_TYPES.includes(payload.errorType)
@@ -302,7 +671,32 @@ export async function sendTelemetry(
       return;
     }
 
-    if (
+    if (command === "get" && Array.isArray(payload.targets)) {
+      sendGetTelemetry(payload.targets, attributes);
+    }
+    if (command === "init" && Array.isArray(payload.addedProviders)) {
+      sendInitTelemetry(payload.addedProviders, attributes);
+    }
+    if (Array.isArray(payload.stackMetadata)) {
+      sendStackTelemetry(
+        payload.stackMetadata,
+        Array.isArray(payload.requiredProviders)
+          ? payload.requiredProviders
+          : [],
+        attributes,
+      );
+    }
+    // a run with failed stacks is not completed: the failure thrown next is
+    // counted as cli.command.error by the entrypoint's reporter
+    const failedStackCount =
+      typeof payload.failedStackCount === "number"
+        ? payload.failedStackCount
+        : 0;
+    if (failedStackCount > 0) {
+      Sentry.metrics.count("cli.stack.failed", failedStackCount, {
+        attributes,
+      });
+    } else if (
       state.startedCommand === undefined ||
       state.startedCommand === command
     ) {

--- a/packages/cdktn-cli/src/bin/cmds/helper/__tests__/init.test.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/__tests__/init.test.ts
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc
+// SPDX-License-Identifier: MPL-2.0
+import { templateTelemetryName } from "../init";
+
+describe("templateTelemetryName", () => {
+  it.each([
+    ["typescript", "typescript"],
+    ["python", "python"],
+    ["https://example.com/my-secret-template", "remote"],
+    ["my-secret-template", "remote"],
+  ])("maps the template %p to %p", (name, expected) => {
+    expect(templateTelemetryName(name)).toBe(expected);
+  });
+});

--- a/packages/cdktn-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/init.ts
@@ -53,6 +53,14 @@ const chalkColour = new chalk.Instance();
 
 const isReadme = (file: string) => file.toLowerCase() === "readme.md";
 
+/**
+ * Template attribute for the init metric: a built-in template by name, any
+ * other (its name is derived from the user-supplied URL) as "remote".
+ */
+export function templateTelemetryName(name: string): string {
+  return templates.includes(name) ? name : "remote";
+}
+
 export function checkForEmptyDirectory(dir: string) {
   if (
     fs
@@ -127,7 +135,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
     template,
     argv.nonInteractive ?? false,
   );
-  telemetryData.template = templateInfo.Name;
+  telemetryData.template = templateTelemetryName(templateInfo.Name);
 
   if (!argv.projectName && argv.nonInteractive) {
     throw Errors.Usage(

--- a/packages/cdktn-cli/src/bin/cmds/ui/__tests__/get.test.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/__tests__/get.test.ts
@@ -48,14 +48,27 @@ describe("runGet telemetry", () => {
     Errors.setScope("unknown");
   });
 
-  it("sends one get metric on success", async () => {
-    mockGet.mockResolvedValue(undefined);
+  it("collects every generated target into one get metric", async () => {
+    mockGet.mockImplementation(async ({ reportTelemetry }) => {
+      await reportTelemetry({
+        targetLanguage: "typescript",
+        trackingPayload: { type: "provider", source: "aws", version: "5.0.0" },
+      });
+      await reportTelemetry({
+        targetLanguage: "typescript",
+        trackingPayload: { type: "module", source: "./modules/vpc" },
+      });
+    });
 
     await runGet(config);
 
     expect(mockSendTelemetry).toHaveBeenCalledTimes(1);
     expect(mockSendTelemetry).toHaveBeenCalledWith("get", {
       language: "typescript",
+      targets: [
+        { type: "provider", source: "aws" },
+        { type: "module", source: "./modules/vpc" },
+      ],
     });
   });
 

--- a/packages/cdktn-cli/src/bin/cmds/ui/get.ts
+++ b/packages/cdktn-cli/src/bin/cmds/ui/get.ts
@@ -58,6 +58,9 @@ export async function runGet({
   stream?.start();
   stream?.setBar(`${GetStatus.STARTING}...`, { spinner: true });
 
+  // the generator reports one target at a time; collected into a single
+  // command metric with per-binding counts
+  const generatedTargets: { type: string; source: string }[] = [];
   try {
     await get({
       constraints,
@@ -67,8 +70,14 @@ export async function runGet({
         stream?.setBar(`${status}...`, { spinner: true });
       },
       providerSchemaCachePath,
+      reportTelemetry: async ({ trackingPayload }) => {
+        generatedTargets.push({
+          type: trackingPayload.type,
+          source: trackingPayload.source,
+        });
+      },
     });
-    await sendTelemetry("get", { language });
+    await sendTelemetry("get", { language, targets: generatedTargets });
   } catch (e: any) {
     // not counted here: the entrypoint's failure reporter counts the run
     // once, under the command's scope


### PR DESCRIPTION
Part 5 of 6 in a stack; review order S1 → S6; base is the previous slice.

1. `chore(deps): upgrade @sentry/node to 10.x with unchanged reporting behaviour`
2. `fix(cli): stop the top-level error handler racing yargs`
3. `feat(cli): replace HashiCorp checkpoint telemetry with Sentry usage metrics and consent`
4. `feat(cli): report the installed binary, target versions and platform in usage metrics`
5. `feat(cli): report per-stack, per-provider and per-command usage metrics` (this PR)
6. `chore(gha): run the telemetry delivery e2e on every build`

### Related issue

Part of #48

### Description

The old checkpoint transport posted a per-stack payload (backends, required providers, overrides) to HashiCorp. S3 removed the transport and, with it, that signal: `SynthStack` was handing a payload to `sendTelemetry` that was then thrown away. This slice brings the signal back, reduced at emission into counted metrics with enumerated and validated values, so nothing carries a name, an address or free text.

What changes:

- `packages/@cdktn/commons/src/telemetry.ts`: `sendStackTelemetry` emitting `cli.stack`, `cli.stack.override`, `cli.stack.provider` and `cli.stack.failed`; `sendGetTelemetry` and `sendInitTelemetry`; a typed `SCALAR_ATTRIBUTES` allow-list per command, so nothing outside it is ever forwarded; and the validators the reduction runs on: `normalizeProviderSource`, `classifyModuleSource`, `classifyProviderBinding`, `normalizeBackendKind`, `normalizeProviderConstraint`, the bounded resource-type grammar and the identity caps.
- Emission sites: `packages/@cdktn/cli-core/src/lib/synth-stack.ts` (the telemetry payload and the stack reduction), `packages/@cdktn/cli-core/src/lib/cdktf-project.ts` (`finishStackRun`), `packages/@cdktn/commons/src/construct-maker-target.ts`, `packages/cdktn-cli/src/bin/cmds/helper/init.ts` (`templateTelemetryName` and the `template` / `is_remote` / `addedProviders` mapping), `packages/cdktn-cli/src/bin/cmds/ui/get.ts` (target collection) and `packages/cdktn-cli/src/bin/cmds/handlers.ts` (the convert stats mapping).

#### Where the command metrics land

The emission rule is fixed in S3 and this slice follows it: `cli.command.invoked` once per run at command start, `cli.command.completed` once at the end of a successful run, `cli.command.error` once per failed run, so `error / invoked` is a true failure rate. Two consequences show up in this slice:

- **`finishStackRun` on a failed run.** The per-stack metrics still go out before the throw, so a deploy that fails partway still reports the stacks it did reach and the `cli.stack.failed` count. What no longer goes out there is the command metric: the run was already counted as invoked at start, and the failure is counted once by the entrypoint as `cli.command.error`.
- **The end-of-run scalars ride on `cli.command.completed`**, not on `invoked`, because they are only known once the command has finished.

**Start with** `sendStackTelemetry` and the normalizers directly above it in `packages/@cdktn/commons/src/telemetry.ts`, because that is where every string is either reduced to an enumerated value or dropped. Then read the reduction in `packages/@cdktn/cli-core/src/lib/synth-stack.ts` to see what the payload looks like before it gets there.

The whole point of the design is that the reduction happens at emission, not at collection. A malformed `required_providers` entry, a non-object stack, an over-long hand-written source: each is tolerated and reduced to `other` rather than passed through or thrown on. Four privacy leaks found by deliberately trying to make the CLI leak were fixed this way, and the tests that found them ship with this slice as `LEAK-*` marker assertions on the raw envelope bytes.

Reading order for this slice:

1. `packages/@cdktn/commons/src/telemetry.ts`: the normalizers and validators, then `sendStackTelemetry`, then `SCALAR_ATTRIBUTES`
2. `packages/@cdktn/cli-core/src/lib/synth-stack.ts` and `cdktf-project.ts`
3. `packages/cdktn-cli/src/bin/cmds/helper/init.ts`, `ui/get.ts`, `handlers.ts`
4. `packages/@cdktn/commons/src/telemetry.test.ts` (the privacy invariant and the normalization tables), then `cdktf-project-telemetry.test.ts`, `synth-stack.test.ts`, `construct-maker-target.test.ts`

#### Known gap

**HCL-output projects yield no `cli.stack.provider`.** For those the CLI reads only the separate metadata file, so `required_providers` is never in hand, and no provider metric can be emitted. The stack and override metrics are unaffected. Recorded as a follow-up rather than worked around, because the fix belongs in the synth output path, not in telemetry.

### What is collected

Added on top of the S3 and S4 sets. Everything still carries the base attributes (`command`, `ci`, `language`, `os`, `arch`, `binary`, `binary_version`, `target_terraform`, `target_opentofu`, `targets_declared`, `validate_installed_binary`) and is still gated by `isUsageTelemetryEnabled()` and a Sentry DSN in the build.

| Metric | Value | Additional attributes |
|---|---|---|
| `cli.stack` | 1 per synthesized stack | `backend` (an enumerated Terraform backend kind, else `other`, `unknown` when absent), `cloud` (boolean), `library_version` (release only), `override_count`, `import_count`, `moved_count` |
| `cli.stack.override` | 1 per overridden resource type | `resource_type` (Terraform type grammar, the stack-level keys, or `module.<kind>`; else `other`; 64-char cap), `override_count` |
| `cli.stack.provider` | 1 per required provider | `provider` (public-registry `namespace/type` only; other hosts `private-registry`; malformed `other`), `version_constraint` (canonical, else `invalid`), `binding` (`generated` or `prebuilt`) |
| `cli.stack.failed` | count of stacks that did not complete | none |
| `cli.get.provider` / `cli.get.module` | 1 per generated binding | normalized `provider` / `module` identity as above |
| `cli.init.provider` | 1 per provider passed to init | normalized `provider` |

Per-command scalars added to `cli.command.completed`, allow-listed by command and nothing else forwarded: `synth_origin` for synth; `template` (a built-in template name, anything else the literal `remote`), `is_remote` and `provider_count` for init; `module_count`, `provider_count` and `converted_lines` for convert; `provider_count` and `module_count` for get. The `event` scalar the `watch` start event used to carry is dropped: `cli.command.invoked` is emitted at command start and already records exactly that.

A `required_providers` entry with no string `source` (`{ aws: { version: "~> 5.0" } }`) is reported under its local name expanded to the default namespace, `hashicorp/<local name>`, the same value Terraform itself resolves it to. Public-registry identities are additionally bounded (each segment at most 64 characters, at most 128 in total), so an over-long hand-written source becomes `other` instead of carrying free text.

#### What is never sent

Extending the S3 list. Stack names; resource ids and addresses (imports and moves are counts only); file paths and the working directory; the machine hostname or username; private-registry hosts and organizations; module URLs and paths (reduced to `local`, `git`, `private-registry` or `other`); remote template URLs (reduced to `remote`); error messages and error context; any user code; the values of `SENTRY_*` environment variables. Unit tests assert these against the raw envelope bytes using deliberate `LEAK-*` markers.

### Test plan

- [x] Unit tests green across `@cdktn/commons`, `@cdktn/cli-core` and `cdktn-cli` on this slice against S4
- [x] Delivery oracle extended: the per-stack items appear with the documented attributes and nothing else
- [x] Privacy refutation: hostname, username, cwd, temp project directory and `SENTRY_ENVIRONMENT` / `SENTRY_TRACE` / `SENTRY_BAGGAGE` exported as `LEAK-*` markers, asserted absent from the raw envelope bytes
- [x] Normalization tables: provider sources (public registry, other host, path, malformed), module sources (local, git, private registry, public registry, other), backend kinds, constraint canonicalization, the resource-type grammar and the 64-char cap, identity segment and total caps
- [x] Malformed entries tolerated: a `required_providers` entry with no string `source`, a non-object stack skipped rather than thrown on
- [x] Typed per-command scalars: only allow-listed keys are forwarded, per command, and they ride on `cli.command.completed`
- [x] A failed deploy yields the per-stack metrics and `cli.stack.failed` before the throw, then exactly one `cli.command.error` and no `cli.command.completed`, against the one `cli.command.invoked` emitted at start
- [x] `cli.stack.failed` counts stacks that did not complete, with no names and no messages
- [x] Lint and `pnpm prettier --check .` clean

### Review threads from #62 answered here

- ["dropped stack payload loses useful information"](https://github.com/open-constructs/cdk-terrain/pull/62#discussion_r3408182518): agreed, and it is restored. One `cli.stack` per stack with the backend kind, the cloud flag, the library version and the override/import/moved counts; one `cli.stack.override` per overridden resource type; one `cli.stack.provider` per required provider with its constraint and whether the binding is generated or prebuilt; plus `cli.stack.failed`. Provider identities are reduced to public-registry `namespace/type`, so private hosts and organizations become `private-registry` and nothing carries a name or an address. The target-versions half of the thread is answered in S4.

### Follow-ups (documented, not in this PR)

1. **`cli.stack.resource`**, an allow-listed per-resource-type count, is the one metric that would help the asset-pipeline decision (#380). Deferred deliberately.
2. **HCL-output projects yield no `cli.stack.provider`**, as described above. Known gap.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable (follow-up in cdk-terrain-docs)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
