### PR TITLE
chore(gha): gate dependency upgrades on release age

### DIFF
--- a/.github/workflows/pnpm-upgrade.yml
+++ b/.github/workflows/pnpm-upgrade.yml
@@ -51,10 +51,10 @@ jobs:
       - name: Run "ncu -u"
         run: |-
           # Upgrade dependencies at repository root
-          ncu --upgrade --filter=@types/node,@types/fs-extra --target=minor --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
-          ncu --upgrade --filter=typescript --target=patch --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+          ncu --upgrade --filter=@types/node,@types/fs-extra --target=minor --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
+          ncu --upgrade --filter=typescript --target=patch --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
           ncu --upgrade --reject=@types/node,@types/fs-extra,constructs,typescript,@types/prettier --target=minor \
-            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
 
       # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
       # strictDepBuilds is relaxed so an unapproved dep build does not kill the PR (see #399)
@@ -209,16 +209,16 @@ jobs:
 
           ncu --upgrade "${workspace_args[@]}" --no-root \
             --filter=@types/node,@types/fs-extra --target=minor \
-            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
 
           ncu --upgrade "${workspace_args[@]}" --no-root \
             --filter=typescript --target=patch \
-            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
 
           ncu --upgrade "${workspace_args[@]}" --no-root \
             --reject='@types/node,@types/fs-extra,constructs,typescript,graphology-types,jsii,jsii-pacmak,jsii-rosetta,jsii-docgen,codemaker,${{ steps.list-packages.outputs.list }}' \
             --target=minor \
-            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
 
       # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
       # strictDepBuilds is relaxed so an unapproved dep build does not kill the PR (see #399)
@@ -301,7 +301,7 @@ jobs:
           ncu --upgrade --workspaces --root \
             --filter='jsii,jsii-pacmak,jsii-rosetta,jsii-docgen,codemaker,constructs' \
             --target=minor \
-            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated
+            --packageManager pnpm --dep prod,dev,optional,peer --no-deprecated --cooldown 25h
       # Refresh the lockfile after the ncu edits above (necessary for "pnpm update" to run)
       # strictDepBuilds is relaxed so an unapproved dep build does not kill the PR (see #399)
       - name: Run "pnpm install"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,5 +11,9 @@ allowBuilds:
   nx: true
   unrs-resolver: true
 
+# Keep ncu's --cooldown in .github/workflows/pnpm-upgrade.yml above this window.
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+
 overrides:
   '@types/react': 18.3.28


### PR DESCRIPTION
> Draft for review — not urgent, and the two numbers below (25h / 24h) are the main thing worth a second opinion.

## Problem

pnpm applies a **24h `minimumReleaseAge`** by default. Without `minimumReleaseAgeStrict` it doesn't block — it records the exception in `minimumReleaseAgeExclude` and installs the fresh version anyway.

The weekly upgrade run hit this with `knip@6.35.1`, published ~6h earlier. pnpm waived its own delay and wrote the bypass into `pnpm-workspace.yaml`, where it would have merged unnoticed had it not been spotted in review on #326. The delay exists precisely so a compromised publish has time to be caught; auto-waiving it defeats the mechanism.

## Change

Two halves that only work together:

| | |
|---|---|
| `ncu --cooldown 25h` (all 7 invocations) | never *proposes* a version inside pnpm's window; falls back to the newest version that clears it |
| `minimumReleaseAge: 1440` + `minimumReleaseAgeStrict: true` | pnpm now *enforces* rather than waives — a backstop that should never fire |

**Enabling strict alone would break the upgrade job** the way `strictDepBuilds` did in #399: the bot would die instead of producing a PR. The cooldown is what makes strict safe to turn on.

The window is pinned rather than inherited so the one-hour buffer stays meaningful if pnpm changes its default. Note that explicitly setting `minimumReleaseAge` auto-enables strict on its own; both are set explicitly so the intent is readable.

**Why 25h and not 24h:** just enough margin that a version sitting exactly on the boundary at `ncu` time is still clear when pnpm re-verifies minutes later, without adding a full day of lag.

## Verification

```
# ncu holds back the fresh version and says so
knip  ^6.16.1  →  ^6.35.1                      # without cooldown
knip  ^6.16.1  →  ^6.35.0  [cooldown] 6.35.1   # with --cooldown 25h
```

- A planted `knip@6.35.1` fails `pnpm ci` with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`, confirming the gate is live from `pnpm-workspace.yaml` and not a silent no-op.
- **main's current lockfile passes the strict check unchanged** — this doesn't turn CI red on merge.
- `prettier --check` clean; both YAML files parse with all 7 cooldown flags in place.

## Trade-off

Upgrades lag up to ~25h. A version published the morning of the Monday run gets picked up the following week instead. That is the intended cost.

## Not included

Pruning the existing `minimumReleaseAgeExclude` entry — that was already handled on #326 by rolling knip back to main's 6.16.1 and removing the bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
