### PR TITLE
test(lib): move matcher Docker fixture to a provider version OpenTofu accepts

### DIFF
--- a/packages/cdktn/test/helper/provider.ts
+++ b/packages/cdktn/test/helper/provider.ts
@@ -66,7 +66,8 @@ export class DockerProvider extends TerraformProvider {
       terraformResourceType: DockerProvider.tfResourceType,
       terraformGeneratorMetadata: {
         providerName: "docker",
-        providerVersionConstraint: "~> 2.0",
+        // OpenTofu rejects kreuzwerker/docker 2.x as unsigned; 3.x is the first signed major
+        providerVersionConstraint: "~> 3.0",
       },
       terraformProviderSource: "kreuzwerker/docker",
     });


### PR DESCRIPTION
### Related issue

Fixes #301

### Description

`toBeValidTerraform` and `toPlanSuccessfully` shell out to the Terraform-compatible CLI, so the matcher tests cannot run under OpenTofu today — `tofu init` refuses the Docker provider the fixture pins:

```
Error while installing kreuzwerker/docker v2.25.0: the provider is not signed with a
valid signing key; please contact the provider author (authentication signature from
unknown issuer)
```

Terraform installs the same provider as self-signed, which is why this has never shown up in CI.

This is a provider-version problem, not an OpenTofu support gap. Confirmed by running `tofu init` against minimal HCL, with no CDK involved:

| constraint | resolves to | OpenTofu 1.12.6 |
| --- | --- | --- |
| `~> 2.0` | 2.25.0 | **fails** — unsigned |
| `~> 3.0` | 3.9.0 | installs |
| `~> 4.0` | 4.x | installs |

So the `DockerProvider` test fixture moves to `~> 3.0`.

**Why `~> 3.0` rather than `~> 4.0`:** v3 is the first signed major, and the repo's other Docker fixtures already sit on 3.0.x (`@cdktn/provider-schema` pins `=3.0.2`, `@cdktn/hcl2cdk` pins `=3.0.1`), so this keeps a single Docker major across the test suite and preserves the floating constraint the fixture already used.

There is no schema fallout: the fixture only touches provider `ssh_opts`/`host` and `docker_image.name`, all unchanged between v2 and v3. No snapshots moved.

The other `~> 2.0` constraint in the same file belongs to the synthetic `TestProvider`, which declares no `terraformProviderSource` and never contacts a registry. It is deliberately untouched — it is also the source of the ~300 `"~> 2.0"` occurrences in `packages/cdktn/test/__snapshots__/`, which are unrelated to this change.

### Testing

Run from `packages/cdktn`, selecting the CLI with `TERRAFORM_BINARY_NAME`:

| CLI | `matchers.test.ts` | full `cdktn` suite |
| --- | --- | --- |
| Terraform 1.14.3 | 21/21 pass | 43 suites, 519 pass / 23 skip, 299 snapshots |
| Terraform 1.5.7 (oldest in `tested`) | 21/21 pass | — |
| OpenTofu 1.12.6 | 21/21 pass | 43 suites, 519 pass / 23 skip, 299 snapshots |

`toPlanSuccessfully` really does run `plan`, so these were run with a live Docker daemon.

### Scope: this closes the unit matchers only

The language integration matchers are **still broken under OpenTofu** and are deliberately out of scope. `test/{typescript,go,java,csharp,python}/testing-matchers/cdktf.json` all pin `kreuzwerker/docker@~> 2.0` and hit the identical signing error.

They cannot simply be bumped: every one of those fixtures uses the `latest` attribute on `docker_image`, which v3 removed. Fixing them means rewriting fixtures in five languages plus regenerating bindings and assertions — a separate and much larger change, and one that could not be verified without the full integration harness.

### Follow-up worth considering

Nothing in CI runs any of this under OpenTofu — every workflow matrix sets `TERRAFORM_BINARY_NAME: terraform<version>`. So this fix can silently regress. The CI image ships `tofu1.12.6`, so an OpenTofu leg on the **unit** matrix would keep #301 closed. That is a different axis from the integration-matrix pinning added in #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
