### PR TITLE
fix(tests): bound and retry the dist publish to the local registry

### DIFF
--- a/test/run-against-dist.mjs
+++ b/test/run-against-dist.mjs
@@ -36,6 +36,11 @@ const REGISTRY_URL = "http://localhost:4873/";
 // inline as npm's per-registry config key.
 const NPM_AUTH_ARG = `--${REGISTRY_URL.replace(/^https?:/, "")}:_authToken=dummy`;
 
+// A healthy publish to the local registry takes about a second; anything past
+// this is a stall, not slowness.
+const PUBLISH_TIMEOUT_MS = 2 * 60 * 1000;
+const PUBLISH_ATTEMPTS = 3;
+
 process.env.CDKTF_DIST = cdktnDist;
 
 /** @type {import("node:http").Server | null} */
@@ -128,14 +133,42 @@ try {
   const tgzGlob = join(cdktnDist, "js", "*.tgz").replaceAll("\\", "/");
   for await (const pkg of glob(tgzGlob)) {
     console.log(pkg);
-    try {
-      await execa(
-        "npm",
-        ["publish", `--registry=${REGISTRY_URL}`, NPM_AUTH_ARG, "--force", pkg],
-        { stdio: ["ignore", "inherit", "inherit"] },
-      );
-    } catch {
-      await fail(`npm publish failed for ${pkg}`);
+    // Bound each publish: a stalled Verdaccio leaves npm waiting on the socket
+    // forever, which otherwise burns the job's whole 60m timeout.
+    for (let attempt = 1; attempt <= PUBLISH_ATTEMPTS; attempt++) {
+      try {
+        await execa(
+          "npm",
+          [
+            "publish",
+            `--registry=${REGISTRY_URL}`,
+            NPM_AUTH_ARG,
+            "--force",
+            pkg,
+          ],
+          {
+            stdio: ["ignore", "inherit", "inherit"],
+            timeout: PUBLISH_TIMEOUT_MS,
+          },
+        );
+        break;
+      } catch (err) {
+        if (attempt === PUBLISH_ATTEMPTS) {
+          await fail(
+            `npm publish failed for ${pkg} after ${PUBLISH_ATTEMPTS} attempts: ${
+              err.timedOut
+                ? `timed out after ${PUBLISH_TIMEOUT_MS}ms`
+                : err.message
+            }`,
+          );
+        }
+        console.log(
+          `Publish attempt ${attempt} for ${pkg} failed${
+            err.timedOut ? " (timed out)" : ""
+          }, retrying in ${attempt * 5}s...`,
+        );
+        await sleep(attempt * 5 * 1000);
+      }
     }
   }
 


### PR DESCRIPTION
### Description

`run-against-dist.mjs` publishes every tarball in `dist/js` to a throwaway Verdaccio registry before the integration tests run. That `npm publish` had no timeout and no retry, so a registry that stops responding mid-upload leaves npm waiting on the socket indefinitely — the script never returns and the job burns its full 60-minute budget before GitHub cancels it. Each publish is now bounded at two minutes and retried up to three times.

**What this looked like in CI.** On [run 34601028750](https://github.com/open-constructs/cdk-terrain/actions/runs/34601028750/job/103270765900), `linux_provider (datadog)` ran for 1h0m46s and reported `cancelled` rather than `failure` — the conclusion GitHub records when a job hits `timeout-minutes`. The step had in fact stalled three seconds in, while publishing `cdktn@0.0.0.jsii.tgz`:

```
13:00:40.4696312  /__w/.../dist/js/cdktn@0.0.0.jsii.tgz
13:00:40.5213662  npm warn using --force Recommended protections disabled.
14:00:33.3804396  context canceled
```

The provider tests never started, so the matrix leg in the job name is incidental — the hang is upstream of them, in the shared publish loop. `linux_provider (kubernetes)` in the same run shows the healthy path: tarball contents follow that same `npm warn` line about 0.6s later. The `cdktn**` block in `test/verdaccio.yaml` sets no `proxy`, so this was not an npmjs uplink stall; the likely cause is the in-process Verdaccio server ceasing to service the request, and `cdktn@0.0.0.jsii.tgz` is the largest tarball in the set at ~870kB of `.jsii` alone.

**Why a timeout plus a retry.** The CLI *install* immediately below this loop already rides out exactly this class of transient Verdaccio failure with a three-attempt retry; the *publish* above it had neither guard. The two now match in shape, with a shorter backoff (5s/10s) because a publish that has already hit its timeout has waited two minutes. A healthy publish to a local registry takes about a second, so the two-minute bound separates a stall from slowness with a wide margin and will not fire on an ordinarily slow runner.

`--force` is already passed on every attempt, so a retry overwrites whatever a killed attempt left half-written in Verdaccio's storage — the republish is idempotent and needs no cleanup between tries. The failure message distinguishes a timeout from an ordinary publish error, so a recurrence is diagnosable from the log alone rather than presenting as a bare `cancelled`.

Worst case is now roughly six minutes ending in a clear error, instead of an hour of a held runner ending in an opaque `cancelled`. That matters more than the wall-clock: the org's runner concurrency cap means one wedged job blocks the queue for everything behind it.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes
