### PR TITLE
feat(cli): add typescript-pnpm and typescript-yarn init templates

### DIFF
--- a/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
+++ b/packages/@cdktn/cli-core/src/lib/dependencies/package-manager.ts
@@ -194,6 +194,32 @@ const pipPackageSchema = z.array(
   z.object({ name: z.string(), version: z.string() }).loose(),
 );
 
+// [
+//   {
+//     "name": "my-project",
+//     "dependencies": {
+//       "@cdktn/provider-random": { "from": "@cdktn/provider-random", "version": "3.0.11" }
+//     }
+//   }
+// ]
+const pnpmListSchema = z.array(
+  z
+    .object({
+      dependencies: z.record(
+        z.string(),
+        z.object({ version: z.string() }).loose(),
+      ),
+      devDependencies: z.record(
+        z.string(),
+        z.object({ version: z.string() }).loose(),
+      ),
+    })
+    .partial()
+    .loose(),
+);
+
+type NodePm = "npm" | "pnpm" | "yarn";
+
 /**
  * manages installing, updating, and removing dependencies
  * in the package system used by the target language of a CDKTN
@@ -243,8 +269,42 @@ export abstract class PackageManager {
 }
 
 class NodePackageManager extends PackageManager {
-  private hasYarnLockfile(): boolean {
-    return existsSync(path.join(this.workingDirectory, "yarn.lock"));
+  private detectedPackageManager?: NodePm;
+
+  /**
+   * The package manager this project uses. An explicit `packageManager` field (corepack) wins over lockfile
+   * probing, since it is a deliberate declaration; the result is cached because `provider add` resolves it per
+   * provider.
+   *
+   * @internal
+   */
+  public get packageManager(): NodePm {
+    if (this.detectedPackageManager) {
+      return this.detectedPackageManager;
+    }
+
+    try {
+      const pkg = fs.readJsonSync(
+        path.join(this.workingDirectory, "package.json"),
+      );
+      const declared = String(pkg?.packageManager ?? "").split("@")[0];
+      if (declared === "pnpm" || declared === "yarn" || declared === "npm") {
+        this.detectedPackageManager = declared;
+        return declared;
+      }
+    } catch {
+      // no or unreadable package.json - fall through to lockfile probing
+    }
+
+    if (existsSync(path.join(this.workingDirectory, "pnpm-lock.yaml"))) {
+      this.detectedPackageManager = "pnpm";
+    } else if (existsSync(path.join(this.workingDirectory, "yarn.lock"))) {
+      this.detectedPackageManager = "yarn";
+    } else {
+      this.detectedPackageManager = "npm";
+    }
+
+    return this.detectedPackageManager;
   }
 
   public async addPackage(
@@ -254,21 +314,21 @@ class NodePackageManager extends PackageManager {
   ): Promise<void> {
     console.log(`Adding package ${packageName} @ ${packageVersion}`);
 
-    // probe for package-lock.json or yarn.lock
-    let command = "npm";
-    let args = ["install"];
+    const command = this.packageManager;
+    const args = [command === "npm" ? "install" : "add"];
 
-    if (this.hasYarnLockfile()) {
-      command = "yarn";
-      args = ["add"];
-    }
     args.push(
       packageVersion ? packageName + "@" + packageVersion : packageName,
     );
 
+    // Quiet flags differ per manager: pnpm has no --no-progress, and Yarn Berry errors on unknown options - it has
+    // neither --silent nor --no-progress (Yarn 1 accepted both).
     if (silent) {
-      args.push("--silent");
-      args.push("--no-progress");
+      if (command === "npm") {
+        args.push("--silent", "--no-progress");
+      } else if (command === "pnpm") {
+        args.push("--silent");
+      }
     }
 
     // Install exact version
@@ -347,12 +407,48 @@ class NodePackageManager extends PackageManager {
     }
   }
 
+  private async listPnpmPackages(): Promise<
+    { name: string; version: string }[]
+  > {
+    try {
+      // --depth 0 keeps the output to direct dependencies, which is where providers always live, and matches the
+      // top-level-only semantics of the npm listing.
+      const stdout = await exec("pnpm", ["list", "--json", "--depth", "0"], {
+        cwd: this.workingDirectory,
+      });
+
+      logger.debug(`Listing pnpm packages using "pnpm list --json": ${stdout}`);
+      const json = pnpmListSchema.parse(JSON.parse(stdout));
+
+      return json
+        .flatMap((project) => [
+          ...Object.entries(project.dependencies || {}),
+          ...Object.entries(project.devDependencies || {}),
+        ])
+        .filter(
+          ([depName]) =>
+            depName.startsWith("@cdktf/provider-") ||
+            depName.startsWith("@cdktn/provider-"),
+        )
+        .map(([name, dep]) => ({ name, version: dep.version }));
+    } catch (e: any) {
+      throw new Error(
+        `Could not determine installed packages using 'pnpm list --json': ${e}`,
+      );
+    }
+  }
+
   public async listProviderPackages(): Promise<
     { name: string; version: string }[]
   > {
-    return this.hasYarnLockfile()
-      ? this.listYarnPackages()
-      : this.listNpmPackages();
+    switch (this.packageManager) {
+      case "pnpm":
+        return this.listPnpmPackages();
+      case "yarn":
+        return this.listYarnPackages();
+      default:
+        return this.listNpmPackages();
+    }
   }
 }
 

--- a/packages/@cdktn/cli-core/src/lib/init.ts
+++ b/packages/@cdktn/cli-core/src/lib/init.ts
@@ -48,6 +48,13 @@ export type InitArgs = {
 
 export const templatesDir = path.join(__dirname, "..", "..", "templates");
 
+// Templates that only carry the files differing from another template. They are scaffolded by running the base
+// template first and then overlaying their own files on top, so the shared files live in exactly one place.
+const TEMPLATE_OVERLAY_BASE: Record<string, string> = {
+  "typescript-pnpm": "typescript",
+  "typescript-yarn": "typescript",
+};
+
 const availableTemplates = fs
   .readdirSync(templatesDir)
   .filter((x) => !x.startsWith("."));
@@ -68,24 +75,34 @@ export async function init({
   providersForceLocal,
   silent,
 }: InitArgs) {
-  const deps: any = await determineDeps(
-    cdktfVersion,
-    dist,
-    path.basename(templatePath),
-  );
+  const templateName = path.basename(templatePath);
+  const overlayBase = TEMPLATE_OVERLAY_BASE[templateName];
+
+  const deps: any = await determineDeps(cdktfVersion, dist, templateName);
 
   const futureFlags = Object.entries(FUTURE_FLAGS)
     .map(([key, value]) => `    "${key}": "${value}"`)
     .join(`,\n`);
 
-  await sscaff(templatePath, destination, {
+  const variables = {
     ...deps,
     ...projectInfo,
     futureFlags,
     projectId,
     sendCrashReports,
     silent,
-  });
+  };
+
+  if (overlayBase) {
+    // `isOverlayBase` tells the base template's hook to lay down files only: the overlay replaces package.json, so
+    // installing here would use the wrong package manager and leave a stray lockfile behind.
+    await sscaff(path.join(templatesDir, overlayBase), destination, {
+      ...variables,
+      isOverlayBase: "true",
+    });
+  }
+
+  await sscaff(templatePath, destination, variables);
   const cdktfConfig = CdktfConfig.read(destination);
 
   let needsGet = false;
@@ -94,6 +111,7 @@ export async function init({
       providers: providers,
       language: cdktfConfig.language,
       projectDirectory: destination,
+      cdktfVersion,
       forceLocal: providersForceLocal,
       dist,
     });
@@ -157,10 +175,13 @@ export async function determineDeps(
 
     // If we know the template, only validate its artifact; otherwise fall
     // back to validating everything (preserves prior behavior for unknown /
-    // remote templates).
+    // remote templates). Overlay templates share their base's artifact.
+    const distTemplate = template
+      ? (TEMPLATE_OVERLAY_BASE[template] ?? template)
+      : template;
     const keysToValidate: DistKey[] =
-      template && distKeysByTemplate[template]
-        ? distKeysByTemplate[template]
+      distTemplate && distKeysByTemplate[distTemplate]
+        ? distKeysByTemplate[distTemplate]
         : (Object.keys(ret) as DistKey[]);
 
     for (const key of keysToValidate) {

--- a/packages/@cdktn/cli-core/src/test/lib/dependencies/package-manager.test.ts
+++ b/packages/@cdktn/cli-core/src/test/lib/dependencies/package-manager.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { mkdtempSync } from "fs";
+import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -31,6 +31,40 @@ describe("package-manager", () => {
   afterEach(() => {
     mockAgent.assertNoPendingInterceptors();
     setGlobalDispatcher(originalDispatcher);
+  });
+
+  describe("NodePackageManager detection", () => {
+    function nodeManagerIn(files: Record<string, string>) {
+      const dir = mkdtempSync(join(tmpdir(), "cdktn-pm-test-"));
+      for (const [name, contents] of Object.entries(files)) {
+        writeFileSync(join(dir, name), contents);
+      }
+      return PackageManager.forLanguage(Language.TYPESCRIPT, dir) as any;
+    }
+
+    it("prefers an explicit packageManager field over a conflicting lockfile", () => {
+      // The field is a deliberate declaration; a stale lockfile from another tool must not override it.
+      const manager = nodeManagerIn({
+        "package.json": JSON.stringify({ packageManager: "pnpm@11.5.2" }),
+        "yarn.lock": "",
+      });
+
+      expect(manager.packageManager).toBe("pnpm");
+    });
+
+    it("detects pnpm from its lockfile", () => {
+      expect(nodeManagerIn({ "pnpm-lock.yaml": "" }).packageManager).toBe(
+        "pnpm",
+      );
+    });
+
+    it("detects yarn from its lockfile", () => {
+      expect(nodeManagerIn({ "yarn.lock": "" }).packageManager).toBe("yarn");
+    });
+
+    it("falls back to npm when there is nothing to go on", () => {
+      expect(nodeManagerIn({}).packageManager).toBe("npm");
+    });
   });
 
   describe("JavaPackageManager.isNpmVersionAvailable", () => {

--- a/packages/@cdktn/cli-core/src/test/templates.test.ts
+++ b/packages/@cdktn/cli-core/src/test/templates.test.ts
@@ -1,25 +1,57 @@
 // Copyright (c) HashiCorp, Inc
 // SPDX-License-Identifier: MPL-2.0
-import { readFileSync } from "fs-extra";
+import { readFileSync, readdirSync } from "fs-extra";
 import * as path from "path";
 import { CODE_MARKER } from "@cdktn/hcl2cdk";
+
+const templatesDir = path.resolve(__dirname, "..", "..", "templates");
 
 describe("Templates", () => {
   describe("Typescript", () => {
     it("main.ts should contain the '// define resources here' mark", () => {
       expect(
-        readFileSync(
-          path.resolve(
-            __dirname,
-            "..",
-            "..",
-            "templates",
-            "typescript",
-            "main.ts",
-          ),
-          "utf8",
-        ),
+        readFileSync(path.join(templatesDir, "typescript", "main.ts"), "utf8"),
       ).toContain(CODE_MARKER);
     });
+  });
+
+  // The package-manager variants overlay the `typescript` template, so they must carry only the files that
+  // actually differ - anything else silently shadows the base and has to be kept in sync by hand.
+  describe.each([
+    ["typescript-pnpm", "pnpm", [".hooks.sscaff.js", "help", "package.json"]],
+    [
+      "typescript-yarn",
+      "yarn",
+      // Yarn also needs the node-modules linker (it defaults to Plug'n'Play) and ignores of its own state files.
+      [
+        ".hooks.sscaff.js",
+        ".yarnrc.yml",
+        "help",
+        "package.json",
+        "{{}}.gitignore",
+      ],
+    ],
+  ])("%s", (template, packageManager, expectedFiles) => {
+    it("only overlays the files that differ from the base template", () => {
+      expect(readdirSync(path.join(templatesDir, template)).sort()).toEqual(
+        expectedFiles,
+      );
+    });
+
+    it.each(["help", "package.json"])(
+      "%s drives the project with its own package manager",
+      (file) => {
+        const contents = readFileSync(
+          path.join(templatesDir, template, file),
+          "utf8",
+        );
+
+        expect(contents).toContain(packageManager);
+        // The npmjs.com search URL is a registry link rather than a command, so it legitimately survives.
+        expect(
+          contents.replace(/https:\/\/www\.npmjs\.com\S*/g, ""),
+        ).not.toMatch(/\bnpm (run|install|i) /);
+      },
+    );
   });
 });

--- a/packages/@cdktn/cli-core/templates/typescript-pnpm/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript-pnpm/.hooks.sscaff.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+const { execSync } = require("child_process");
+const { readFileSync, writeFileSync } = require("fs");
+
+// The `typescript` template is scaffolded first and supplies every shared file, including the Terraform Cloud
+// rewrite of main.ts. This hook only installs dependencies with pnpm and prints the help text.
+const packageManager = "pnpm";
+
+exports.pre = () => {
+  const probe = process.platform === "win32" ? "where" : "which";
+  try {
+    execSync(`${probe} ${packageManager}`, { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      `Could not find "${packageManager}" on your PATH. Install it (e.g. "corepack enable ${packageManager}") and run cdktn init again.`
+    );
+  }
+};
+
+exports.post = (ctx) => {
+  const silent = ctx.silent === "true" || ctx.silent === true;
+
+  const npm_cdktf = ctx.npm_cdktf;
+  if (!npm_cdktf) {
+    throw new Error(`missing context "npm_cdktf"`);
+  }
+
+  // `constructs@10` resolves to the newest 10.x, which satisfies the `^10.6.0`
+  // peer range cdktn declares; that peer range is the real constraint, so
+  // only the major here has to follow cdktn's.
+  installDeps([npm_cdktf, `constructs@10`], false, silent);
+  // Capped below 7.x: that is the native port, which jsii does not support yet.
+  installDeps(
+    [
+      "@types/node",
+      "typescript@>=5.0.0 <7.0.0",
+      "jest",
+      "@types/jest",
+      "ts-jest",
+      "tsx",
+    ],
+    true,
+    silent
+  );
+
+  pinPackageManager();
+
+  if (!silent) {
+    console.log(readFileSync("./help", "utf-8"));
+  }
+};
+
+/**
+ * Record the package manager that just installed the dependencies, so corepack reproduces it for everyone working
+ * on the project. The version is read at scaffold time rather than baked into the template, which would go stale
+ * with every release.
+ */
+function pinPackageManager() {
+  let version;
+  try {
+    version = execSync(`${packageManager} --version`, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return;
+  }
+
+  // Anything but a plain version (a corepack passthrough message, say) is not safe to pin.
+  if (!/^\d+\.\d+\.\d+/.test(version)) {
+    return;
+  }
+
+  const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+  pkg.packageManager = `${packageManager}@${version}`;
+  writeFileSync("./package.json", `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
+}
+
+function installDeps(deps, isDev, silent) {
+  const devDep = isDev ? "-D" : "";
+  // make sure we're installing dev dependencies as well
+  const env = Object.assign({}, process.env);
+  env["NODE_ENV"] = "development";
+
+  // Each spec is double-quoted so ranges containing spaces or shell
+  // metacharacters survive the shell. Double quotes (rather than single) work
+  // on both POSIX shells and cmd.exe, where an unquoted `^` is the escape
+  // character and would silently turn `cdktn@^1.2.3` into `cdktn@1.2.3`.
+  const specs = deps.map((dep) => `"${dep}"`).join(" ");
+
+  execSync(`${packageManager} add ${devDep} ${specs}`, {
+    stdio: silent ? "ignore" : "inherit",
+    env,
+  });
+}

--- a/packages/@cdktn/cli-core/templates/typescript-pnpm/help
+++ b/packages/@cdktn/cli-core/templates/typescript-pnpm/help
@@ -1,0 +1,51 @@
+========================================================================================================
+
+  Your CDKTN TypeScript project is ready!
+
+  cat help                Print this message
+
+  Compile:
+    pnpm run get           Import/update Terraform providers and modules (you should check-in this directory)
+    pnpm run compile       Compile typescript code to javascript (or "pnpm run watch")
+    pnpm run watch         Watch for changes and compile typescript in the background
+    pnpm run build         Compile typescript
+
+  Synthesize:
+    cdktn synth [stack]   Synthesize Terraform resources from stacks to cdktf.out/ (ready for 'terraform apply')
+
+  Diff:
+    cdktn diff [stack]    Perform a diff (terraform plan) for the given stack
+
+  Deploy:
+    cdktn deploy [stack]  Deploy the given stack
+
+  Destroy:
+    cdktn destroy [stack] Destroy the stack
+
+  Test:
+    pnpm run test        Runs unit tests (edit __tests__/main-test.ts to add your own tests)
+    pnpm run test:watch  Watches the tests and reruns them on change
+
+  Upgrades:
+    pnpm run upgrade        Upgrade cdktn modules to latest version
+    pnpm run upgrade:next   Upgrade cdktn modules to latest "@next" version (last commit)
+
+ Use Providers:
+
+  You can add prebuilt providers (if available) or locally generated ones using the add command:
+  
+  cdktn provider add "aws@~>3.0" null kreuzwerker/docker
+
+  You can find all prebuilt providers on npm: https://www.npmjs.com/search?q=keywords:cdktn
+  You can also install these providers directly through pnpm:
+
+  pnpm add @cdktn/provider-aws
+  pnpm add @cdktn/provider-google
+  pnpm add @cdktn/provider-azurerm
+  pnpm add @cdktn/provider-docker
+  pnpm add @cdktn/provider-github
+  pnpm add @cdktn/provider-null
+
+  You can also build any module or provider locally. Learn more https://cdktn.io/docs/concepts/providers
+
+========================================================================================================

--- a/packages/@cdktn/cli-core/templates/typescript-pnpm/package.json
+++ b/packages/@cdktn/cli-core/templates/typescript-pnpm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "{{ $base }}",
+  "version": "1.0.0",
+  "main": "main.js",
+  "types": "main.ts",
+  "license": "MPL-2.0",
+  "private": true,
+  "scripts": {
+    "get": "cdktn get",
+    "build": "tsc",
+    "synth": "cdktn synth",
+    "compile": "tsc --pretty",
+    "watch": "tsc -w",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "upgrade": "pnpm add cdktn@latest cdktn-cli@latest",
+    "upgrade:next": "pnpm add cdktn@next cdktn-cli@next"
+  },
+  "engines": {
+    "node": ">=22.0"
+  }
+}

--- a/packages/@cdktn/cli-core/templates/typescript-yarn/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript-yarn/.hooks.sscaff.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+const { execSync } = require("child_process");
+const { readFileSync, writeFileSync } = require("fs");
+
+// The `typescript` template is scaffolded first and supplies every shared file, including the Terraform Cloud
+// rewrite of main.ts. This hook only installs dependencies with yarn and prints the help text.
+const packageManager = "yarn";
+
+exports.pre = () => {
+  const probe = process.platform === "win32" ? "where" : "which";
+  try {
+    execSync(`${probe} ${packageManager}`, { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      `Could not find "${packageManager}" on your PATH. Install it (e.g. "corepack enable ${packageManager}") and run cdktn init again.`
+    );
+  }
+};
+
+exports.post = (ctx) => {
+  const silent = ctx.silent === "true" || ctx.silent === true;
+
+  const npm_cdktf = ctx.npm_cdktf;
+  if (!npm_cdktf) {
+    throw new Error(`missing context "npm_cdktf"`);
+  }
+
+  // Pin before installing: a bare `yarn` behind a corepack shim resolves to the EOL 1.22 default until the project
+  // declares a version, so the pin is what selects a modern Yarn for the install below.
+  pinPackageManager(silent);
+
+  // `constructs@10` resolves to the newest 10.x, which satisfies the `^10.6.0`
+  // peer range cdktn declares; that peer range is the real constraint, so
+  // only the major here has to follow cdktn's.
+  installDeps([npm_cdktf, `constructs@10`], false, silent);
+  // Capped below 7.x: that is the native port, which jsii does not support yet.
+  installDeps(
+    [
+      "@types/node",
+      "typescript@>=5.0.0 <7.0.0",
+      "jest",
+      "@types/jest",
+      "ts-jest",
+      "tsx",
+    ],
+    true,
+    silent
+  );
+
+  if (!silent) {
+    console.log(readFileSync("./help", "utf-8"));
+  }
+};
+
+/** Read a version from a command, returning "" when it fails or prints anything other than a plain version. */
+function readVersion(command) {
+  let out;
+  try {
+    out = execSync(command, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+
+  return /^\d+\.\d+\.\d+/.test(out) ? out : "";
+}
+
+/**
+ * Record the Yarn version this project should use, so corepack reproduces it for everyone working on the project.
+ * Versions are resolved at scaffold time rather than baked into this template, which would go stale with every
+ * Yarn release.
+ *
+ * This runs before the install: until a project declares a version, a corepack `yarn` shim resolves to the
+ * end-of-life 1.22 default, so writing the pin first is what gets a modern Yarn to perform the install.
+ */
+function pinPackageManager(silent) {
+  const installed = readVersion(`${packageManager} --version`);
+  let version = installed;
+
+  // Yarn 1.x is end-of-life, and it is what a corepack shim reports until a project pins something. Ask the
+  // registry for the current release instead of scaffolding onto the legacy line. Modern Yarn publishes as
+  // @yarnpkg/cli (the `yarn` package still points at 1.x), and npm ships with Node, whereas corepack no longer
+  // does from Node 26 on.
+  if (!version || version.startsWith("1.")) {
+    version = readVersion(`npm view @yarnpkg/cli version`) || installed;
+  }
+
+  if (!version) {
+    return;
+  }
+
+  // The pin only changes which Yarn runs if corepack is managing the `yarn` shim. Without it (corepack is not
+  // bundled from Node 26 on) a 1.x binary ignores `packageManager` altogether, so say so rather than leaving a
+  // lockfile that silently disagrees with the pin.
+  if (version !== installed && !hasCorepack()) {
+    if (!silent) {
+      console.log(
+        `\nNote: Yarn ${installed || "1.x"} is on your PATH, but this project pins Yarn ${version}.\n` +
+          `Corepack is not available to switch automatically, so the install below uses Yarn ${installed || "1.x"}.\n` +
+          `Install Yarn ${version} (https://yarnpkg.com/getting-started/install) and re-run "yarn install" to match the pin.\n`
+      );
+    }
+  }
+
+  const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+  pkg.packageManager = `${packageManager}@${version}`;
+  writeFileSync("./package.json", `${JSON.stringify(pkg, null, 2)}\n`, "utf-8");
+}
+
+/** Corepack is what makes a `packageManager` pin actually select a version. It is not bundled from Node 26 on. */
+function hasCorepack() {
+  const probe = process.platform === "win32" ? "where" : "which";
+  try {
+    execSync(`${probe} corepack`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function installDeps(deps, isDev, silent) {
+  const devDep = isDev ? "-D" : "";
+  // make sure we're installing dev dependencies as well
+  const env = Object.assign({}, process.env);
+  env["NODE_ENV"] = "development";
+
+  // Each spec is double-quoted so ranges containing spaces or shell
+  // metacharacters survive the shell. Double quotes (rather than single) work
+  // on both POSIX shells and cmd.exe, where an unquoted `^` is the escape
+  // character and would silently turn `cdktn@^1.2.3` into `cdktn@1.2.3`.
+  const specs = deps.map((dep) => `"${dep}"`).join(" ");
+
+  execSync(`${packageManager} add ${devDep} ${specs}`, {
+    stdio: silent ? "ignore" : "inherit",
+    env,
+  });
+}

--- a/packages/@cdktn/cli-core/templates/typescript-yarn/.yarnrc.yml
+++ b/packages/@cdktn/cli-core/templates/typescript-yarn/.yarnrc.yml
@@ -1,0 +1,3 @@
+# Yarn defaults to Plug'n'Play, which does not create node_modules. CDKTN runs your app through
+# `npx tsx main.ts` (see cdktf.json) and Jest resolves from node_modules, so use the classic linker.
+nodeLinker: node-modules

--- a/packages/@cdktn/cli-core/templates/typescript-yarn/help
+++ b/packages/@cdktn/cli-core/templates/typescript-yarn/help
@@ -1,0 +1,51 @@
+========================================================================================================
+
+  Your CDKTN TypeScript project is ready!
+
+  cat help                Print this message
+
+  Compile:
+    yarn get           Import/update Terraform providers and modules (you should check-in this directory)
+    yarn compile       Compile typescript code to javascript (or "yarn watch")
+    yarn watch         Watch for changes and compile typescript in the background
+    yarn build         Compile typescript
+
+  Synthesize:
+    cdktn synth [stack]   Synthesize Terraform resources from stacks to cdktf.out/ (ready for 'terraform apply')
+
+  Diff:
+    cdktn diff [stack]    Perform a diff (terraform plan) for the given stack
+
+  Deploy:
+    cdktn deploy [stack]  Deploy the given stack
+
+  Destroy:
+    cdktn destroy [stack] Destroy the stack
+
+  Test:
+    yarn test        Runs unit tests (edit __tests__/main-test.ts to add your own tests)
+    yarn test:watch  Watches the tests and reruns them on change
+
+  Upgrades:
+    yarn upgrade        Upgrade cdktn modules to latest version
+    yarn upgrade:next   Upgrade cdktn modules to latest "@next" version (last commit)
+
+ Use Providers:
+
+  You can add prebuilt providers (if available) or locally generated ones using the add command:
+  
+  cdktn provider add "aws@~>3.0" null kreuzwerker/docker
+
+  You can find all prebuilt providers on npm: https://www.npmjs.com/search?q=keywords:cdktn
+  You can also install these providers directly through yarn:
+
+  yarn add @cdktn/provider-aws
+  yarn add @cdktn/provider-google
+  yarn add @cdktn/provider-azurerm
+  yarn add @cdktn/provider-docker
+  yarn add @cdktn/provider-github
+  yarn add @cdktn/provider-null
+
+  You can also build any module or provider locally. Learn more https://cdktn.io/docs/concepts/providers
+
+========================================================================================================

--- a/packages/@cdktn/cli-core/templates/typescript-yarn/package.json
+++ b/packages/@cdktn/cli-core/templates/typescript-yarn/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "{{ $base }}",
+  "version": "1.0.0",
+  "main": "main.js",
+  "types": "main.ts",
+  "license": "MPL-2.0",
+  "private": true,
+  "scripts": {
+    "get": "cdktn get",
+    "build": "tsc",
+    "synth": "cdktn synth",
+    "compile": "tsc --pretty",
+    "watch": "tsc -w",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "upgrade": "yarn add cdktn@latest cdktn-cli@latest",
+    "upgrade:next": "yarn add cdktn@next cdktn-cli@next"
+  },
+  "engines": {
+    "node": ">=22.0"
+  }
+}

--- a/packages/@cdktn/cli-core/templates/typescript-yarn/{{}}.gitignore
+++ b/packages/@cdktn/cli-core/templates/typescript-yarn/{{}}.gitignore
@@ -1,0 +1,16 @@
+*.d.ts
+*.js
+node_modules
+cdktf.out
+cdktf.log
+*terraform.*.tfstate*
+.gen
+.terraform
+tsconfig.tsbuildinfo
+!jest.config.js
+!setup.js
+
+# Yarn writes these alongside node_modules; the lockfile and .yarnrc.yml are committed, these are not.
+.yarn/*
+!.yarn/patches
+.pnp.*

--- a/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
+++ b/packages/@cdktn/cli-core/templates/typescript/.hooks.sscaff.js
@@ -6,6 +6,10 @@
 const { execSync } = require("child_process");
 const { readFileSync, writeFileSync } = require("fs");
 
+exports.pre = () => {
+  requirePackageManager("npm");
+};
+
 exports.post = (ctx) => {
   const silent = ctx.silent === "true" || ctx.silent === true;
   // Terraform Cloud configuration settings if the organization name and workspace is set.
@@ -21,6 +25,12 @@ exports.post = (ctx) => {
       ctx.WorkspaceName,
       ctx.TerraformRemoteHostname
     );
+  }
+
+  // When this template is only the base of an overlay template, the overlay owns dependency installation and the
+  // help text: it replaces package.json, so installing with npm here would leave a stray package-lock.json.
+  if (ctx.isOverlayBase === "true") {
+    return;
   }
 
   const npm_cdktf = ctx.npm_cdktf;
@@ -50,6 +60,17 @@ exports.post = (ctx) => {
     console.log(readFileSync("./help", "utf-8"));
   }
 };
+
+function requirePackageManager(packageManager) {
+  const probe = process.platform === "win32" ? "where" : "which";
+  try {
+    execSync(`${probe} ${packageManager}`, { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      `Could not find "${packageManager}" on your PATH. Install it (e.g. "corepack enable ${packageManager}") and run cdktn init again.`
+    );
+  }
+}
 
 function installDeps(deps, isDev, silent) {
   const devDep = isDev ? "-D" : "";

--- a/packages/@cdktn/cli-core/templates/typescript/jest.config.js
+++ b/packages/@cdktn/cli-core/templates/typescript/jest.config.js
@@ -1,4 +1,4 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 /*
  * For a detailed explanation regarding each configuration property, visit:
  * https://jestjs.io/docs/configuration

--- a/packages/cdktn-cli/src/bin/cmds/helper/init.ts
+++ b/packages/cdktn-cli/src/bin/cmds/helper/init.ts
@@ -48,6 +48,21 @@ const chalkColour = new chalk.Instance();
 
 const isReadme = (file: string) => file.toLowerCase() === "readme.md";
 
+// Matches the `typescript` template and its package-manager variants (`typescript-pnpm`, `typescript-yarn`).
+const isTypescriptTemplate = (name: string) =>
+  name === "typescript" || name.startsWith("typescript-");
+
+// The package manager a TypeScript template scaffolds with, used to run scripts in the generated project.
+function packageManagerFor(templateName: string): string {
+  if (templateName === "typescript-pnpm") {
+    return "pnpm";
+  }
+  if (templateName === "typescript-yarn") {
+    return "yarn";
+  }
+  return "npm";
+}
+
 export function checkForEmptyDirectory(dir: string) {
   if (
     fs
@@ -145,7 +160,7 @@ This means that your Terraform state file will be stored locally on disk in a fi
 
   let fromTerraformProject = argv.fromTerraformProject || undefined;
   if (!fromTerraformProject) {
-    if (templateInfo.Name === "typescript") {
+    if (isTypescriptTemplate(templateInfo.Name)) {
       fromTerraformProject = await getTerraformProject(
         argv.nonInteractive ?? false,
       );
@@ -183,9 +198,9 @@ This means that your Terraform state file will be stored locally on disk in a fi
 
   let convertResult, importPath;
   if (fromTerraformProject) {
-    if (templateInfo.Name !== "typescript") {
+    if (!isTypescriptTemplate(templateInfo.Name)) {
       console.error(
-        `The --from-terraform-project flag is only supported with the typescript template. The command will continue and ignore the flag.`,
+        `The --from-terraform-project flag is only supported with the typescript templates. The command will continue and ignore the flag.`,
       );
     }
 
@@ -262,13 +277,16 @@ This means that your Terraform state file will be stored locally on disk in a fi
     }
 
     if (terraformModules.length + terraformProviders.length > 0) {
-      const npmRunGetOptions: ExecSyncOptions = {
+      const runGetOptions: ExecSyncOptions = {
         cwd: destination,
       };
       if (argv.silent) {
-        npmRunGetOptions.stdio = "ignore";
+        runGetOptions.stdio = "ignore";
       }
-      execSync("npm run get", { cwd: destination });
+      execSync(
+        `${packageManagerFor(templateInfo.Name)} run get`,
+        runGetOptions,
+      );
     }
 
     telemetryData.conversionStats = stats;


### PR DESCRIPTION
### Description

This PR adds `typescript-pnpm` and `typescript-yarn` templates to `cdktn init`, so a project can be scaffolded with the package manager of choice. Until now `cdktn init --template=typescript` hardcoded npm and the generated `package.json` scripts, `help` text and post-convert `npm run get` all assumed npm.

**Selected through `--template`.** This follows the existing `python` / `python-pip` precedent of splitting a language on its packaging tool, and keeps the variants scriptable and visible in the interactive picker with no extra code — template discovery is already a `readdirSync` of the templates directory.

**Stored as overlays.** Only 3 of the 10 TypeScript template files differ per package manager; the other 7 include `jest.config.js` (6.6 KB) and `__tests__/main-test.ts`. Duplicating those three ways would mean every future edit to `tsconfig.json` or `main.ts` landing three times, so `typescript/` stays the complete base and each variant carries only its own files:

```
templates/
  typescript/            <- full base, 10 files (npm)
  typescript-pnpm/       <- help, package.json, .hooks.sscaff.js
  typescript-yarn/       <- the same three, plus .yarnrc.yml and .gitignore
```

`init()` scaffolds the base first, then overlays the variant. sscaff writes with plain `fs.writeFile`, so the second pass simply wins. The base pass receives `isOverlayBase`, which stops its `post` hook before the install step and leaves dependency installation to the overlay — so a pnpm project gets a `pnpm-lock.yaml` and nothing else.

**Two places keyed off the literal `"typescript"`** and now resolve through the template family / overlay base instead: the `--from-terraform-project` gate in `helper/init.ts`, so HCL conversion is offered for every TypeScript variant, and `distKeysByTemplate` in `cli-core/init.ts`, so `--dist` resolves each variant to its base's artifact.

**Yarn needs two things pnpm does not.** A corepack `yarn` shim resolves to the end-of-life 1.22 line until a project declares a version, so the `packageManager` pin is written *before* installing — that is what selects a modern Yarn (verified: Yarn 4.18.0 performs the install). The version is resolved at scaffold time from `@yarnpkg/cli` on the registry, so it tracks Yarn releases rather than going stale, and the lookup keeps working on Node 26+ where corepack is no longer bundled — the template declares `node >=22.0`. Where corepack is absent the pin records intent but cannot switch versions, so the hook reports which Yarn actually ran. Yarn also defaults to Plug'n'Play, so `.yarnrc.yml` sets `nodeLinker: node-modules` to keep `npx tsx main.ts` and Jest resolving, with a variant `.gitignore` for `.yarn/install-state.gz`.

**`cdktn provider add` now agrees with what `init` scaffolded.** `NodePackageManager` previously probed only for `yarn.lock`, so a pnpm project got `npm install` and ended up with a `package-lock.json` beside its `pnpm-lock.yaml`. Detection now reads the `packageManager` field first — the strongest signal, and what these templates write — then `pnpm-lock.yaml`, then `yarn.lock`, then npm. Quiet flags are emitted per manager, since pnpm has no `--no-progress` and Yarn Berry errors on unknown options, accepting neither `--silent` nor `--no-progress`.

**Four pre-existing bugs fixed in passing**, each a one-liner encountered while testing this path:

- `helper/init.ts` built an `ExecSyncOptions` (including `stdio: "ignore"` under `--silent`) and then never passed it, so `--silent` leaked output from the post-convert `run get`.
- `init()` never passed `cdktfVersion` to `providerAdd`, so `cdktn init --cdktf-version=X --providers=aws` scaffolded fine and then failed with `cannot use version 0.0.0`.
- The `--from-terraform-project` warning said "the typescript template" where several now qualify.
- `jest.config.js` annotated its config with ts-jest's deprecated `InitialOptionsTsJest`; ts-jest's own annotation says to use `JestConfigWithTsJest`.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
