### PR TITLE
chore(tests): run the function-binding scripts with tsx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1556,9 +1556,9 @@ importers:
       '@types/node':
         specifier: 22.20.1
         version: 22.20.1
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.16.2(@swc/helpers@0.5.23))(@types/node@22.20.1)(typescript@6.0.3)
+      tsx:
+        specifier: 4.23.13
+        version: 4.23.13
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -9060,6 +9060,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@cypress/request@3.0.10':
     dependencies:
@@ -9822,6 +9823,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+    optional: true
 
   '@jsii/check-node@1.140.0':
     dependencies:
@@ -10416,13 +10418,17 @@ snapshots:
       defer-to-connect: 2.0.1
     optional: true
 
-  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node10@1.0.11':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -11064,6 +11070,7 @@ snapshots:
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.16.0
+    optional: true
 
   acorn@8.16.0: {}
 
@@ -11136,7 +11143,8 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -11824,7 +11832,8 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.3
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -11953,7 +11962,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -15577,6 +15587,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.16.2(@swc/helpers@0.5.23)
+    optional: true
 
   tsc-files@1.1.4(typescript@6.0.3):
     dependencies:
@@ -15785,7 +15796,8 @@ snapshots:
   uuid@8.3.2:
     optional: true
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -16045,7 +16057,8 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/tools/generate-function-bindings/package.json
+++ b/tools/generate-function-bindings/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "description": "Tool to generate CDK Terrain function bindings",
   "scripts": {
-    "fetch-metadata": "ts-node scripts/fetch-metadata.ts",
-    "generate": "ts-node scripts/generate.ts",
-    "update-function-matrix": "ts-node scripts/update-function-matrix.ts",
-    "generate-function-availability": "ts-node scripts/generate-function-availability.ts"
+    "fetch-metadata": "tsx scripts/fetch-metadata.ts",
+    "generate": "tsx scripts/generate.ts",
+    "update-function-matrix": "tsx scripts/update-function-matrix.ts",
+    "generate-function-availability": "tsx scripts/generate-function-availability.ts"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
     "@types/babel__generator": "^7.27.0",
     "@types/babel__template": "^7.4.4",
     "@types/node": "22.20.1",
-    "ts-node": "^10.9.1",
+    "tsx": "4.23.13",
     "typescript": "~6.0.0"
   },
   "lint-staged": {


### PR DESCRIPTION
### Related issue

Loose end from #406. Noticed while auditing the remaining `ts-node` references after the TypeScript 6 work.

### Description

`tools/generate-function-bindings` still ran its four codegen scripts through ts-node after #406 moved the package to `typescript ~6.0.0`:

```
fetch-metadata                  ts-node scripts/fetch-metadata.ts
generate                        ts-node scripts/generate.ts
update-function-matrix          ts-node scripts/update-function-matrix.ts
generate-function-availability  ts-node scripts/generate-function-availability.ts
```

That is the pairing that broke `cdktn synth` for the init template in #396: ts-node merges a bundled `@tsconfig/nodeXX` default supplying a deprecated `moduleResolution: node10`, which TypeScript 6 rejects with `TS5107`. Nothing in CI runs these scripts — they are invoked manually via the root `generate-function-bindings` script — so the risk was silent and would have surfaced the next time someone regenerated the bindings.

### On certainty

Whether ts-node actually fails here is environment-sensitive, and I could not settle it:

| environment | result |
| --- | --- |
| CI container (`jsii-terraform`) | reproduced reliably — `tsNodeModuleResolution: Node10` → `TS5107` |
| Windows | never reproduced; ts-node resolves no `moduleResolution` at all |
| plain `node:22` container | not reproduced — **and the template's own known-failing tsconfig passes there too**, so this check cannot clear anything |

Rather than keep chasing why the injection is environment-dependent, this moves to tsx: the same runner the init template, the integration fixtures and the examples already use. That removes the exposure regardless.

### Verification

`tsc --noEmit` is clean under TypeScript 6, and three of the four scripts were executed through tsx locally:

- `generate-function-availability` — ran, wrote `function-availability.generated.ts`
- `generate` — ran clean
- `update-function-matrix` — reached its own `Unsupported platform win32/x64` guard, a pre-existing Windows limitation in the script rather than a runner problem, so tsx had loaded and executed it

Critically, `git status` showed **no changes to any tracked file** afterwards: the generated output is byte-identical to what is committed, so tsx produces the same result ts-node did.

`fetch-metadata` was not run — it performs network fetches — but tsx's ability to load this package's module graph is established by the other three.

### Checklist

- [x] I have updated the PR title to match [CDKTN's style guide](https://github.com/open-constructs/cdk-terrain/blob/main/CONTRIBUTING.md#pull-requests-1)
- [x] I have run the linter on my code locally
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/open-constructs/cdk-terrain-docs/tree/main/content) if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works if applicable
- [x] New and existing unit tests pass locally with my changes

### Not included

`packages/@cdktn/cli-core/src/lib/synth-stack.ts:118` still has a comment reading "increase memory to allow ts-node (when using TypeScript)", which is now stale since the template uses tsx. Left out to keep this scoped; happy to fold in or do separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
